### PR TITLE
Support local graphviz export for 'tach show'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ cython_debug/
 .env.leave
 .DS_Store
 .pre-commit-config.yaml
+
+
+# Generated graph files
+*.dot

--- a/docs/getting-started/getting-started.mdx
+++ b/docs/getting-started/getting-started.mdx
@@ -83,7 +83,9 @@ Tach will generate a graph of your dependencies. Here's what this looks like for
 
 ![tach show](../assets/tach_show.png)
 
-Note that this graph is generated remotely the contents of your `tach.yml`.
+Note that this graph is generated remotely with the contents of your `tach.yml` when running `tach show --web`.
+
+If you would like to use the [GraphViz DOT format](https://graphviz.org/about/) locally, simply running `tach show` will generate `tach_module_graph.dot` in your working directory.
 
 You can view the dependencies and usages for a given path:
 

--- a/docs/usage/commands.mdx
+++ b/docs/usage/commands.mdx
@@ -114,14 +114,19 @@ This will generate a textual report showing the file and line number of each rel
 Tach will generate a visual representation of your dependency graph!
 
 ```bash
-usage: tach show [-h]
+usage: tach show [-h] [--web] [-o [OUT]]
 
-Visualize the dependency graph of your project on the web.
+Visualize the dependency graph of your project.
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help            show this help message and exit
+  --web                 Open your dependency graph in a remote web viewer.
+  -o [OUT], --out [OUT]
+                        Specify an output path for a locally generated module graph file.
 ```
 
+
+These are the results of `tach show --web` on the Tach codebase itself:
 ![tach show](assets/tach_show.png)
 
 ## tach test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "prompt-toolkit~=3.0",
     "GitPython~=3.1",
     "networkx~=3.0",
+    "pydot~=2.0",
     "stdlib-list>=0.10.0; python_version < '3.10'",
     "eval-type-backport>=0.2.0; python_version < '3.10'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "rich~=13.0",
     "prompt-toolkit~=3.0",
     "GitPython~=3.1",
+    "networkx~=3.0",
     "stdlib-list>=0.10.0; python_version < '3.10'",
     "eval-type-backport>=0.2.0; python_version < '3.10'"
 ]

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -240,7 +240,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--out",
         type=str,
         nargs="?",
-        default="tach_module_graph.dot",
+        default=None,
         help="Specify an output path for a locally generated module graph file.",
     )
     install_parser = subparsers.add_parser(
@@ -725,7 +725,11 @@ def main() -> None:
             pytest_args=args.pytest_args,
         )
     elif args.command == "show":
-        tach_show(project_root=project_root)
+        tach_show(
+            project_root=project_root,
+            output_filepath=Path(args.out) if args.out is not None else None,
+            is_web=args.web,
+        )
     else:
         print("Unrecognized command")
         parser.print_help()

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -212,11 +212,24 @@ def build_parser() -> argparse.ArgumentParser:
     report_parser.add_argument(
         "path", help="The path or directory path used to generate the report."
     )
-    subparsers.add_parser(
+    show_parser = subparsers.add_parser(
         "show",
         prog="tach show",
-        help="Visualize the dependency graph of your project on the web.",
-        description="Visualize the dependency graph of your project on the web.",
+        help="Visualize the dependency graph of your project.",
+        description="Visualize the dependency graph of your project.",
+    )
+    show_parser.add_argument(
+        "--web",
+        action="store_true",
+        help="Open your dependency graph in a remote web viewer.",
+    )
+    show_parser.add_argument(
+        "-o",
+        "--out",
+        type=str,
+        nargs="?",
+        default="tach_module_graph.dot",
+        help="Specify an output path for a locally generated module graph file.",
     )
     install_parser = subparsers.add_parser(
         "install",

--- a/python/tach/show.py
+++ b/python/tach/show.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from json.decoder import JSONDecodeError
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib import error, request
 
@@ -32,4 +33,9 @@ def generate_show_url(project_config: ProjectConfig) -> str | None:
         return None
 
 
-__all__ = ["generate_show_url"]
+def generate_module_graph_dot_file(
+    project_config: ProjectConfig, output_filepath: Path
+) -> None: ...
+
+
+__all__ = ["generate_show_url", "generate_module_graph_dot_file"]


### PR DESCRIPTION
@letmerecall asked in [Discord](https://discord.gg/Kz2TnszerR) about generating the `tach show` graph locally by default so that devs avoid sending `tach.yml` remotely.

While the long-term goal is to improve the web viewer with interactivity that would be difficult for us to replicate locally, and we don't want to add visualization tools as dependencies, it makes sense to at least export into the standard DOT language that GraphViz uses. This would let devs use their own visualization tools with their module graph easily.

The new CLI for `tach show` in this PR is:
```
usage: tach show [-h] [--web] [-o [OUT]]

Visualize the dependency graph of your project.

options:
  -h, --help            show this help message and exit
  --web                 Open your dependency graph in a remote web viewer.
  -o [OUT], --out [OUT]
                        Specify an output path for a locally generated module graph file.
```