### PR TITLE
Show warnings when file parsing fails during project import gathering

### DIFF
--- a/python/tach.yml
+++ b/python/tach.yml
@@ -13,7 +13,6 @@ modules:
   strict: true
 - path: tach.check
   depends_on:
-  - tach.colors
   - tach.errors
   - tach.filesystem
   - tach.parsing

--- a/python/tach.yml
+++ b/python/tach.yml
@@ -13,6 +13,7 @@ modules:
   strict: true
 - path: tach.check
   depends_on:
+  - tach.colors
   - tach.errors
   - tach.filesystem
   - tach.parsing

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from tach import errors
 from tach import filesystem as fs
+from tach.colors import BCOLORS
 from tach.extension import get_project_imports, set_excluded_paths
 from tach.parsing import build_module_tree
 
@@ -149,11 +150,22 @@ def check(
             if nearest_module is None:
                 continue
 
-            project_imports = get_project_imports(
-                ".",
-                file_path,
-                ignore_type_checking_imports=project_config.ignore_type_checking_imports,
-            )
+            try:
+                project_imports = get_project_imports(
+                    ".",
+                    file_path,
+                    ignore_type_checking_imports=project_config.ignore_type_checking_imports,
+                )
+            except SyntaxError:
+                print(
+                    f"{BCOLORS.WARNING}Skipping file '{file_path}' due to a syntax error.{BCOLORS.ENDC}"
+                )
+                continue
+            except OSError:
+                print(
+                    f"{BCOLORS.WARNING}Skipping file '{file_path}' due to a file system error.{BCOLORS.ENDC}"
+                )
+                continue
             for project_import in project_imports:
                 check_error = check_import(
                     module_tree=module_tree,

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -158,12 +158,12 @@ def check(
                 )
             except SyntaxError:
                 print(
-                    f"{BCOLORS.WARNING}Skipping file '{file_path}' due to a syntax error.{BCOLORS.ENDC}"
+                    f"{BCOLORS.WARNING}Skipping '{file_path}' due to a syntax error.{BCOLORS.ENDC}"
                 )
                 continue
             except OSError:
                 print(
-                    f"{BCOLORS.WARNING}Skipping file '{file_path}' due to a file system error.{BCOLORS.ENDC}"
+                    f"{BCOLORS.WARNING}Skipping '{file_path}' due to a file system error.{BCOLORS.ENDC}"
                 )
                 continue
             for project_import in project_imports:

--- a/python/tach/sync.py
+++ b/python/tach/sync.py
@@ -15,20 +15,17 @@ if TYPE_CHECKING:
 
 
 def sync_dependency_constraints(
-    root: str,
-    project_config: ProjectConfig,
-    exclude_paths: list[str] | None = None,
+    root: str, project_config: ProjectConfig, exclude_paths: list[str] | None = None
 ) -> ProjectConfig:
     """
     Update project configuration with auto-detected dependency constraints.
     This is additive, meaning it will create dependencies to resolve existing errors,
     but will not remove any constraints.
-    Passing 'filter_tags' will limit updates to only those dependencies which include one of those tags.
     """
-    check_errors = check(
+    check_result = check(
         root, project_config=project_config, exclude_paths=exclude_paths
     )
-    for error in check_errors:
+    for error in check_result.errors:
         error_info = error.error_info
         if error_info.is_dependency_error:
             project_config.add_dependency_to_module(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -5,14 +5,14 @@ from unittest.mock import Mock
 import pytest
 
 from tach import cli
-from tach.check import BoundaryError, ErrorInfo
+from tach.check import BoundaryError, CheckResult, ErrorInfo
 from tach.constants import CONFIG_FILE_NAME
 from tach.core import ModuleConfig, ProjectConfig
 
 
 @pytest.fixture
 def mock_check(mocker) -> Mock:
-    mock = Mock(return_value=[])  # default to a return with no errors
+    mock = Mock(return_value=CheckResult())  # default to a return with no errors
     mocker.patch("tach.cli.check", mock)
     return mock
 
@@ -67,16 +67,18 @@ def test_execute_with_error(capfd, mock_path_exists, mock_check, mock_project_co
     # Mock an error returned from check
     location = "valid_dir/file.py"
     message = "Import valid_dir in valid_dir/file.py is blocked by boundary"
-    mock_check.return_value = [
-        BoundaryError(
-            file_path=location,
-            line_number=0,
-            import_mod_path="valid_dir",
-            error_info=ErrorInfo(
-                exception_message="Import valid_dir in valid_dir/file.py is blocked by boundary",
-            ),
-        )
-    ]
+    mock_check.return_value = CheckResult(
+        errors=[
+            BoundaryError(
+                file_path=location,
+                line_number=0,
+                import_mod_path="valid_dir",
+                error_info=ErrorInfo(
+                    exception_message="Import valid_dir in valid_dir/file.py is blocked by boundary",
+                ),
+            )
+        ]
+    )
     with pytest.raises(SystemExit) as sys_exit:
         cli.tach_check()
     captured = capfd.readouterr()

--- a/python/tests/test_parsing.py
+++ b/python/tests/test_parsing.py
@@ -41,7 +41,7 @@ def test_run_valid_project_config():
             project_config,
             exclude_paths=project_config.exclude,
         )
-        assert results == []
+        assert results.errors == []
     finally:
         # Make sure not to dirty the test directory state
         fs.chdir(current_dir)

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -14,8 +14,15 @@ use ruff_source_file::Locator;
 
 use crate::{filesystem, parsing};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
+pub enum ImportParseErrorType {
+    FILESYSTEM,
+    PARSING,
+}
+
+#[derive(Debug)]
 pub struct ImportParseError {
+    pub err_type: ImportParseErrorType,
     pub message: String,
 }
 
@@ -298,14 +305,17 @@ pub fn get_project_imports(
 ) -> Result<ProjectImports> {
     let canonical_path: PathBuf = filesystem::canonical(project_root.as_ref(), file_path.as_ref())
         .map_err(|err| ImportParseError {
+            err_type: ImportParseErrorType::FILESYSTEM,
             message: format!("Failed to parse project imports. Failure: {}", err.message),
         })?;
     let file_contents =
         filesystem::read_file_content(&canonical_path).map_err(|err| ImportParseError {
+            err_type: ImportParseErrorType::FILESYSTEM,
             message: format!("Failed to parse project imports. Failure: {}", err.message),
         })?;
     let file_ast =
         parsing::parse_python_source(&file_contents).map_err(|err| ImportParseError {
+            err_type: ImportParseErrorType::PARSING,
             message: format!(
                 "Failed to parse project imports. File: {:?} Failure: {:?}",
                 canonical_path.as_path().to_str().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,15 @@ pub mod imports;
 pub mod parsing;
 pub mod reports;
 
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyOSError, PySyntaxError, PyValueError};
 use pyo3::prelude::*;
 
 impl From<imports::ImportParseError> for PyErr {
     fn from(err: imports::ImportParseError) -> Self {
-        PyValueError::new_err(err.message)
+        match err.err_type {
+            imports::ImportParseErrorType::FILESYSTEM => PyOSError::new_err(err.message),
+            imports::ImportParseErrorType::PARSING => PySyntaxError::new_err(err.message),
+        }
     }
 }
 


### PR DESCRIPTION
This PR changes the behavior of Tach in the presence of syntax errors.

Previously, the entire process would exit with an error message indicating a syntax error.

With this PR, Tach will instead report a warning to stdout when the syntax error is encountered during `check` or `sync`, or will collect warnings and add them to the output of `tach report`.