### PR TITLE
Fix deps make function, install pip and maturin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ deps: ## Install dependencies
 		echo "Virtual environment already exists at $(VENV)"; \
 	fi
 
-	source $(VENV_BIN)/activate
+	source $(VENV_BIN)/activate && \
+	uv pip install pip maturin
 
 	@unset CONDA_PREFIX && \
 	source $(VENV_BIN)/activate && \


### PR DESCRIPTION
## Why this PR?
`make deps` for fresh venv where pip and maturin are not installed.

## What's updated?
Added a step to install `pip` & `maturin` in deps make function.