### PR TITLE
Add suggested fixes to error output from 'tach check'

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -109,12 +109,17 @@ def print_unused_dependencies(
     all_unused_dependencies: list[UnusedDependencies],
 ) -> None:
     constraint_messages = "\n".join(
-        f"\t{BCOLORS.WARNING}{unused_dependencies.path} does not depend on: {unused_dependencies.dependencies}{BCOLORS.ENDC}"
+        f"\t{BCOLORS.WARNING}'{unused_dependencies.path}' does not depend on: {unused_dependencies.dependencies}{BCOLORS.ENDC}"
         for unused_dependencies in all_unused_dependencies
     )
     print(
         f"❌ {BCOLORS.FAIL}Found unused dependencies: {BCOLORS.ENDC}\n"
         + constraint_messages
+    )
+    print(
+        f"{BCOLORS.WARNING}\nRemove the unused dependencies from tach.yml, "
+        f"or consider running 'tach sync --prune' to update module configuration and "
+        f"eliminate all unused dependencies.\n{BCOLORS.ENDC}"
     )
 
 

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -99,6 +99,10 @@ def print_errors(error_list: list[BoundaryError]) -> None:
             build_error_message(error),
             file=sys.stderr,
         )
+    print(
+        f"{BCOLORS.WARNING}\nIf you intended to add a new dependency, run 'tach sync' to update your module configuration."
+        f"\nOtherwise, remove any disallowed imports and consider refactoring.\n{BCOLORS.ENDC}"
+    )
 
 
 def print_unused_dependencies(


### PR DESCRIPTION
This PR adds help text with suggested fixes for errors emitted by 'tach check'.

This should help clarify Tach's behavior for new contributors to a codebase who might get blocked by its checks.