### PR TITLE
feat: Preserve language server directive and formatting in tach sync

### DIFF
--- a/python/tach/constants/__init__.py
+++ b/python/tach/constants/__init__.py
@@ -5,7 +5,9 @@ TOOL_NAME = "tach"
 CONFIG_FILE_NAME = TOOL_NAME
 PACKAGE_FILE_NAME = "package"
 ROOT_MODULE_SENTINEL_TAG = "<root>"
-TACH_YML_SCHEMA_URL = "https://raw.githubusercontent.com/gauge-sh/tach/v0.6.8/public/tach-yml-schema.json"
+TACH_YML_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/gauge-sh/tach/v0.6.8/public/tach-yml-schema.json"
+)
 
 DEFAULT_EXCLUDE_PATHS = ["tests", "docs", "venv", ".*__pycache__", ".*egg-info"]
 
@@ -15,5 +17,6 @@ __all__ = [
     "CONFIG_FILE_NAME",
     "PACKAGE_FILE_NAME",
     "ROOT_MODULE_SENTINEL_TAG",
+    "TACH_YML_SCHEMA_URL",
     "DEFAULT_EXCLUDE_PATHS",
 ]

--- a/python/tach/constants/__init__.py
+++ b/python/tach/constants/__init__.py
@@ -5,6 +5,7 @@ TOOL_NAME = "tach"
 CONFIG_FILE_NAME = TOOL_NAME
 PACKAGE_FILE_NAME = "package"
 ROOT_MODULE_SENTINEL_TAG = "<root>"
+TACH_YML_SCHEMA_URL = "https://raw.githubusercontent.com/gauge-sh/tach/v0.6.8/public/tach-yml-schema.json"
 
 DEFAULT_EXCLUDE_PATHS = ["tests", "docs", "venv", ".*__pycache__", ".*egg-info"]
 

--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -8,7 +8,7 @@ from tach import filesystem as fs
 from tach.constants import ROOT_MODULE_SENTINEL_TAG
 from tach.core import ProjectConfig
 
-class CustomDumper(yaml.Dumper):
+class TachYamlDumper(yaml.Dumper):
     def increase_indent(self, flow=False, indentless=False):
         return super().increase_indent(flow, False)
 
@@ -30,7 +30,7 @@ def dump_project_config_to_yaml(config: ProjectConfig) -> str:
     language_server_directive = "# yaml-language-server: $schema=docs/assets/tach-yml-schema.json\n"
     return language_server_directive + yaml.dump(
         config.model_dump(exclude_unset=True),
-        Dumper=CustomDumper,
+        Dumper=TachYamlDumper,
         sort_keys=False,
         default_flow_style=False,
         indent=2

--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 from tach import filesystem as fs
-from tach.constants import ROOT_MODULE_SENTINEL_TAG
+from tach.constants import ROOT_MODULE_SENTINEL_TAG, TACH_YML_SCHEMA_URL
 from tach.core import ProjectConfig
 
 class TachYamlDumper(yaml.Dumper):
@@ -27,14 +27,15 @@ def dump_project_config_to_yaml(config: ProjectConfig) -> str:
     # show excluded paths.
     config.exclude = list(set(config.exclude)) if config.exclude else []
     config.exclude.sort()
-    language_server_directive = "# yaml-language-server: $schema=docs/assets/tach-yml-schema.json\n"
-    return language_server_directive + yaml.dump(
+    language_server_directive = f"# yaml-language-server: $schema={TACH_YML_SCHEMA_URL}\n"
+    yaml_content = yaml.dump(
         config.model_dump(exclude_unset=True),
         Dumper=TachYamlDumper,
         sort_keys=False,
         default_flow_style=False,
         indent=2
     )
+    return language_server_directive + yaml_content
 
 
 def parse_project_config(root: Path | None = None) -> ProjectConfig | None:

--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -8,6 +8,9 @@ from tach import filesystem as fs
 from tach.constants import ROOT_MODULE_SENTINEL_TAG
 from tach.core import ProjectConfig
 
+class CustomDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow, False)
 
 def dump_project_config_to_yaml(config: ProjectConfig) -> str:
     # Using sort_keys=False here and depending on config.model_dump maintaining 'insertion order'
@@ -24,7 +27,14 @@ def dump_project_config_to_yaml(config: ProjectConfig) -> str:
     # show excluded paths.
     config.exclude = list(set(config.exclude)) if config.exclude else []
     config.exclude.sort()
-    return yaml.dump(config.model_dump(exclude_unset=True), sort_keys=False)
+    language_server_directive = "# yaml-language-server: $schema=docs/assets/tach-yml-schema.json\n"
+    return language_server_directive + yaml.dump(
+        config.model_dump(exclude_unset=True),
+        Dumper=CustomDumper,
+        sort_keys=False,
+        default_flow_style=False,
+        indent=2
+    )
 
 
 def parse_project_config(root: Path | None = None) -> ProjectConfig | None:

--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -8,9 +8,11 @@ from tach import filesystem as fs
 from tach.constants import ROOT_MODULE_SENTINEL_TAG, TACH_YML_SCHEMA_URL
 from tach.core import ProjectConfig
 
+
 class TachYamlDumper(yaml.Dumper):
-    def increase_indent(self, flow=False, indentless=False):
+    def increase_indent(self, flow: bool = False, indentless: bool = False):
         return super().increase_indent(flow, False)
+
 
 def dump_project_config_to_yaml(config: ProjectConfig) -> str:
     # Using sort_keys=False here and depending on config.model_dump maintaining 'insertion order'
@@ -27,13 +29,15 @@ def dump_project_config_to_yaml(config: ProjectConfig) -> str:
     # show excluded paths.
     config.exclude = list(set(config.exclude)) if config.exclude else []
     config.exclude.sort()
-    language_server_directive = f"# yaml-language-server: $schema={TACH_YML_SCHEMA_URL}\n"
+    language_server_directive = (
+        f"# yaml-language-server: $schema={TACH_YML_SCHEMA_URL}\n"
+    )
     yaml_content = yaml.dump(
         config.model_dump(exclude_unset=True),
         Dumper=TachYamlDumper,
         sort_keys=False,
         default_flow_style=False,
-        indent=2
+        indent=2,
     )
     return language_server_directive + yaml_content
 


### PR DESCRIPTION
- [x] Retained the language server comment directive at the top of tach.yml
- [x] Implemented a custom YAML dumper `TachYamlDumper` to maintain 2-space indentation for consistent formatting

Fixes #150 