### PR TITLE
Improve `tach check` output

### DIFF
--- a/tach/cli.py
+++ b/tach/cli.py
@@ -67,16 +67,10 @@ def build_error_message(error: BoundaryError) -> str:
     elif not error_info.is_tag_error:
         return error_template.format(message="Unexpected error")
 
-    if error_info.allowed_tags:
-        message = (
-            f"Import '{error.import_mod_path}' has tags '{error_info.invalid_tags}' "
-            f"while '{error.file_path}' (tags: '{error_info.source_tags}') can only depend on '{error_info.allowed_tags}'"
-        )
-    else:
-        message = (
-            f"Import '{error.import_mod_path}' has tags '{error_info.invalid_tags}' "
-            f"while '{error.file_path}' (tags: '{error_info.source_tags}') cannot depend on any tags."
-        )
+    message = (
+        f"Cannot import '{error.import_mod_path}'. "
+        f"Tags {error_info.source_tags} cannot depend on {error_info.invalid_tags}."
+    )
 
     return error_template.format(message=message)
 

--- a/tach/cli.py
+++ b/tach/cli.py
@@ -1,10 +1,12 @@
 import argparse
+import os
 import sys
 from enum import Enum
+from functools import lru_cache
 from typing import Optional
 
 from tach.add import add_packages
-from tach.check import check, ErrorInfo
+from tach.check import check, BoundaryError
 from tach import filesystem as fs
 from tach.constants import CONFIG_FILE_NAME
 from tach.filesystem import install_pre_commit
@@ -14,11 +16,72 @@ from tach.parsing import parse_project_config
 from tach.colors import BCOLORS
 
 
-def print_errors(error_list: list[ErrorInfo]) -> None:
-    sorted_results = sorted(error_list, key=lambda e: e.location)
+class TerminalEnvironment(Enum):
+    UNKNOWN = 1
+    JETBRAINS = 2
+    VSCODE = 3
+
+
+@lru_cache()
+def detect_environment() -> TerminalEnvironment:
+    if "jetbrains" in os.environ.get("TERMINAL_EMULATOR", "").lower():
+        return TerminalEnvironment.JETBRAINS
+    elif "vscode" in os.environ.get("TERM_PROGRAM", "").lower():
+        return TerminalEnvironment.VSCODE
+
+    return TerminalEnvironment.UNKNOWN
+
+
+def create_clickable_link(file_path: str, line: Optional[int] = None) -> str:
+    terminal_env = detect_environment()
+    abs_path = os.path.abspath(file_path)
+
+    if terminal_env == TerminalEnvironment.JETBRAINS:
+        link = f"file://{abs_path}:{line}" if line is not None else f"file://{abs_path}"
+    elif terminal_env == TerminalEnvironment.VSCODE:
+        link = (
+            f"vscode://file/{abs_path}:{line}"
+            if line is not None
+            else f"vscode://file/{abs_path}"
+        )
+    else:
+        # For generic terminals, use a standard file link
+        link = f"file://{abs_path}"
+
+    # ANSI escape codes for clickable link
+    display_file_path = f"{file_path}[{line}]" if line else file_path
+    clickable_link = f"\033]8;;{link}\033\\{display_file_path}\033]8;;\033\\"
+    return clickable_link
+
+
+def build_error_message(error: BoundaryError) -> str:
+    error_location = create_clickable_link(error.file_path, error.line_number)
+    error_template = f"❌ {BCOLORS.FAIL}{error_location}{BCOLORS.ENDC}{BCOLORS.WARNING}: {{message}} {BCOLORS.ENDC}"
+    error_info = error.error_info
+    if error_info.exception_message:
+        return error_template.format(message=error_info.exception_message)
+    elif not error_info.is_tag_error:
+        return error_template.format(message="Unexpected error")
+
+    if error_info.allowed_tags:
+        message = (
+            f"Import '{error.import_mod_path}' has tags '{error_info.invalid_tags}' "
+            f"while '{error.file_path}' (tags: '{error_info.source_tags}') can only depend on '{error_info.allowed_tags}'"
+        )
+    else:
+        message = (
+            f"Import '{error.import_mod_path}' has tags '{error_info.invalid_tags}' "
+            f"while '{error.file_path}' (tags: '{error_info.source_tags}') cannot depend on any tags."
+        )
+
+    return error_template.format(message=message)
+
+
+def print_errors(error_list: list[BoundaryError]) -> None:
+    sorted_results = sorted(error_list, key=lambda e: e.file_path)
     for error in sorted_results:
         print(
-            f"❌ {BCOLORS.FAIL}{error.location}{BCOLORS.ENDC}{BCOLORS.WARNING}: {error.message}{BCOLORS.ENDC}",
+            build_error_message(error),
             file=sys.stderr,
         )
 
@@ -134,7 +197,7 @@ def tach_check(
         else:
             exclude_paths = project_config.exclude
 
-        result: list[ErrorInfo] = check(
+        result: list[BoundaryError] = check(
             ".",
             project_config,
             exclude_paths=exclude_paths,

--- a/tach/cli.py
+++ b/tach/cli.py
@@ -49,7 +49,11 @@ def create_clickable_link(file_path: str, line: Optional[int] = None) -> str:
         link = f"file://{abs_path}"
 
     # ANSI escape codes for clickable link
-    display_file_path = f"{file_path}[{line}]" if line else file_path
+    if line and terminal_env != TerminalEnvironment.UNKNOWN:
+        # Show the line number if clicking will take you to the line
+        display_file_path = f"{file_path}[L{line}]"
+    else:
+        display_file_path = file_path
     clickable_link = f"\033]8;;{link}\033\\{display_file_path}\033]8;;\033\\"
     return clickable_link
 

--- a/tach/core/config.py
+++ b/tach/core/config.py
@@ -63,22 +63,27 @@ class ProjectConfig(Config):
             [],  # type: ignore
         )
 
-    def add_dependencies_to_tag(self, tag: str, dependencies: list[str]):
-        current_dependency_rules = next(
-            (constraint for constraint in self.constraints if constraint.tag == tag),
-            None,
-        )
-        if not current_dependency_rules:
-            # No constraint exists for tag, just add the new dependencies
-            self.constraints.append(
-                TagDependencyRules(tag=tag, depends_on=dependencies)
+    def add_dependencies_to_tags(self, tags: list[str], dependencies: list[str]):
+        for tag in tags:
+            current_dependency_rules = next(
+                (
+                    constraint
+                    for constraint in self.constraints
+                    if constraint.tag == tag
+                ),
+                None,
             )
-        else:
-            # Constraints already exist, set the union of existing and new as dependencies
-            new_dependencies = set(current_dependency_rules.depends_on) | set(
-                dependencies
-            )
-            current_dependency_rules.depends_on = list(new_dependencies)
+            if not current_dependency_rules:
+                # No constraint exists for tag, just add the new dependencies
+                self.constraints.append(
+                    TagDependencyRules(tag=tag, depends_on=dependencies)
+                )
+            else:
+                # Constraints already exist, set the union of existing and new as dependencies
+                new_dependencies = set(current_dependency_rules.depends_on) | set(
+                    dependencies
+                )
+                current_dependency_rules.depends_on = list(new_dependencies)
 
     @classmethod
     def factory(cls, config: dict[str, Any]) -> tuple[bool, "ProjectConfig"]:

--- a/tach/filesystem/service.py
+++ b/tach/filesystem/service.py
@@ -251,17 +251,14 @@ def path_exists_case_sensitive(p: Path) -> bool:
         p = p.parent
 
 
-def module_to_file_path(
-    mod_path: str, find_package_init: bool = False
-) -> tuple[str, str]:
+def module_to_file_path(mod_path: str) -> tuple[str, str]:
     # Assumes that the mod_path is correctly formatted and refers to an actual module
     fs_path = mod_path.replace(".", os.path.sep)
 
     # mod_path may refer to a package
-    if path_exists_case_sensitive(Path(fs_path)):
-        return (
-            os.path.join(fs_path, "__init__.py") if find_package_init else fs_path
-        ), ""
+    init_file_path = Path(fs_path) / "__init__.py"
+    if path_exists_case_sensitive(init_file_path):
+        return str(init_file_path), ""
 
     # mod_path may refer to a file module
     file_path = fs_path + ".py"
@@ -275,7 +272,8 @@ def module_to_file_path(
         member_name = fs_path[last_sep_index + 1 :]
         return file_path, member_name
 
-    init_file_path = fs_path[:last_sep_index] + "/__init__.py"
+    # mod_path may refer to a member within a package
+    init_file_path = fs_path[:last_sep_index] + os.path.sep + "__init__.py"
     if path_exists_case_sensitive(Path(init_file_path)):
         member_name = fs_path[last_sep_index + 1 :]
         return init_file_path, member_name

--- a/tach/init.py
+++ b/tach/init.py
@@ -60,8 +60,11 @@ def init_root(root: str, exclude_paths: Optional[list[str]] = None) -> InitRootR
         root, project_config=project_config, exclude_paths=exclude_paths
     )
     for error in check_errors:
-        if error.is_tag_error:
-            project_config.add_dependencies_to_tag(error.source_tag, error.invalid_tags)
+        error_info = error.error_info
+        if error_info.is_tag_error:
+            project_config.add_dependencies_to_tags(
+                error_info.source_tags, error_info.invalid_tags
+            )
 
     tach_yml_path = os.path.join(root, f"{CONFIG_FILE_NAME}.yml")
     tach_yml_content = dump_project_config_to_yaml(project_config)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -97,10 +97,11 @@ def package_trie() -> PackageTrie:
 def test_check_import(
     project_config, package_trie, file_mod_path, import_mod_path, expected_result
 ):
-    result = check_import(
+    check_error = check_import(
         project_config=project_config,
         package_trie=package_trie,
         file_mod_path=file_mod_path,
         import_mod_path=import_mod_path,
     )
-    assert result.ok == expected_result
+    result = check_error is None
+    assert result == expected_result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 import pytest
 
 from tach import cli
-from tach.check import ErrorInfo
+from tach.check import ErrorInfo, BoundaryError
 from tach.constants import CONFIG_FILE_NAME
 from tach.core import ProjectConfig, TagDependencyRules
 
@@ -65,8 +65,13 @@ def test_execute_with_error(capfd, mock_path_exists, mock_check, mock_project_co
     location = "valid_dir/file.py"
     message = "Import valid_dir in valid_dir/file.py is blocked by boundary"
     mock_check.return_value = [
-        ErrorInfo(
-            exception_message="Import valid_dir in valid_dir/file.py is blocked by boundary",
+        BoundaryError(
+            file_path=location,
+            line_number=0,
+            import_mod_path="valid_dir",
+            error_info=ErrorInfo(
+                exception_message="Import valid_dir in valid_dir/file.py is blocked by boundary",
+            ),
         )
     ]
     with pytest.raises(SystemExit) as sys_exit:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pydantic import ValidationError
 
-from tach.check import check, ErrorInfo
+from tach.check import check
 from tach.core.config import PackageConfig, TagDependencyRules, ProjectConfig
 from tach.parsing.config import parse_project_config, parse_package_config
 from tach.filesystem import file_to_module_path
@@ -95,14 +95,7 @@ def test_exclude_hidden_paths_fails():
             exclude_hidden_paths=project_config.exclude_hidden_paths,
         )
         assert len(results) == 1
-        assert results[0] == ErrorInfo(
-            location="hidden",
-            import_mod_path="",
-            source_tag="",
-            allowed_tags=[],
-            exception_message="Package 'unhidden' is in strict mode. Only imports from the root of"
-            " this package are allowed. The import 'unhidden.secret.shhhh' (in 'hidden') is not included in __all__.",
-        )
+        assert "strict mode" in results[0].error_info.exception_message
 
         project_config.exclude_hidden_paths = True
         assert check(".", project_config, exclude_hidden_paths=True) == []


### PR DESCRIPTION
![image](https://github.com/gauge-sh/tach/assets/10570340/eadec2a0-39eb-490b-aec0-e315a9fef338)

This PR improves the output of `tach check`:
- errors show file paths and line numbers
- error path is clickable
- error message is simpler and more direct

I also included a bit of refactoring in `check`/`check_import` and `cli.py`