### PR TITLE
Remove auto-suggestion of packages from 'tach pkg'

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,7 +14,7 @@ The only exceptions are imports made within `TYPE_CHECKING` conditional blocks. 
 these imports, you can add `ignore_type_checking_imports: true` to your `tach.yml`.
 
 ### Can you catch dynamic references?
-Since `tach` uses the AST to find imports and public members, dynamic imports (e.g. using a string path) and dynamic names (e.g. using `setattr`, `locals`, `globals`) are generally not supported. If these usages cause `tach` to report incorrect errors, the [ignore directive](tach-ignore#tach-ignore) should be sufficient to reach a passing state.
+Since `tach` uses the AST to find imports and public members, dynamic imports (e.g. using a string path) and dynamic names (e.g. using `setattr`, `locals`, `globals`) are generally not supported. If these usages cause `tach` to report incorrect errors, the [ignore directive](tach-ignore.md#tach-ignore) should be sufficient to reach a passing state.
 
 ### What information does Tach track?
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,7 +44,7 @@ Configure package boundaries interactively
 options:
   -h, --help            show this help message and exit
   -d [DEPTH], --depth [DEPTH]
-                        The number of child directories to search for packages to auto-select
+                        The number of child directories to expand from the root
   -e file_or_path,..., --exclude file_or_path,...
                         Comma separated path list to exclude. tests/, ci/, etc.
 ```
@@ -54,9 +54,7 @@ Running `tach pkg` will open an interactive editor in your terminal which allows
 You can navigate with the arrow keys, mark individual packages with `Enter`, and mark all sibling directories
 as packages with `Ctrl + a`.
 
-If you have not configured `tach` in your project before, `tach pkg` will automatically mark an initial set of packages.
-The `--depth` flag controls how many directories `tach` will traverse when suggesting these initial packages.
-You can accept these suggestions immediately with `Ctrl + s`, or you can edit the selections freely before confirming.
+When you are ready to save your packages, use `Ctrl + s` to save and exit. Otherwise, to exit without saving you can use `Ctrl + c`.
 
 Any time you make changes with `tach pkg`, it is recommended to run [`tach sync`](usage.md#tach-sync)
 to automatically configure dependency rules.

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -140,7 +140,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         nargs="?",
         default=None,
-        help="The number of child directories to search for packages to auto-select",
+        help="The number of child directories to expand from the root",
     )
     add_base_arguments(pkg_parser)
     check_parser = subparsers.add_parser(

--- a/python/tach/pkg.py
+++ b/python/tach/pkg.py
@@ -96,13 +96,10 @@ def pkg_edit_interactive(
 
     warnings: list[str] = []
 
-    # We only want to auto-select if the project appears not to have been configured already
-    auto_select_initial_packages = fs.get_project_config_path(root) == ""
     selected_packages = get_selected_packages_interactive(
         root,
         depth=depth,
         exclude_paths=exclude_paths,
-        auto_select_initial_packages=auto_select_initial_packages,
     )
     if selected_packages is not None:
         set_packages_result = set_packages(


### PR DESCRIPTION
Automatically marking packages in 'tach pkg' often doesn't match user expectations and can lead to confusing behavior. It also generally leads to a much larger and more bloated `tach.yml` when trying to adopt `tach` in an existing, mature codebase.