### PR TITLE
Add `--strict` flag to `tach check`

### DIFF
--- a/tach/core/config.py
+++ b/tach/core/config.py
@@ -85,6 +85,32 @@ class ProjectConfig(Config):
                 )
                 current_dependency_rules.depends_on = list(new_dependencies)
 
+    def find_extra_constraints(
+        self, other_config: "ProjectConfig"
+    ) -> list[TagDependencyRules]:
+        extra_constraints = []
+        base_constraint_tags = set(constraint.tag for constraint in self.constraints)
+        for constraint in other_config.constraints:
+            if constraint.tag not in base_constraint_tags:
+                extra_constraints.append(constraint)
+                continue
+            base_constraint_dependencies = set(
+                self.dependencies_for_tag(constraint.tag)
+            )
+            extra_dependencies = (
+                set(other_config.dependencies_for_tag(constraint.tag))
+                - base_constraint_dependencies
+            )
+            if extra_dependencies:
+                extra_constraints.append(
+                    TagDependencyRules(
+                        tag=constraint.tag,
+                        depends_on=list(extra_dependencies),
+                    )
+                )
+
+        return extra_constraints
+
     @classmethod
     def factory(cls, config: dict[str, Any]) -> tuple[bool, "ProjectConfig"]:
         """

--- a/tach/core/config.py
+++ b/tach/core/config.py
@@ -88,7 +88,7 @@ class ProjectConfig(Config):
     def find_extra_constraints(
         self, other_config: "ProjectConfig"
     ) -> list[TagDependencyRules]:
-        extra_constraints = []
+        extra_constraints: list[TagDependencyRules] = []
         base_constraint_tags = set(constraint.tag for constraint in self.constraints)
         for constraint in other_config.constraints:
             if constraint.tag not in base_constraint_tags:

--- a/tach/sync.py
+++ b/tach/sync.py
@@ -58,9 +58,11 @@ def prune_dependency_constraints(
     """
     Build a minimal project configuration with auto-detected dependency constraints.
     """
-    project_config = project_config or ProjectConfig()
-    # Force constraints to be empty in case we received configuration with pre-existing constraints
-    project_config.constraints = []
+    if project_config is not None:
+        # Force constraints to be empty in case we received configuration with pre-existing constraints
+        project_config = project_config.model_copy(update={"constraints": []})
+    else:
+        project_config = ProjectConfig()
 
     sync_dependency_constraints(
         root, project_config=project_config, exclude_paths=exclude_paths


### PR DESCRIPTION
Issue: #63 

This PR introduces the `--strict` flag to `tach check`. If this flag is passed, any unused dependencies will be considered errors.

![image](https://github.com/gauge-sh/tach/assets/10570340/d237944e-34e3-4961-9e2a-6d0d25dff790)