### PR TITLE
Allow filtering tach report output

### DIFF
--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -5,7 +5,16 @@ def get_project_imports(
     ignore_type_checking_imports: bool,
 ) -> list[tuple[str, int]]: ...
 def set_excluded_paths(exclude_paths: list[str]) -> None: ...
-def create_dependency_report(project_root: str, source_root: str, path: str) -> str: ...
+def create_dependency_report(
+    project_root: str,
+    source_root: str,
+    path: str,
+    include_dependency_modules: list[str] | None,
+    include_usage_modules: list[str] | None,
+    skip_dependencies: bool,
+    skip_usages: bool,
+    ignore_type_checking_imports: bool,
+) -> str: ...
 def create_computation_cache_key(
     project_root: str,
     source_root: str,

--- a/python/tach/report.py
+++ b/python/tach/report.py
@@ -15,6 +15,10 @@ def report(
     project_root: Path,
     path: Path,
     project_config: ProjectConfig,
+    include_dependency_modules: list[str] | None = None,
+    include_usage_modules: list[str] | None = None,
+    skip_dependencies: bool = False,
+    skip_usages: bool = False,
     exclude_paths: list[str] | None = None,
 ) -> str:
     if not project_root.is_dir():
@@ -37,6 +41,11 @@ def report(
         project_root=str(project_root),
         source_root=str(project_config.source_root),
         path=str(path),
+        include_dependency_modules=include_dependency_modules,
+        include_usage_modules=include_usage_modules,
+        skip_dependencies=skip_dependencies,
+        skip_usages=skip_usages,
+        ignore_type_checking_imports=project_config.ignore_type_checking_imports,
     )
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,17 +66,25 @@ fn set_excluded_paths(exclude_paths: Vec<String>) -> exclusion::Result<()> {
 
 /// Create a report of dependencies and usages of a given path
 #[pyfunction]
-#[pyo3(signature = (project_root, source_root, path, ignore_type_checking_imports=false))]
+#[pyo3(signature = (project_root, source_root, path, include_dependency_modules, include_usage_modules, skip_dependencies, skip_usages, ignore_type_checking_imports=false))]
 fn create_dependency_report(
     project_root: String,
     source_root: String,
     path: String,
+    include_dependency_modules: Option<Vec<String>>,
+    include_usage_modules: Option<Vec<String>>,
+    skip_dependencies: bool,
+    skip_usages: bool,
     ignore_type_checking_imports: bool,
 ) -> reports::Result<String> {
     reports::create_dependency_report(
         project_root,
         source_root,
         path,
+        include_dependency_modules,
+        include_usage_modules,
+        skip_dependencies,
+        skip_usages,
         ignore_type_checking_imports,
     )
 }


### PR DESCRIPTION
Fixes #187 

This introduces several CLI options to `tach report`:
```
options:
...
  -d module_path,..., --dependencies module_path,...
                        Comma separated module list of dependencies to include [includes everything by default]
  --no-deps             Do not include dependencies in the report.
  -u module_path,..., --usages module_path,...
                        Comma separated module list of usages to include [includes everything by default]
  --no-usages           Do not include usages in the report.
...
```

Example:
`tach report python/tach/filesystem -u tach.sync --dependencies tach.core`
would filter any usages of the module to only those within `tach.sync`, and would filter dependencies to children of `tach.core`

while `tach report python/tach/filesystem --no-usages`
would simply show dependencies of the module, skipping the report on its usages.