### PR TITLE
[Bugfixes] 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "tach"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "criterion",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tach"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [lib]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,7 +114,7 @@ If you use the [pre-commit framework](https://github.com/pre-commit/pre-commit),
 ```yaml
 repos:
 -   repo: https://github.com/gauge-sh/tach-pre-commit
-    rev: v0.6.0  # change this to the latest tag!
+    rev: v0.6.1  # change this to the latest tag!
     hooks:
     -   id: tach
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tach"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   { name="Caelean Barnes", email="caeleanb@gmail.com" },
   { name="Evan Doyle", email="evanmdoyle@gmail.com" },

--- a/python/tach/__init__.py
+++ b/python/tach/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = ["__version__"]

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -243,11 +243,6 @@ def tach_check(
 
         exact |= project_config.exact
 
-        if exclude_paths is not None and project_config.exclude is not None:
-            exclude_paths.extend(project_config.exclude)
-        else:
-            exclude_paths = project_config.exclude
-
         check_result = check(
             project_root=project_root,
             project_config=project_config,

--- a/tach.yml
+++ b/tach.yml
@@ -13,6 +13,7 @@ modules:
   strict: true
 - path: tach.check
   depends_on:
+  - tach.constants
   - tach.core
   - tach.errors
   - tach.filesystem


### PR DESCRIPTION
Fixes two issues in 0.6.0

1. The '<root>' module fails validation and blocks checks
2. If there are Python files outside the source root, their path fails to validate and blocks checks