### PR TITLE
Fix deps make function, activate venv before installing crate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ deps: ## Install dependencies
 	uv pip install -r dev-requirements.txt
 
 	@unset CONDA_PREFIX && \
+	source $(VENV_BIN)/activate && \
 	maturin develop --profile release
 
 


### PR DESCRIPTION
## What's new in this PR?
Fixes #185 

Makefile rule is executed in it's down subshell. Therefore, the activation of the virtual environment in the line with source $(VENV_BIN)/activate was not affecting the subsequent line.
