### PR TITLE
Update docs to point to pre-commit mirror repo

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,0 @@
-- id: tach
-  name: tach
-  description: Validate package dependencies
-  entry: tach check
-  language: python
-  pass_filenames: false

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -106,7 +106,7 @@ If you use the [pre-commit framework](https://github.com/pre-commit/pre-commit),
 
 ```yaml
 repos:
--   repo: https://github.com/gauge-sh/tach
+-   repo: https://github.com/gauge-sh/tach-pre-commit
     rev: v0.5.1  # change this to the latest tag!
     hooks:
     -   id: tach


### PR DESCRIPTION
Fixes #98 

We now have https://github.com/gauge-sh/tach-pre-commit (based on the analogous pre-commit mirrors used by ruff, black)

That repository will check for a new version of `tach` every 4 hours, and publish a new matching tag accordingly.

Using this layer of indirection fixes our pre-commit hook with the [pre-commit framework](https://pre-commit.com) because it lets us use PyPI to distribute pre-built wheels instead of forcing the end user to build our package from source (which requires a Rust toolchain). This is necessary because the pre-commit framework will simply run `pip install .` from the git root -- we introduce the mirror so that we can list our package as a remote dependency from PyPI, which means we will get an appropriate pre-built wheel for our system.