### PR TITLE
Add JSON schema for tach.yml to docs site

### DIFF
--- a/docs/assets/tach-yml-schema.json
+++ b/docs/assets/tach-yml-schema.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Tach Project Configuration Schema",
+    "type": "object",
+    "properties": {
+        "modules": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the module"
+                    },
+                    "depends_on": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [],
+                        "description": "List of dependencies for the module"
+                    },
+                    "strict": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Strict mode for the module"
+                    }
+                },
+                "required": [
+                    "path"
+                ]
+            },
+            "default": [],
+            "description": "List of module configurations"
+        },
+        "exclude": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "List of paths to exclude while checking module boundaries"
+        },
+        "source_root": {
+            "type": "string",
+            "description": "Root directory for Python source code"
+        },
+        "exact": {
+            "type": "boolean",
+            "default": false,
+            "description": "Check that module configuration exactly matches real dependencies"
+        },
+        "disable_logging": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable anonymized usage logging"
+        },
+        "ignore_type_checking_imports": {
+            "type": "boolean",
+            "default": true,
+            "description": "Ignore type-checking imports when checking module boundaries"
+        }
+    },
+    "required": [
+        "modules"
+    ]
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,7 +62,7 @@ tach show
 ```
 Tach will generate a graph of your dependencies. Here's what this looks like for Tach:
 
-![tach show](docs/assets/tach_show.png)
+![tach show](assets/tach_show.png)
 
 Note that this graph is generated remotely the contents of your `tach.yml`.
 

--- a/tach.yml
+++ b/tach.yml
@@ -1,116 +1,117 @@
+# yaml-language-server: $schema=docs/assets/tach-yml-schema.json
 modules:
-- path: tach
-  depends_on: []
-  strict: true
-- path: tach.__main__
-  depends_on:
-  - tach.start
-  strict: true
-- path: tach.cache
-  depends_on:
-  - tach
-  - tach.filesystem
-  strict: true
-- path: tach.check
-  depends_on:
-  - tach.constants
-  - tach.core
-  - tach.errors
-  - tach.filesystem
-  - tach.parsing
-  strict: true
-- path: tach.cli
-  depends_on:
-  - tach
-  - tach.cache
-  - tach.check
-  - tach.colors
-  - tach.constants
-  - tach.core
-  - tach.errors
-  - tach.filesystem
-  - tach.logging
-  - tach.mod
-  - tach.parsing
-  - tach.report
-  - tach.show
-  - tach.sync
-  strict: true
-- path: tach.colors
-  depends_on: []
-  strict: true
-- path: tach.constants
-  depends_on: []
-  strict: true
-- path: tach.core
-  depends_on:
-  - tach.constants
-  strict: true
-- path: tach.errors
-  depends_on: []
-  strict: true
-- path: tach.filesystem
-  depends_on:
-  - tach.colors
-  - tach.constants
-  - tach.errors
-  - tach.hooks
-  strict: true
-- path: tach.hooks
-  depends_on:
-  - tach.constants
-  strict: true
-- path: tach.interactive
-  depends_on:
-  - tach.errors
-  - tach.filesystem
-  strict: true
-- path: tach.logging
-  depends_on:
-  - tach
-  - tach.cache
-  - tach.parsing
-  strict: true
-- path: tach.mod
-  depends_on:
-  - tach.colors
-  - tach.constants
-  - tach.errors
-  - tach.filesystem
-  - tach.interactive
-  - tach.parsing
-  strict: true
-- path: tach.parsing
-  depends_on:
-  - tach.constants
-  - tach.core
-  - tach.filesystem
-  strict: true
-- path: tach.report
-  depends_on:
-  - tach.errors
-  strict: true
-- path: tach.show
-  depends_on: []
-  strict: true
-- path: tach.start
-  depends_on:
-  - tach.cli
-  strict: true
-- path: tach.sync
-  depends_on:
-  - tach.check
-  - tach.errors
-  - tach.filesystem
-  - tach.parsing
-  strict: true
+  - path: tach
+    depends_on: []
+    strict: true
+  - path: tach.__main__
+    depends_on:
+      - tach.start
+    strict: true
+  - path: tach.cache
+    depends_on:
+      - tach
+      - tach.filesystem
+    strict: true
+  - path: tach.check
+    depends_on:
+      - tach.constants
+      - tach.core
+      - tach.errors
+      - tach.filesystem
+      - tach.parsing
+    strict: true
+  - path: tach.cli
+    depends_on:
+      - tach
+      - tach.cache
+      - tach.check
+      - tach.colors
+      - tach.constants
+      - tach.core
+      - tach.errors
+      - tach.filesystem
+      - tach.logging
+      - tach.mod
+      - tach.parsing
+      - tach.report
+      - tach.show
+      - tach.sync
+    strict: true
+  - path: tach.colors
+    depends_on: []
+    strict: true
+  - path: tach.constants
+    depends_on: []
+    strict: true
+  - path: tach.core
+    depends_on:
+      - tach.constants
+    strict: true
+  - path: tach.errors
+    depends_on: []
+    strict: true
+  - path: tach.filesystem
+    depends_on:
+      - tach.colors
+      - tach.constants
+      - tach.errors
+      - tach.hooks
+    strict: true
+  - path: tach.hooks
+    depends_on:
+      - tach.constants
+    strict: true
+  - path: tach.interactive
+    depends_on:
+      - tach.errors
+      - tach.filesystem
+    strict: true
+  - path: tach.logging
+    depends_on:
+      - tach
+      - tach.cache
+      - tach.parsing
+    strict: true
+  - path: tach.mod
+    depends_on:
+      - tach.colors
+      - tach.constants
+      - tach.errors
+      - tach.filesystem
+      - tach.interactive
+      - tach.parsing
+    strict: true
+  - path: tach.parsing
+    depends_on:
+      - tach.constants
+      - tach.core
+      - tach.filesystem
+    strict: true
+  - path: tach.report
+    depends_on:
+      - tach.errors
+    strict: true
+  - path: tach.show
+    depends_on: []
+    strict: true
+  - path: tach.start
+    depends_on:
+      - tach.cli
+    strict: true
+  - path: tach.sync
+    depends_on:
+      - tach.check
+      - tach.errors
+      - tach.filesystem
+      - tach.parsing
+    strict: true
 exclude:
-- .*__pycache__
-- build/
-- dist/
-- docs/
-- python/tests/
-- tach.egg-info/
-- venv/
+  - .*__pycache__
+  - build/
+  - dist/
+  - docs/
+  - python/tests/
+  - tach.egg-info/
+  - venv/
 source_root: python
 exact: true


### PR DESCRIPTION
Fixes #142 

This adds a simple JSON schema file to the assets on our documentation site. This means the URL will be:

[https://gauge-sh.github.io/tach/assets/tach-yml-schema.json](https://gauge-sh.github.io/tach/assets/tach-yml-json-schema)