### PR TITLE
Allow execution as a python module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tach"
-version = "0.2.6"
+version = "0.2.7"
 authors = [
   { name="Caelean Barnes", email="caeleanb@gmail.com" },
   { name="Evan Doyle", email="evanmdoyle@gmail.com" },

--- a/python/tach/__main__.py
+++ b/python/tach/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from tach.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -423,7 +423,3 @@ def main() -> None:
         print("Unrecognized command")
         parser.print_help()
         exit(1)
-
-
-if __name__ == "__main__":
-    main()

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -423,3 +423,7 @@ def main() -> None:
         print("Unrecognized command")
         parser.print_help()
         exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Allows execution of tach like so: `python -m tach check`
This is a required entrypoint for the vscode plugin

The script entrypoint remains the same