### PR TITLE
Avoid Unnecessary Imports, Modernize Typing Syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Issues = "https://github.com/gauge-sh/tach/issues"
 
 [tool.ruff]
 target-version = "py38"
-lint.extend-select = ["I"]
+lint.extend-select = ["I", "TCH", "UP"]
 
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]

--- a/tach/check.py
+++ b/tach/check.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from tach import errors
 from tach import filesystem as fs
-from tach.core import PackageNode, PackageTrie, ProjectConfig
 from tach.parsing import build_package_trie, get_project_imports
+
+if TYPE_CHECKING:
+    from tach.core import PackageNode, PackageTrie, ProjectConfig
 
 
 @dataclass
@@ -43,8 +45,8 @@ def check_import(
     package_trie: PackageTrie,
     import_mod_path: str,
     file_mod_path: str,
-    file_nearest_package: Optional[PackageNode] = None,
-) -> Optional[ErrorInfo]:
+    file_nearest_package: PackageNode | None = None,
+) -> ErrorInfo | None:
     import_nearest_package = package_trie.find_nearest(import_mod_path)
     if import_nearest_package is None:
         # This shouldn't happen since we intend to filter out any external imports,
@@ -120,8 +122,8 @@ class BoundaryError:
 def check(
     root: str,
     project_config: ProjectConfig,
-    exclude_paths: Optional[list[str]] = None,
-    exclude_hidden_paths: Optional[bool] = True,
+    exclude_paths: list[str] | None = None,
+    exclude_hidden_paths: bool | None = True,
 ) -> list[BoundaryError]:
     if not os.path.isdir(root):
         raise errors.TachSetupError(f"The path {root} is not a valid directory.")

--- a/tach/cli.py
+++ b/tach/cli.py
@@ -5,19 +5,21 @@ import os
 import sys
 from enum import Enum
 from functools import lru_cache
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from tach import filesystem as fs
 from tach.check import BoundaryError, check
 from tach.clean import clean_project
 from tach.colors import BCOLORS
 from tach.constants import TOOL_NAME
-from tach.core import TagDependencyRules
 from tach.filesystem import install_pre_commit
 from tach.loading import start_spinner, stop_spinner
 from tach.parsing import parse_project_config
 from tach.pkg import pkg_edit_interactive
 from tach.sync import prune_dependency_constraints, sync_project
+
+if TYPE_CHECKING:
+    from tach.core import TagDependencyRules
 
 
 class TerminalEnvironment(Enum):
@@ -26,7 +28,7 @@ class TerminalEnvironment(Enum):
     VSCODE = 3
 
 
-@lru_cache()
+@lru_cache
 def detect_environment() -> TerminalEnvironment:
     if "jetbrains" in os.environ.get("TERMINAL_EMULATOR", "").lower():
         return TerminalEnvironment.JETBRAINS
@@ -36,7 +38,7 @@ def detect_environment() -> TerminalEnvironment:
     return TerminalEnvironment.UNKNOWN
 
 
-def create_clickable_link(file_path: str, line: Optional[int] = None) -> str:
+def create_clickable_link(file_path: str, line: int | None = None) -> str:
     terminal_env = detect_environment()
     abs_path = os.path.abspath(file_path)
 
@@ -213,7 +215,7 @@ def parse_arguments(
 def tach_check(
     root: str = ".",
     exact: bool = False,
-    exclude_paths: Optional[list[str]] = None,
+    exclude_paths: list[str] | None = None,
 ):
     try:
         project_config = parse_project_config(root=root)
@@ -255,7 +257,7 @@ def tach_check(
     sys.exit(0)
 
 
-def tach_pkg(depth: Optional[int] = 1, exclude_paths: Optional[list[str]] = None):
+def tach_pkg(depth: int | None = 1, exclude_paths: list[str] | None = None):
     try:
         saved_changes, warnings = pkg_edit_interactive(
             root=".", depth=depth, exclude_paths=exclude_paths
@@ -274,7 +276,7 @@ def tach_pkg(depth: Optional[int] = 1, exclude_paths: Optional[list[str]] = None
     sys.exit(0)
 
 
-def tach_sync(prune: bool = False, exclude_paths: Optional[list[str]] = None):
+def tach_sync(prune: bool = False, exclude_paths: list[str] | None = None):
     try:
         sync_project(prune=prune, exclude_paths=exclude_paths)
     except Exception as e:

--- a/tach/core/config.py
+++ b/tach/core/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -14,7 +14,7 @@ class PackageConfig(Config):
     Configuration for a single package within a project.
     """
 
-    tags: List[str]
+    tags: list[str]
     strict: bool = False
 
 
@@ -24,7 +24,7 @@ class TagDependencyRules(Config):
     """
 
     tag: str
-    depends_on: List[str]
+    depends_on: list[str]
 
 
 def is_deprecated_project_config(config: dict[str, Any]) -> bool:
@@ -50,8 +50,8 @@ class ProjectConfig(Config):
     Configuration applied globally to a project.
     """
 
-    constraints: List[TagDependencyRules] = Field(default_factory=list)
-    exclude: Optional[List[str]] = Field(default_factory=lambda: ["tests", "docs"])
+    constraints: list[TagDependencyRules] = Field(default_factory=list)
+    exclude: list[str] | None = Field(default_factory=lambda: ["tests", "docs"])
     exclude_hidden_paths: bool = True
     exact: bool = False
     ignore_type_checking_imports: bool = False
@@ -89,7 +89,7 @@ class ProjectConfig(Config):
                 current_dependency_rules.depends_on = list(new_dependencies)
 
     def find_extra_constraints(
-        self, other_config: "ProjectConfig"
+        self, other_config: ProjectConfig
     ) -> list[TagDependencyRules]:
         extra_constraints: list[TagDependencyRules] = []
         base_constraint_tags = set(constraint.tag for constraint in self.constraints)
@@ -115,7 +115,7 @@ class ProjectConfig(Config):
         return extra_constraints
 
     @classmethod
-    def factory(cls, config: dict[str, Any]) -> tuple[bool, "ProjectConfig"]:
+    def factory(cls, config: dict[str, Any]) -> tuple[bool, ProjectConfig]:
         """
         Using this factory to catch deprecated config and flag it to the caller
         """

--- a/tach/core/package.py
+++ b/tach/core/package.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Generator, Optional
+from typing import TYPE_CHECKING, Generator
 
-from tach.core.config import PackageConfig
+if TYPE_CHECKING:
+    from tach.core.config import PackageConfig
 
 
 @dataclass
@@ -21,12 +22,12 @@ class PackageNode:
 
     is_end_of_path: bool
     full_path: str
-    config: Optional[PackageConfig]
+    config: PackageConfig | None
     interface_members: list[str] = field(default_factory=list)
-    children: dict[str, "PackageNode"] = field(default_factory=dict)
+    children: dict[str, PackageNode] = field(default_factory=dict)
 
     @classmethod
-    def empty(cls) -> "PackageNode":
+    def empty(cls) -> PackageNode:
         return PackageNode(is_end_of_path=False, full_path="", config=None)
 
     def fill(
@@ -56,7 +57,7 @@ class PackageTrie:
         # so we want to remove any whitespace path components
         return [part for part in path.split(".") if part]
 
-    def get(self, path: str) -> Optional[PackageNode]:
+    def get(self, path: str) -> PackageNode | None:
         node = self.root
         parts = self._split_mod_path(path)
 
@@ -78,7 +79,7 @@ class PackageTrie:
 
         node.fill(config, path, interface_members)
 
-    def find_nearest(self, path: str) -> Optional[PackageNode]:
+    def find_nearest(self, path: str) -> PackageNode | None:
         node = self.root
         parts = self._split_mod_path(path)
         nearest_parent = node

--- a/tach/filesystem/package.py
+++ b/tach/filesystem/package.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import os
-from typing import Optional
 
 from tach.constants import PACKAGE_FILE_NAME
 
 
-def validate_package_config(root: str = ".") -> Optional[str]:
+def validate_package_config(root: str = ".") -> str | None:
     file_path = os.path.join(root, f"{PACKAGE_FILE_NAME}.yml")
     if os.path.exists(file_path):
         return file_path

--- a/tach/filesystem/project.py
+++ b/tach/filesystem/project.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 from tach.colors import BCOLORS
 from tach.constants import CONFIG_FILE_NAME
@@ -26,7 +25,7 @@ def get_project_config_path(root: str = ".") -> str:
     return ""
 
 
-def find_project_config_root(path: str) -> Optional[str]:
+def find_project_config_root(path: str) -> str | None:
     path = os.path.abspath(path)
     if os.path.isdir(path):
         if get_project_config_path(path):

--- a/tach/filesystem/service.py
+++ b/tach/filesystem/service.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Generator, Optional
+from typing import Generator
 
 from tach import errors
 from tach.colors import BCOLORS
@@ -19,9 +19,9 @@ from tach.colors import BCOLORS
 @dataclass
 class FileInfo:
     path: str
-    content: Optional[str] = None
-    canonical_path: Optional[str] = None
-    ast: Optional["ast.AST"] = None
+    content: str | None = None
+    canonical_path: str | None = None
+    ast: ast.AST | None = None
 
 
 # Thread-local file cache to avoid going to disk as much as possible
@@ -59,7 +59,7 @@ def _file_cache_key(path: str) -> str:
     return f"{get_cwd()}:::{path}"
 
 
-def _cached_file(path: str) -> Optional[FileInfo]:
+def _cached_file(path: str) -> FileInfo | None:
     return _get_file_cache().get(_file_cache_key(path))
 
 
@@ -91,7 +91,7 @@ def read_file(path: str) -> str:
     if cached_file and cached_file.content:
         return cached_file.content
 
-    with open(path, "r") as f:
+    with open(path) as f:
         content = f.read()
 
     if cached_file:
@@ -140,7 +140,7 @@ def parse_ast(path: str) -> ast.AST:
         except SyntaxError as e:
             raise errors.TachParseError(f"Syntax error in {path}: {e}")
     else:
-        with open(path, "r") as f:
+        with open(path) as f:
             content = f.read()
         try:
             ast_result = ast.parse(content)
@@ -158,10 +158,10 @@ def parse_ast(path: str) -> ast.AST:
 
 def walk(
     root: str,
-    depth: Optional[int] = None,
+    depth: int | None = None,
     exclude_root: bool = True,
-    exclude_paths: Optional[list[str]] = None,
-    exclude_hidden_paths: Optional[bool] = True,
+    exclude_paths: list[str] | None = None,
+    exclude_hidden_paths: bool | None = True,
 ) -> Generator[tuple[str, list[str]], None, None]:
     canonical_root = canonical(root)
     base_depth = 0 if canonical_root == "." else canonical_root.count(os.path.sep) + 1
@@ -207,9 +207,9 @@ def walk(
 
 def walk_pyfiles(
     root: str,
-    depth: Optional[int] = None,
-    exclude_paths: Optional[list[str]] = None,
-    exclude_hidden_paths: Optional[bool] = True,
+    depth: int | None = None,
+    exclude_paths: list[str] | None = None,
+    exclude_hidden_paths: bool | None = True,
 ) -> Generator[str, None, None]:
     for dirpath, filenames in walk(
         root,
@@ -224,9 +224,9 @@ def walk_pyfiles(
 
 def walk_pypackages(
     root: str,
-    depth: Optional[int] = None,
-    exclude_paths: Optional[list[str]] = None,
-    exclude_hidden_paths: Optional[bool] = True,
+    depth: int | None = None,
+    exclude_paths: list[str] | None = None,
+    exclude_hidden_paths: bool | None = True,
 ) -> Generator[str, None, None]:
     for filepath in walk_pyfiles(
         root,
@@ -241,9 +241,9 @@ def walk_pypackages(
 
 def walk_configured_packages(
     root: str,
-    depth: Optional[int] = None,
-    exclude_paths: Optional[list[str]] = None,
-    exclude_hidden_paths: Optional[bool] = True,
+    depth: int | None = None,
+    exclude_paths: list[str] | None = None,
+    exclude_hidden_paths: bool | None = True,
 ) -> Generator[tuple[str, str], None, None]:
     for dirpath in walk_pypackages(
         root,

--- a/tach/interactive/packages.py
+++ b/tach/interactive/packages.py
@@ -6,12 +6,11 @@ from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
 from itertools import chain
-from typing import Callable, Generator, Optional, Union
+from typing import TYPE_CHECKING, Callable, Generator
 
 from prompt_toolkit import ANSI
 from prompt_toolkit.application import Application
 from prompt_toolkit.data_structures import Point
-from prompt_toolkit.formatted_text import AnyFormattedText
 from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
 from prompt_toolkit.layout import (
     Container,
@@ -32,6 +31,9 @@ from tach import errors
 from tach import filesystem as fs
 from tach.constants import PACKAGE_FILE_NAME
 
+if TYPE_CHECKING:
+    from prompt_toolkit.formatted_text import AnyFormattedText
+
 
 @dataclass
 class SelectedPackage:
@@ -50,33 +52,33 @@ class FileNode:
     is_dir: bool
     expanded: bool = False
     is_package: bool = False
-    parent: Optional["FileNode"] = None
-    children: list["FileNode"] = field(default_factory=list)
+    parent: FileNode | None = None
+    children: list[FileNode] = field(default_factory=list)
 
     @property
     def empty(self) -> bool:
         return len(self.children) == 0
 
     @property
-    def visible_children(self) -> list["FileNode"]:
+    def visible_children(self) -> list[FileNode]:
         if not self.expanded:
             return []
         return self.children
 
     @classmethod
-    def build_from_path(cls, path: str) -> "FileNode":
+    def build_from_path(cls, path: str) -> FileNode:
         is_dir = os.path.isdir(path)
         is_package = os.path.isfile(os.path.join(path, f"{PACKAGE_FILE_NAME}.yml"))
         return cls(full_path=path, is_dir=is_dir, is_package=is_package)
 
     @property
-    def parent_sorted_children(self) -> Optional[list["FileNode"]]:
+    def parent_sorted_children(self) -> list[FileNode] | None:
         if not self.parent:
             return None
         return sorted(self.parent.visible_children, key=lambda node: node.full_path)
 
     @property
-    def prev_sibling(self) -> Optional["FileNode"]:
+    def prev_sibling(self) -> FileNode | None:
         parent_sorted_children = self.parent_sorted_children
         if not parent_sorted_children:
             return None
@@ -91,7 +93,7 @@ class FileNode:
         return parent_sorted_children[my_index - 1]
 
     @property
-    def next_sibling(self) -> Optional["FileNode"]:
+    def next_sibling(self) -> FileNode | None:
         parent_sorted_children = self.parent_sorted_children
         if not parent_sorted_children:
             return None
@@ -105,7 +107,7 @@ class FileNode:
             return None
         return parent_sorted_children[my_index + 1]
 
-    def siblings(self, include_self: bool = True) -> list["FileNode"]:
+    def siblings(self, include_self: bool = True) -> list[FileNode]:
         if not self.parent:
             return [self] if include_self else []
 
@@ -125,10 +127,10 @@ class FileTree:
     def build_from_path(
         cls,
         path: str,
-        depth: Optional[int] = 1,
-        exclude_paths: Optional[list[str]] = None,
+        depth: int | None = 1,
+        exclude_paths: list[str] | None = None,
         auto_select_initial_packages: bool = False,
-    ) -> "FileTree":
+    ) -> FileTree:
         root = FileNode.build_from_path(fs.canonical(path))
         root.expanded = True
         tree = cls(root)
@@ -146,7 +148,7 @@ class FileTree:
         self,
         root: FileNode,
         depth: int = 1,
-        exclude_paths: Optional[list[str]] = None,
+        exclude_paths: list[str] | None = None,
     ):
         if root.is_dir:
             try:
@@ -185,7 +187,7 @@ class FileTree:
                 return
 
     def mark_pypackages_as_packages(
-        self, depth: Optional[int], exclude_paths: Optional[list[str]] = None
+        self, depth: int | None, exclude_paths: list[str] | None = None
     ):
         packages_found: list[str] = []
         for package_path in fs.walk_pypackages(
@@ -249,8 +251,8 @@ class InteractivePackageTree:
     def __init__(
         self,
         path: str,
-        depth: Optional[int] = 1,
-        exclude_paths: Optional[list[str]] = None,
+        depth: int | None = 1,
+        exclude_paths: list[str] | None = None,
         auto_select_initial_packages: bool = False,
     ):
         # By default, don't save if we exit for any reason
@@ -477,7 +479,7 @@ class InteractivePackageTree:
             self._update_display()
 
     def _render_node(self, node: FileNode) -> Text:
-        text_parts: list[Union[tuple[str, str], str]] = []
+        text_parts: list[tuple[str, str] | str] = []
         if node == self.selected_node:
             text_parts.append(("-> ", "bold cyan"))
 
@@ -524,7 +526,7 @@ class InteractivePackageTree:
     def _update_display(self):
         self.tree_control.text = ANSI(self._render_tree())
 
-    def run(self) -> Optional[list[SelectedPackage]]:
+    def run(self) -> list[SelectedPackage] | None:
         self.app.run()
         if self.exit_code == ExitCode.QUIT_SAVE:
             return [
@@ -536,10 +538,10 @@ class InteractivePackageTree:
 
 def get_selected_packages_interactive(
     path: str,
-    depth: Optional[int] = 1,
-    exclude_paths: Optional[list[str]] = None,
+    depth: int | None = 1,
+    exclude_paths: list[str] | None = None,
     auto_select_initial_packages: bool = False,
-) -> Optional[list[SelectedPackage]]:
+) -> list[SelectedPackage] | None:
     ipt = InteractivePackageTree(
         path=path,
         depth=depth,

--- a/tach/parsing/config.py
+++ b/tach/parsing/config.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 import yaml
 
 from tach import filesystem as fs
@@ -23,7 +21,7 @@ def dump_project_config_to_yaml(config: ProjectConfig) -> str:
 
 def parse_project_config(root: str = ".") -> ProjectConfig:
     file_path = fs.validate_project_config_path(root)
-    with open(file_path, "r") as f:
+    with open(file_path) as f:
         result = yaml.safe_load(f)
         if not result or not isinstance(result, dict):
             raise ValueError(f"Empty or invalid project config file: {file_path}")
@@ -37,10 +35,10 @@ def parse_project_config(root: str = ".") -> ProjectConfig:
     return config
 
 
-def parse_package_config(root: str = ".") -> Optional[PackageConfig]:
+def parse_package_config(root: str = ".") -> PackageConfig | None:
     file_path = fs.validate_package_config(root)
     if file_path:
-        with open(file_path, "r") as f:
+        with open(file_path) as f:
             result = yaml.safe_load(f)
             if not result or not isinstance(result, dict):
                 raise ValueError(f"Empty or invalid package config file: {file_path}")

--- a/tach/parsing/imports.py
+++ b/tach/parsing/imports.py
@@ -4,7 +4,6 @@ import ast
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Optional
 
 from tach import filesystem as fs
 
@@ -47,7 +46,7 @@ class ImportVisitor(ast.NodeVisitor):
         project_root: str,
         current_mod_path: str,
         is_package: bool = False,
-        ignore_directives: Optional[dict[int, IgnoreDirective]] = None,
+        ignore_directives: dict[int, IgnoreDirective] | None = None,
         ignore_type_checking_imports: bool = False,
     ):
         self.project_root = project_root
@@ -57,7 +56,7 @@ class ImportVisitor(ast.NodeVisitor):
         self.imports: list[ProjectImport] = []
         self.ignore_type_checking_imports = ignore_type_checking_imports
 
-    def _get_ignored_modules(self, lineno: int) -> Optional[list[str]]:
+    def _get_ignored_modules(self, lineno: int) -> list[str] | None:
         # Check for ignore directive at the previous line or on the current line
         directive = self.ignored_imports.get(lineno - 1) or self.ignored_imports.get(
             lineno

--- a/tach/parsing/packages.py
+++ b/tach/parsing/packages.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from tach import filesystem as fs
 from tach.core import PackageTrie
 from tach.parsing import parse_interface_members, parse_package_config
@@ -9,8 +7,8 @@ from tach.parsing import parse_interface_members, parse_package_config
 
 def build_package_trie(
     root: str,
-    exclude_paths: Optional[list[str]] = None,
-    exclude_hidden_paths: Optional[bool] = True,
+    exclude_paths: list[str] | None = None,
+    exclude_hidden_paths: bool | None = True,
 ) -> PackageTrie:
     package_trie = PackageTrie()
 

--- a/tach/pkg.py
+++ b/tach/pkg.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Optional
 
 from tach import errors
 from tach import filesystem as fs
@@ -24,7 +23,7 @@ class SetPackagesResult:
 def set_packages(
     selected_packages: list[SelectedPackage],
     path: str,
-    exclude_paths: Optional[list[str]] = None,
+    exclude_paths: list[str] | None = None,
 ) -> SetPackagesResult:
     package_paths: list[str] = []
     warnings: list[str] = []
@@ -87,7 +86,7 @@ def init_root(root: str) -> InitRootResult:
 
 
 def pkg_edit_interactive(
-    root: str, depth: Optional[int] = 1, exclude_paths: Optional[list[str]] = None
+    root: str, depth: int | None = 1, exclude_paths: list[str] | None = None
 ) -> tuple[bool, list[str]]:
     if not os.path.isdir(root):
         raise errors.TachSetupError(f"The path {root} is not a directory.")

--- a/tach/sync.py
+++ b/tach/sync.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from typing import Optional
 
 from tach import errors
 from tach import filesystem as fs
@@ -15,8 +14,8 @@ from tach.parsing import dump_project_config_to_yaml, parse_project_config
 def sync_dependency_constraints(
     root: str,
     project_config: ProjectConfig,
-    filter_tags: Optional[set[str]] = None,
-    exclude_paths: Optional[list[str]] = None,
+    filter_tags: set[str] | None = None,
+    exclude_paths: list[str] | None = None,
 ) -> ProjectConfig:
     """
     Update project configuration with auto-detected dependency constraints.
@@ -54,8 +53,8 @@ def sync_dependency_constraints(
 
 def prune_dependency_constraints(
     root: str,
-    project_config: Optional[ProjectConfig] = None,
-    exclude_paths: Optional[list[str]] = None,
+    project_config: ProjectConfig | None = None,
+    exclude_paths: list[str] | None = None,
 ) -> ProjectConfig:
     """
     Build a minimal project configuration with auto-detected dependency constraints.
@@ -73,9 +72,7 @@ def prune_dependency_constraints(
     return project_config
 
 
-def sync_project(
-    prune: bool = False, exclude_paths: Optional[list[str]] = None
-) -> None:
+def sync_project(prune: bool = False, exclude_paths: list[str] | None = None) -> None:
     original_cwd = fs.get_cwd()
     try:
         root = fs.find_project_config_root(original_cwd)

--- a/tests/test_package_trie.py
+++ b/tests/test_package_trie.py
@@ -60,7 +60,7 @@ def test_iterate_over_empty_trie():
 
 
 def test_iterate_over_populated_trie(package_trie):
-    assert set((node.full_path for node in package_trie)) == {
+    assert set(node.full_path for node in package_trie) == {
         "domain_one",
         "domain_one.subdomain",
         "domain_two",
@@ -85,19 +85,19 @@ def test_get_actual_path(package_trie):
 def test_insert_empty_path(test_config):
     trie = PackageTrie()
     trie.insert(test_config, "", [])
-    assert set((node.full_path for node in trie)) == {""}
+    assert set(node.full_path for node in trie) == {""}
 
 
 def test_insert_single_level_path(test_config):
     trie = PackageTrie()
     trie.insert(test_config, "domain", [])
-    assert set((node.full_path for node in trie)) == {"domain"}
+    assert set(node.full_path for node in trie) == {"domain"}
 
 
 def test_insert_multi_level_path(test_config):
     trie = PackageTrie()
     trie.insert(test_config, "domain.subdomain", [])
-    assert set((node.full_path for node in trie)) == {"domain.subdomain"}
+    assert set(node.full_path for node in trie) == {"domain.subdomain"}
 
 
 def test_find_nearest_at_root(package_trie):


### PR DESCRIPTION
Utilize Ruff to enforce modern typing syntax and other modernizations through the [UP rule-set](https://docs.astral.sh/ruff/rules/#pyupgrade-up), and move imports purely used as type annotations to `TYPE_CHECKING` block reducing project init time through [TCH](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch).