### PR TITLE
Keyboard ugly stack trace handled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,4 @@ module-name = "tach.extension"
 features = ["pyo3/extension-module"]
 
 [project.scripts]
-tach = "tach.cli:main"
+tach = "tach.start:start"

--- a/python/tach/__main__.py
+++ b/python/tach/__main__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tach.cli import main
+from tach.start import start
 
 if __name__ == "__main__":
-    main()
+    start()

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -456,8 +456,4 @@ def main() -> None:
         exit(1)
 
 
-if __name__ == "__main__":
-    main()
-
-
 __all__ = ["main"]

--- a/python/tach/start.py
+++ b/python/tach/start.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import sys
 
+
 def start():
     try:
         from tach.cli import main
+
         main()
     except KeyboardInterrupt:
         print("Exiting...")
         sys.exit(1)
-        
+
+
 if __name__ == "__main__":
     start()

--- a/python/tach/start.py
+++ b/python/tach/start.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import sys
+
+def start():
+    try:
+        from tach.cli import main
+        main()
+    except KeyboardInterrupt:
+        print("Exiting...")
+        sys.exit(1)
+        
+if __name__ == "__main__":
+    start()

--- a/tach.yml
+++ b/tach.yml
@@ -4,8 +4,11 @@ modules:
   strict: true
 - path: tach.__main__
   depends_on:
-  - tach.cli
+  - tach.start
   strict: true
+- path: tach.start
+  depends_on:
+  - tach.cli
 - path: tach.cache
   depends_on:
   - tach


### PR DESCRIPTION
Fix for issue: https://github.com/gauge-sh/tach/issues/125

the ugly stack trace is due to 2 reason's
1. Impot's taking time to load
2. Tach acutall task execution is not catching keyboard exception.

I am crating a PR that will fix both the issues by moving both import and actual tach execution inside a Try Catch. This is done by creating another file start.py and moving the entry from main class of cli.py to start class of start.py

From now onward's this is how execution will exit.
    
<img width="562" alt="Screenshot 2024-06-24 at 3 30 04 AM" src="https://github.com/gauge-sh/tach/assets/28388623/cd944233-bae6-42a7-b56f-5336bce4e91e">





This is how our start.py will look like:
```python
from __future__ import annotations

import sys

def start():
    try:
        from tach.cli import main
        main()
    except KeyboardInterrupt:
        print("Exiting...")
        sys.exit(1)
        
if __name__ == "__main__":
    start()



