### PR TITLE
Fix 'tach test' impact analysis when git root is not cwd

### DIFF
--- a/python/tach/filesystem/git_ops.py
+++ b/python/tach/filesystem/git_ops.py
@@ -40,7 +40,8 @@ def get_changed_files(
         changed_files.update(untracked_files.splitlines())
 
     # return list of unique Paths
-    return list(map(Path, changed_files))
+    git_root: str = repo.git.rev_parse("--show-toplevel")
+    return [(Path(git_root) / filepath).resolve() for filepath in changed_files]
 
 
 __all__ = ["get_changed_files"]

--- a/python/tach/test.py
+++ b/python/tach/test.py
@@ -32,12 +32,9 @@ def get_changed_module_paths(
 ) -> list[str]:
     source_root = project_root / project_config.source_root
     changed_module_paths = [
-        fs.file_to_module_path(
-            source_root=source_root, file_path=changed_file.resolve()
-        )
+        fs.file_to_module_path(source_root=source_root, file_path=changed_file)
         for changed_file in changed_files
-        if source_root in changed_file.resolve().parents
-        and changed_file.suffix == ".py"
+        if source_root in changed_file.parents and changed_file.suffix == ".py"
     ]
 
     return changed_module_paths
@@ -205,7 +202,6 @@ def run_affected_tests(
         modules=module_validation_result.valid_modules,
     )
 
-    # These paths come from git output, which means they are relative to cwd
     changed_files = get_changed_files(project_root, head=head, base=base)
     affected_module_paths = get_affected_modules(
         project_root,

--- a/python/tests/test_changed_files.py
+++ b/python/tests/test_changed_files.py
@@ -89,7 +89,9 @@ def test_changed_files_new_branch(git_repo, setup_changes, expected_files):
 
     changed_files = get_changed_files(repo_path, base="main", head="new_branch")
 
-    assert set(changed_files) == set(Path(filepath) for filepath in expected_files)
+    assert set(
+        changed_file.relative_to(git_repo) for changed_file in changed_files
+    ) == set(Path(filepath) for filepath in expected_files)
 
 
 @pytest.mark.parametrize(
@@ -132,4 +134,6 @@ def test_changed_files_working_directory(git_repo, setup_changes, expected_files
 
     changed_files = get_changed_files(git_repo, base="main")
 
-    assert set(changed_files) == set(Path(filepath) for filepath in expected_files)
+    assert set(
+        changed_file.relative_to(git_repo) for changed_file in changed_files
+    ) == set(Path(filepath) for filepath in expected_files)


### PR DESCRIPTION
Fixes an issue @max-muoto brought to my attention.

The bug manifested as a particular file change being mapped onto the wrong module, triggering almost the entire test suite when there should have been zero tests affected.

The issue was that the changed file detection assumed that `git diff --name-status` provided paths relative to the current working directory (similar to `git status`) but this is not the case. The paths are always relative to the git root, which means that later calls to `resolve` were creating incorrect paths relative to CWD.

This led to incorrect module paths being detected, and then incorrect tests being run.