### PR TITLE
Fix clickable link absolute path with custom source_root

### DIFF
--- a/python/tach/start.py
+++ b/python/tach/start.py
@@ -15,3 +15,5 @@ def start():
 
 if __name__ == "__main__":
     start()
+
+__all__ = ["start"]

--- a/tach.yml
+++ b/tach.yml
@@ -9,6 +9,7 @@ modules:
 - path: tach.start
   depends_on:
   - tach.cli
+  strict: true
 - path: tach.cache
   depends_on:
   - tach


### PR DESCRIPTION
Fixes #132 

See the description in the issue.

This PR addresses the issue by passing the absolute path to the source root through the error message builders.