### PR TITLE
Fix 'tach report'

### DIFF
--- a/python/tests/test_report.py
+++ b/python/tests/test_report.py
@@ -33,7 +33,7 @@ def test_valid_path(mock_project_config, mock_cwd):
     mock_path = mock_cwd / "test.py"
     mock_path.touch()
     result = report(
-        project_root=mock_cwd, path=mock_path, project_config=mock_project_config
+        project_root=mock_cwd, path=Path("test.py"), project_config=mock_project_config
     )
     assert result
 
@@ -42,7 +42,7 @@ def test_valid_dir(mock_project_config, mock_cwd):
     mock_path = mock_cwd / "test"
     mock_path.mkdir()
     result = report(
-        project_root=mock_cwd, path=mock_path, project_config=mock_project_config
+        project_root=mock_cwd, path=Path("test"), project_config=mock_project_config
     )
     assert result
 
@@ -52,7 +52,7 @@ def test_valid_dir_trailing_slash(mock_project_config, mock_cwd):
     mock_path.mkdir()
     result = report(
         project_root=mock_cwd,
-        path=Path(str(mock_path) + "/"),
+        path=Path("test/"),
         project_config=mock_project_config,
     )
     assert result
@@ -62,7 +62,7 @@ def test_invalid_root(mock_project_config, mock_cwd):
     with pytest.raises(TachError):
         report(
             project_root=Path("Invalid!!"),
-            path=mock_cwd,
+            path=Path("."),
             project_config=mock_project_config,
         )
 

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -156,7 +156,7 @@ pub fn create_dependency_report(
     path: String,
     ignore_type_checking_imports: bool,
 ) -> Result<String> {
-    let absolute_path = fs::canonicalize(&path)?;
+    let absolute_path = PathBuf::from(&project_root).join(fs::canonicalize(&path)?);
     let absolute_source_root = PathBuf::from(&project_root).join(&source_root);
     let module_path = file_to_module_path(
         absolute_source_root.to_str().unwrap(),
@@ -165,14 +165,14 @@ pub fn create_dependency_report(
     let mut result = DependencyReport::new(path.clone()); // TODO: clone shouldnt be necessary
 
     for pyfile in walk_pyfiles(&project_root) {
+        let absolute_pyfile = PathBuf::from(&project_root).join(&pyfile);
         match get_project_imports(
             project_root.clone(), // TODO: clones shouldn't be necessary, need to update the args
             source_root.clone(),
-            pyfile.to_string_lossy().to_string(),
+            absolute_pyfile.to_string_lossy().to_string(),
             ignore_type_checking_imports,
         ) {
             Ok(project_imports) => {
-                let absolute_pyfile = PathBuf::from(&project_root).join(&pyfile);
                 let pyfile_in_target_module = absolute_pyfile.starts_with(&absolute_path);
                 if pyfile_in_target_module {
                     // Any import from within the target module which points to an external mod_path


### PR DESCRIPTION
Right now, `tach report` is failing with an error indicating the 'path' argument is not being turned into an absolute path correctly.

This PR fixes the handling, and adjusts the tests to exercise this case.