### PR TITLE
Fix visibility of package boundary in root (package.yml sibling of tach.yml)

### DIFF
--- a/python/tach/filesystem/service.py
+++ b/python/tach/filesystem/service.py
@@ -159,7 +159,6 @@ def parse_ast(path: str) -> ast.AST:
 def walk(
     root: str,
     depth: int | None = None,
-    exclude_root: bool = True,
     exclude_paths: list[str] | None = None,
 ) -> Generator[tuple[str, list[str]], None, None]:
     canonical_root = canonical(root)
@@ -168,10 +167,10 @@ def walk(
         dirpath = canonical(dirpath)
         dirpath_for_matching = f"{dirpath}/"
 
-        if exclude_root and dirpath == canonical_root:
-            continue
-
-        if os.path.basename(os.path.normpath(dirpath)).startswith("."):
+        # The root dir is a special case which starts with '.' but is not hidden
+        if dirpath != "." and os.path.basename(os.path.normpath(dirpath)).startswith(
+            "."
+        ):
             # This prevents recursing into child directories of hidden paths
             del dirnames[:]
             continue


### PR DESCRIPTION
This is a short-term fix for the following case:
```
/
  my_package/
    __init__.py
    package.yml
  my_other_package/
    __init__.py
  __init__.py
  package.yml
  tach.yml
```

Without this PR, the setup above would never catch a dependency on `my_package` from the root or from `my_other_package`, because the boundary in the root was being ignored.

It seems like an explicit 'exclude_root' condition was necessary at some point in the past, but this PR simply removes it and adjusts another conditional which is affected downstream.


## Future work
The setup described above is not ergonomic (forcing an `__init__.py`, `package.yml` in the root), and instead we should likely have a first-class 'source_root' concept which is separate from the 'project root' where `tach.yml` is placed.

The `source_root` would become an implicit package boundary, and would determine how file paths map to module paths (which affects 1st party vs. 3rd party import detection among other things).