### PR TITLE
Fix empty path errors related to selecting root in 'tach mod'

### DIFF
--- a/python/tach.yml
+++ b/python/tach.yml
@@ -13,6 +13,7 @@ modules:
   strict: true
 - path: tach.check
   depends_on:
+  - tach.core
   - tach.errors
   - tach.filesystem
   - tach.parsing

--- a/python/tach/filesystem/service.py
+++ b/python/tach/filesystem/service.py
@@ -294,6 +294,11 @@ def module_to_pyfile_or_dir_path(module_path: str) -> Path | None:
     This resolves a dotted Python module path ('a.b.c')
     into a Python file or a Python package directory
     """
+    if not module_path:
+        # Path("") turns into PosixPath("."), but we don't want to
+        # treat an empty module path as the root directory
+        return None
+
     base_path = module_path.replace(".", os.sep)
     pyfile_path = Path(f"{base_path}.py")
     dir_path = Path(base_path)

--- a/python/tach/interactive/modules.py
+++ b/python/tach/interactive/modules.py
@@ -120,6 +120,7 @@ class FileTree:
         exclude_paths: list[str] | None = None,
     ) -> FileTree:
         root = FileNode.build_from_path(fs.canonical(path))
+        root.is_module = False
         root.expanded = True
         tree = cls(root)
         tree.nodes[fs.canonical(path)] = root
@@ -422,6 +423,9 @@ class InteractiveModuleTree:
 
         @self.key_bindings.add("enter")
         def _(event: KeyPressEvent):
+            if self.selected_node is self.file_tree.root:
+                # Root should not be explicitly selected
+                return
             self.selected_node.is_module = not self.selected_node.is_module
             self._update_display()
 


### PR DESCRIPTION
This PR addresses a bug when marking the current directory as a module in 'tach mod'. This results in a module with the path '', which causes an error when building the module tree in 'tach check'.

This PR makes the following changes:
- Selecting the current directory is no longer supported in 'tach mod'
- The current directory will no longer be shown as a module in 'tach mod' when a module with the empty path exists in 'tach.yml'
- The empty path and any other invalid module path will be emitted as a warning from 'tach check' without blocking the rest of the check