### PR TITLE
Python 3.8 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ keywords = ['python', 'module', 'package', 'guard', 'enforcement', 'boundary', '
 Homepage = "https://github.com/gauge-sh/tach"
 Issues = "https://github.com/gauge-sh/tach/issues"
 
+[tool.ruff]
+target-version = "py38"
+lint.extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
 
 [tool.pyright]
 include = ["tach"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ required-imports = ["from __future__ import annotations"]
 include = ["tach"]
 exclude = ["**/__pycache__", ".venv"]
 strict = ["tach"]
+pythonVersion = "3.8"
 
 [build-system]
 requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]

--- a/tach/check.py
+++ b/tach/check.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass, field
 from typing import Optional
 
-from tach import filesystem as fs
 from tach import errors
-from tach.core import PackageTrie, PackageNode, ProjectConfig
+from tach import filesystem as fs
+from tach.core import PackageNode, PackageTrie, ProjectConfig
 from tach.parsing import build_package_trie, get_project_imports
 
 

--- a/tach/clean.py
+++ b/tach/clean.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from tach import filesystem as fs
 
 

--- a/tach/cli.py
+++ b/tach/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 import sys
@@ -5,17 +7,17 @@ from enum import Enum
 from functools import lru_cache
 from typing import Optional
 
-from tach.check import check, BoundaryError
 from tach import filesystem as fs
+from tach.check import BoundaryError, check
 from tach.clean import clean_project
+from tach.colors import BCOLORS
 from tach.constants import TOOL_NAME
 from tach.core import TagDependencyRules
 from tach.filesystem import install_pre_commit
-from tach.pkg import pkg_edit_interactive
-from tach.loading import stop_spinner, start_spinner
+from tach.loading import start_spinner, stop_spinner
 from tach.parsing import parse_project_config
-from tach.colors import BCOLORS
-from tach.sync import sync_project, prune_dependency_constraints
+from tach.pkg import pkg_edit_interactive
+from tach.sync import prune_dependency_constraints, sync_project
 
 
 class TerminalEnvironment(Enum):

--- a/tach/colors/__init__.py
+++ b/tach/colors/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class BCOLORS:
     HEADER = "\033[95m"
     OKBLUE = "\033[94m"

--- a/tach/constants/__init__.py
+++ b/tach/constants/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 PACKAGE_NAME = "tach"
 TOOL_NAME = "tach"
 CONFIG_FILE_NAME = TOOL_NAME

--- a/tach/core/__init__.py
+++ b/tach/core/__init__.py
@@ -1,4 +1,6 @@
-from tach.core.config import PackageConfig, TagDependencyRules, ProjectConfig
+from __future__ import annotations
+
+from tach.core.config import PackageConfig, ProjectConfig, TagDependencyRules
 from tach.core.package import PackageNode, PackageTrie
 
 __all__ = [

--- a/tach/core/config.py
+++ b/tach/core/config.py
@@ -1,4 +1,6 @@
-from typing import List, Optional, Any
+from __future__ import annotations
+
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
 

--- a/tach/core/package.py
+++ b/tach/core/package.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Optional, Generator
+from typing import Generator, Optional
 
 from tach.core.config import PackageConfig
 

--- a/tach/errors/__init__.py
+++ b/tach/errors/__init__.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 
-class TachError(Exception):
-    ...
+class TachError(Exception): ...
 
 
-class TachParseError(TachError):
-    ...
+class TachParseError(TachError): ...
 
 
-class TachSetupError(TachError):
-    ...
+class TachSetupError(TachError): ...
 
 
 __all__ = ["TachError", "TachParseError", "TachSetupError"]

--- a/tach/errors/__init__.py
+++ b/tach/errors/__init__.py
@@ -1,10 +1,16 @@
-class TachError(Exception): ...
+from __future__ import annotations
 
 
-class TachParseError(TachError): ...
+class TachError(Exception):
+    ...
 
 
-class TachSetupError(TachError): ...
+class TachParseError(TachError):
+    ...
+
+
+class TachSetupError(TachError):
+    ...
 
 
 __all__ = ["TachError", "TachParseError", "TachSetupError"]

--- a/tach/filesystem/__init__.py
+++ b/tach/filesystem/__init__.py
@@ -1,29 +1,31 @@
-from tach.filesystem.service import (
-    get_cwd,
-    chdir,
-    canonical,
-    read_file,
-    write_file,
-    delete_file,
-    parse_ast,
-    walk,
-    walk_pyfiles,
-    walk_pypackages,
-    walk_configured_packages,
-    file_to_module_path,
-    module_to_file_path,
-    is_project_import,
-)
-from tach.filesystem.project import (
-    get_project_config_path,
-    validate_project_config_path,
-    print_no_config_yml,
-    find_project_config_root,
-)
+from __future__ import annotations
+
+from tach.filesystem.install import install_pre_commit
 from tach.filesystem.package import (
     validate_package_config,
 )
-from tach.filesystem.install import install_pre_commit
+from tach.filesystem.project import (
+    find_project_config_root,
+    get_project_config_path,
+    print_no_config_yml,
+    validate_project_config_path,
+)
+from tach.filesystem.service import (
+    canonical,
+    chdir,
+    delete_file,
+    file_to_module_path,
+    get_cwd,
+    is_project_import,
+    module_to_file_path,
+    parse_ast,
+    read_file,
+    walk,
+    walk_configured_packages,
+    walk_pyfiles,
+    walk_pypackages,
+    write_file,
+)
 
 __all__ = [
     "get_cwd",

--- a/tach/filesystem/install.py
+++ b/tach/filesystem/install.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from tach.filesystem.service import mark_executable, write_file

--- a/tach/filesystem/package.py
+++ b/tach/filesystem/package.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import os
 from typing import Optional
-
 
 from tach.constants import PACKAGE_FILE_NAME
 

--- a/tach/filesystem/project.py
+++ b/tach/filesystem/project.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/tach/filesystem/service.py
+++ b/tach/filesystem/service.py
@@ -1,5 +1,7 @@
-import os
+from __future__ import annotations
+
 import ast
+import os
 import re
 import stat
 import sys
@@ -8,7 +10,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional, Generator
+from typing import Generator, Optional
+
 from tach import errors
 from tach.colors import BCOLORS
 
@@ -46,9 +49,9 @@ def chdir(path: str):
 def _get_file_cache() -> dict[str, FileInfo]:
     if not hasattr(thread_local, "file_caches_by_cwd"):
         thread_local.file_caches_by_cwd = defaultdict(dict)
-    file_caches_by_cwd: defaultdict[str, dict[str, FileInfo]] = (
-        thread_local.file_caches_by_cwd
-    )  # type: ignore
+    file_caches_by_cwd: defaultdict[
+        str, dict[str, FileInfo]
+    ] = thread_local.file_caches_by_cwd  # type: ignore
     return file_caches_by_cwd[get_cwd()]
 
 

--- a/tach/filesystem/service.py
+++ b/tach/filesystem/service.py
@@ -49,9 +49,9 @@ def chdir(path: str):
 def _get_file_cache() -> dict[str, FileInfo]:
     if not hasattr(thread_local, "file_caches_by_cwd"):
         thread_local.file_caches_by_cwd = defaultdict(dict)
-    file_caches_by_cwd: defaultdict[
-        str, dict[str, FileInfo]
-    ] = thread_local.file_caches_by_cwd  # type: ignore
+    file_caches_by_cwd: defaultdict[str, dict[str, FileInfo]] = (
+        thread_local.file_caches_by_cwd
+    )  # type: ignore
     return file_caches_by_cwd[get_cwd()]
 
 

--- a/tach/hooks/__init__.py
+++ b/tach/hooks/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from tach.hooks.pre_commit import build_pre_commit_hook_content
 
 __all__ = ["build_pre_commit_hook_content"]

--- a/tach/hooks/pre_commit.py
+++ b/tach/hooks/pre_commit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from tach.constants import TOOL_NAME
 
 template = """#!/bin/sh

--- a/tach/interactive/__init__.py
+++ b/tach/interactive/__init__.py
@@ -1,3 +1,5 @@
-from tach.interactive.packages import get_selected_packages_interactive, SelectedPackage
+from __future__ import annotations
+
+from tach.interactive.packages import SelectedPackage, get_selected_packages_interactive
 
 __all__ = ["get_selected_packages_interactive", "SelectedPackage"]

--- a/tach/interactive/packages.py
+++ b/tach/interactive/packages.py
@@ -1,30 +1,32 @@
+from __future__ import annotations
+
 import os
 import re
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
 from itertools import chain
-from typing import Optional, Generator, Callable, Union
+from typing import Callable, Generator, Optional, Union
 
 from prompt_toolkit import ANSI
+from prompt_toolkit.application import Application
 from prompt_toolkit.data_structures import Point
 from prompt_toolkit.formatted_text import AnyFormattedText
-from prompt_toolkit.widgets import Frame
-from rich.console import Console
-from rich.tree import Tree
-from rich.text import Text
-from prompt_toolkit.application import Application
 from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
 from prompt_toolkit.layout import (
-    Layout,
-    HSplit,
-    Window,
-    ScrollablePane,
     Container,
+    HSplit,
+    Layout,
+    ScrollablePane,
     VerticalAlign,
+    Window,
 )
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.styles import Style
+from prompt_toolkit.widgets import Frame
+from rich.console import Console
+from rich.text import Text
+from rich.tree import Tree
 
 from tach import errors
 from tach import filesystem as fs

--- a/tach/loading.py
+++ b/tach/loading.py
@@ -1,7 +1,9 @@
-import threading
-import sys
+from __future__ import annotations
+
 import itertools
 import queue
+import sys
+import threading
 import time
 
 SPINNER_CHARS = ".oOo"

--- a/tach/parsing/__init__.py
+++ b/tach/parsing/__init__.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 from tach.parsing.config import (
+    dump_project_config_to_yaml,
     parse_package_config,
     parse_project_config,
-    dump_project_config_to_yaml,
 )
 from tach.parsing.imports import get_project_imports
 from tach.parsing.interface import parse_interface_members
 from tach.parsing.packages import build_package_trie
-
 
 __all__ = [
     "parse_package_config",

--- a/tach/parsing/ast_visitor.py
+++ b/tach/parsing/ast_visitor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 from typing import Any
 

--- a/tach/parsing/config.py
+++ b/tach/parsing/config.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import yaml
 
-from tach.colors import BCOLORS
-from tach.core import ProjectConfig, PackageConfig
 from tach import filesystem as fs
+from tach.colors import BCOLORS
+from tach.core import PackageConfig, ProjectConfig
 
 
 def dump_project_config_to_yaml(config: ProjectConfig) -> str:

--- a/tach/parsing/imports.py
+++ b/tach/parsing/imports.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import ast
 import os
 import re
-from typing import Optional
 from dataclasses import dataclass, field
+from typing import Optional
 
 from tach import filesystem as fs
 

--- a/tach/parsing/interface.py
+++ b/tach/parsing/interface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import os
 from typing import Any

--- a/tach/parsing/packages.py
+++ b/tach/parsing/packages.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from tach import filesystem as fs
 from tach.core import PackageTrie
-from tach.parsing import parse_package_config, parse_interface_members
+from tach.parsing import parse_interface_members, parse_package_config
 
 
 def build_package_trie(

--- a/tach/pkg.py
+++ b/tach/pkg.py
@@ -1,14 +1,15 @@
-import os
-from dataclasses import field, dataclass
-from typing import Optional
+from __future__ import annotations
 
+import os
+from dataclasses import dataclass, field
+from typing import Optional
 
 from tach import errors
 from tach import filesystem as fs
 from tach.colors import BCOLORS
-from tach.constants import PACKAGE_FILE_NAME, CONFIG_FILE_NAME, TOOL_NAME
+from tach.constants import CONFIG_FILE_NAME, PACKAGE_FILE_NAME, TOOL_NAME
 from tach.core import ProjectConfig
-from tach.interactive import get_selected_packages_interactive, SelectedPackage
+from tach.interactive import SelectedPackage, get_selected_packages_interactive
 from tach.parsing import dump_project_config_to_yaml
 
 __package_yml_template = """tags: ['{dir_name}']\n"""

--- a/tach/sync.py
+++ b/tach/sync.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import os
 from typing import Optional
 
-from tach import filesystem as fs
 from tach import errors
+from tach import filesystem as fs
+from tach.check import check
 from tach.colors import BCOLORS
 from tach.constants import CONFIG_FILE_NAME
 from tach.core import ProjectConfig
-from tach.check import check
-from tach.parsing import parse_project_config, dump_project_config_to_yaml
+from tach.parsing import dump_project_config_to_yaml, parse_project_config
 
 
 def sync_dependency_constraints(

--- a/tests/example/domain_one/subdomain/__init__.py
+++ b/tests/example/domain_one/subdomain/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from domain_three.core import d3function
 
 d3function()

--- a/tests/example/domain_three/core.py
+++ b/tests/example/domain_three/core.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
 
 
-def d3function():
-    ...
+def d3function(): ...

--- a/tests/example/domain_three/core.py
+++ b/tests/example/domain_three/core.py
@@ -1,1 +1,5 @@
-def d3function(): ...
+from __future__ import annotations
+
+
+def d3function():
+    ...

--- a/tests/example/invalid/hidden/.hidden/__init__.py
+++ b/tests/example/invalid/hidden/.hidden/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unhidden.secret import shhhh
 
 __all__ = ["shhhh"]

--- a/tests/example/invalid/hidden/unhidden/secret.py
+++ b/tests/example/invalid/hidden/unhidden/secret.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 shhhh = "🤫"

--- a/tests/example/valid/domain_three/__init__.py
+++ b/tests/example/valid/domain_three/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 x = 3
 
 __all__ = ["x"]

--- a/tests/example/valid/domain_two/__init__.py
+++ b/tests/example/valid/domain_two/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from domain_three import x
 
 __all__ = ["x"]

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 import pytest
+
+from tach.check import check_import
 from tach.core import (
     PackageConfig,
-    PackageTrie,
     PackageNode,
+    PackageTrie,
     ProjectConfig,
     TagDependencyRules,
 )
-from tach.check import check_import
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from unittest.mock import Mock
+
 import pytest
 
 from tach import cli
-from tach.check import ErrorInfo, BoundaryError
+from tach.check import BoundaryError, ErrorInfo
 from tach.constants import CONFIG_FILE_NAME
 from tach.core import ProjectConfig, TagDependencyRules
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,8 +1,13 @@
-import pytest
-import tempfile
-import shutil
+from __future__ import annotations
+
 import os
-from tach import errors, filesystem as fs
+import shutil
+import tempfile
+
+import pytest
+
+from tach import errors
+from tach import filesystem as fs
 from tach.pkg import pkg_edit_interactive
 
 

--- a/tests/test_package_trie.py
+++ b/tests/test_package_trie.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import pytest
 
-from tach.core import PackageTrie, PackageNode, PackageConfig
+from tach.core import PackageConfig, PackageNode, PackageTrie
 
 
 @pytest.fixture

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import os
 
 import pytest
 from pydantic import ValidationError
 
-from tach.check import check
-from tach.core.config import PackageConfig, TagDependencyRules, ProjectConfig
-from tach.parsing.config import parse_project_config, parse_package_config
-from tach.filesystem import file_to_module_path
 from tach import filesystem as fs
+from tach.check import check
+from tach.core.config import PackageConfig, ProjectConfig, TagDependencyRules
+from tach.filesystem import file_to_module_path
+from tach.parsing.config import parse_package_config, parse_project_config
 
 
 def test_file_to_mod_path():


### PR DESCRIPTION
Add Python 3.8 support by deferring annotations, which should allow new-style annotations to be utilized in older versions of Python, including the pipe operator for optionals.