### PR TITLE
Fixes Gracefully exit on `KeyboardInterrupt`

### DIFF
--- a/python/tach/__main__.py
+++ b/python/tach/__main__.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
-
+import sys
 from tach.cli import main
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nExiting gracefully...")
+        sys.exit(1)


### PR DESCRIPTION
This PR fixes https://github.com/gauge-sh/tach/issues/125

Description:
This PR enhances the user experience by catching KeyboardInterrupt exceptions during Tach's execution. Currently, interrupting the script with Ctrl + C results in an ugly stack trace. Instead, this PR introduces a try-except block in the main script to catch KeyboardInterrupt at a high level. Upon receiving a KeyboardInterrupt, the script will exit gracefully with a nonzero exit code, ensuring a cleaner termination.

Changes:

`Earlier`:
![image](https://github.com/gauge-sh/tach/assets/92686157/40b5c8cf-3711-4d3c-99dc-d789085d9d1c)

`Now`
![image](https://github.com/gauge-sh/tach/assets/92686157/d399b397-e36a-4712-a41a-06212042cb54)

@emdoyle Any feedbacks on the above PR from your side would be appreciated
