### PR TITLE
Move '<root>' module to the bottom/end of modules in tach.yml

### DIFF
--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import yaml
 
 from tach import filesystem as fs
+from tach.constants import ROOT_MODULE_SENTINEL_TAG
 from tach.core import ProjectConfig
 
 
@@ -13,7 +14,9 @@ def dump_project_config_to_yaml(config: ProjectConfig) -> str:
     # so that 'tag' appears before 'depends_on'
     # Instead, should provide custom yaml.Dumper & yaml.Representer or just write our own
     # Sort only constraints and dependencies alphabetically for now
-    config.modules.sort(key=lambda mod: mod.path)
+    config.modules.sort(
+        key=lambda mod: (mod.path == ROOT_MODULE_SENTINEL_TAG, mod.path)
+    )
     for mod in config.modules:
         mod.depends_on.sort()
     # NOTE: setting 'exclude' explicitly here also interacts with the 'exclude_unset' option

--- a/tach.yml
+++ b/tach.yml
@@ -82,6 +82,7 @@ modules:
   strict: true
 - path: tach.parsing
   depends_on:
+  - tach.constants
   - tach.core
   - tach.filesystem
   strict: true


### PR DESCRIPTION
The implicit boundary occurs in very certain use cases, therefore haven't extensively tested this enhancement
Fixes #127 
let me know what you think