### PR TITLE
Support `deprecated` dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,6 @@ jobs:
       run: cargo fmt --all --check
     - name: Check Rust
       run: cargo check
+    - name: Compile Maturin
+      run: maturin develop --release -E dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,11 @@ jobs:
       run: |
         ruff check
         ruff format --check
-    - name: Test with pytest and report coverage
+    - name: Test with tach/pytest and report coverage
       run: |
         coverage run --branch --source=python -m pytest
         coverage report
+        tach test
     - name: Check types with pyright
       run: |
         pyright --pythonversion ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,35 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         check-latest: true
+
+    - name: Cache Python dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Cache Rust dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
+
     - name: Check ruff
       run: |
         ruff check
@@ -45,3 +65,4 @@ jobs:
       run: cargo fmt --all --check
     - name: Check Rust
       run: cargo check
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,10 @@ jobs:
       run: |
         ruff check
         ruff format --check
-    - name: Test with tach/pytest and report coverage
+    - name: Test with pytest and report coverage
       run: |
         coverage run --branch --source=python -m pytest
         coverage report
-        cd python && tach test
     - name: Check types with pyright
       run: |
         pyright --pythonversion ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         coverage run --branch --source=python -m pytest
         coverage report
-        tach test
+        cd python && tach test
     - name: Check types with pyright
       run: |
         pyright --pythonversion ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,6 @@ jobs:
     - name: Check Rust
       run: cargo check
     - name: Compile Maturin
-      run: maturin develop --release -E dev
-
+      run: maturin build
+    - name: Build Python
+      run: pip install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,3 @@ jobs:
       run: cargo fmt --all --check
     - name: Check Rust
       run: cargo check
-    - name: Compile Maturin
-      run: maturin build
-    - name: Build Python
-      run: pip install .

--- a/README.md
+++ b/README.md
@@ -37,18 +37,23 @@ Tach is:
 ## Getting Started
 
 ### Installation
+
 ```bash
 pip install tach
 ```
+
 ### Setup
+
 Tach allows you to configure where you want to place module boundaries in your project.
 
 You can do this interactively - run:
+
 ```bash
  tach mod
 # Up/Down: Navigate  Enter: Mark/unmark module  Right: Expand  Left: Collapse  Ctrl + Up: Jump to parent
 # Ctrl + s: Exit and save  Ctrl + c: Exit without saving  Ctrl + a: Mark/unmark all
 ```
+
 Mark each module boundary with 'Enter'. You can mark all of your top-level Python source packages, or just a few which you want to isolate.
 
 If your Python code lives below your project root, mark your Python [source root](https://docs.gauge.sh/usage/configuration#source-root) using the 's' key.
@@ -56,35 +61,44 @@ If your Python code lives below your project root, mark your Python [source root
 This will create the config file for your project, `tach.yml`.
 
 Once you've marked all the modules you want to enforce dependencies between, run:
+
 ```bash
 tach sync
 ```
+
 Dependencies that exist between each module you've marked will be written to `tach.yml`.
 
-Check out what Tach has found! 
+Check out what Tach has found!
+
 ```
-cat tach.yml | less
+cat tach.yml
 ```
 
 Note: Your [source root](https://docs.gauge.sh/usage/configuration#source-root) directory will implicitly be treated as a module boundary, and can show up as `<root>`.
 
 ### Enforcement
+
 Tach comes with a cli command to enforce the boundaries that you just set up! From the root of your Python project, run:
+
 ```bash
 tach check
 ```
+
 You will see:
+
 ```bash
 ✅ All module dependencies validated!
 ```
 
 You can validate that Tach is working by either:
+
 1. Commenting out an item in a `depends_on` key in `tach.yml`
-2. By adding an import between modules that didn't previously import from each other. 
+2. By adding an import between modules that didn't previously import from each other.
 
 Give both a try and run `tach check` again. This will generate an error:
+
 ```bash
-❌ tach/check.py[L8]: Cannot import 'tach.filesystem'. Tag 'tach' cannot depend on 'tach.filesystem'. 
+❌ tach/check.py[L8]: Cannot import 'tach.filesystem'. Tag 'tach' cannot depend on 'tach.filesystem'.
 ```
 
 Each error indicates an import which violates your dependencies. If your terminal supports hyperlinks, click on the file path to go directly to the error.
@@ -94,22 +108,29 @@ When an error is detected, `tach check` will exit with a non-zero code. It can b
 ### Extras
 
 Visualize your dependency graph.
+
 ```bash
-tach show
+tach show [--web]
 ```
-Tach will generate a graph of your dependencies. Here's what this looks like for Tach itself:
+
+Tach will generate a graph of your dependencies. Here's what this looks like for Tach:
 
 ![tach show](docs/assets/tach_show.png)
 
-Note that this graph is generated remotely based on the contents of your `tach.yml`.
+Note that this graph is generated remotely with the contents of your `tach.yml` when running `tach show --web`.
+
+If you would like to use the [GraphViz DOT format](https://graphviz.org/about/) locally, simply running `tach show` will generate `tach_module_graph.dot` in your working directory.
 
 You can view the dependencies and usages for a given path:
+
 ```bash
 tach report my_package/
 # OR
 tach report my_module.py
 ```
+
 e.g.:
+
 ```bash
 > tach report python/tach/filesystem
 [Dependencies of 'python/tach/filesystem']
@@ -127,6 +148,7 @@ Tach also supports:
 
 - [Manual file configuration](https://docs.gauge.sh/usage/configuration)
 - [Strict public interfaces for modules](https://docs.gauge.sh/usage/strict-mode/)
+- [Deprecating individual dependencies](https://docs.gauge.sh/usage/deprecate)
 - [Inline exceptions](https://docs.gauge.sh/usage/tach-ignore)
 - [Pre-commit hooks](https://docs.gauge.sh/usage/commands#tach-install)
 

--- a/docs/getting-started/getting-started.mdx
+++ b/docs/getting-started/getting-started.mdx
@@ -76,7 +76,7 @@ Each error indicates an import which violates your dependencies. If your termina
 Visualize your dependency graph.
 
 ```bash
-tach show
+tach show [--web]
 ```
 
 Tach will generate a graph of your dependencies. Here's what this looks like for Tach:
@@ -114,5 +114,6 @@ Tach also supports:
 
 - [Manual file configuration](../usage/configuration)
 - [Strict public interfaces for modules](../usage/strict-mode)
+- [Deprecating individual dependencies](../usage/deprecate)
 - [Inline exceptions](../usage/tach-ignore)
 - [Pre-commit hooks](../usage/command#tach-install)

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -7,11 +7,13 @@ title: Overview
 Tach allows you to control dependencies between your Python modules.
 Modules can also define an explicit public interface to prevent deep coupling.
 
-This creates a decoupled, modular architecture, which makes maintenance and development easier.
+This creates a modular architecture, which makes development easier.
 
 If a module tries to import from another module that is not listed as a dependency, Tach will report an error.
 
-When a module is in ['strict mode'](../usage/strict-mode), if another module tries to import from it without using its public interface, Tach will report an error.
+When a module is marked ['strict'](../usage/strict-mode), if another module tries to import from it without using its public interface, Tach will report an error.
+
+Dependencies can be additionally marked as ['deprecated'](../usage/deprecate). Tach will not report an error but will surface usages of the deprecated dependency.
 
 Tach is a CLI tool, and is ideal for pre-commit hooks and CI checks.
 

--- a/docs/getting-started/why-tach.mdx
+++ b/docs/getting-started/why-tach.mdx
@@ -6,7 +6,7 @@ title: Why Tach
 
 Python allows you to import and use anything, anywhere. Over time, this results in modules that were intended to be separate getting tightly coupled together, and domain boundaries breaking down.
 
-We experienced this first-hand at a unicorn startup, where the entire engineering team paused development for over a year in an attempt to split up tightly coupled packages into independent micro-services. This ultimately failed, and resulted in the CTO getting fired.
+We experienced this first-hand at a unicorn startup, where the entire engineering team paused development for over a year in an attempt to split up tightly coupled packages into independent microservices. This ultimately failed, and resulted in the CTO getting fired.
 
 This problem occurs because:
 
@@ -25,4 +25,4 @@ With Tach, you can:
 3. Enforce those dependencies ([`tach check`](../usage/commands#tach-check))
 4. Visualize those dependencies ([`tach show`](../usage/commands#tach-show) and [`tach report`](../usage/commands#tach-report))
 
-You can also enforce a [strict interface](../usage/strict-mode) for each module. This means that only members that are listed in `__all__` can be imported by other modules.
+You can also enforce a [strict interface](../usage/strict-mode) for each module, and [deprecate dependencies](../usage/deprecate) over time. This means that only members that are listed in `__all__` can be imported by other modules.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -52,6 +52,7 @@
         "usage/configuration",
         "usage/caching",
         "usage/strict-mode",
+        "usage/deprecate",
         "usage/tach-ignore",
         "usage/vscode",
         "usage/faq"

--- a/docs/usage/caching.mdx
+++ b/docs/usage/caching.mdx
@@ -4,7 +4,7 @@ title: Caching
 
 Tach makes use of a 'computation cache' to speed up certain tasks, such as [testing](commands#tach-test).
 
-When Tach finds cached results for a given task, you will see the terminal output enclosed in:
+When Tach finds cached results for a given task, the terminal output is enclosed in:
 
 ```
 ============ Cached results found!  ============
@@ -12,7 +12,7 @@ When Tach finds cached results for a given task, you will see the terminal outpu
 ============ END Cached results  ============
 ```
 
-Caching is done at the command-level, meaning a single invocation of `tach test` can only ever result in a single cache hit or a single cache miss; individual tests are not cached separately.
+Caching is done at the command level. This means a single invocation of `tach test` can only ever result in a single cache hit or miss. Individual tests are not cached separately.
 
 ## Cache content
 
@@ -22,7 +22,7 @@ This is done to enable 'replaying' cached tasks so that their output can be reus
 
 ## Determining cache hits
 
-Tach uses several pieces of information to determine cache hits. These include:
+Tach uses several pieces of information to determine cache hits:
 
 - Python interpreter version (`major.minor.micro`)
 - All Python file contents beneath the [source root](configuration#source-root)
@@ -30,14 +30,14 @@ Tach uses several pieces of information to determine cache hits. These include:
 - File contents of explicitly configured [file dependencies](configuration#cache)
 - Explicitly configured [environment variable values](configuration#cache)
 
-When all of these pieces of information match a previous cache entry, the cached results are printed directly to the terminal.
+When all of these match a previous cache entry, the cached results are printed directly to the terminal.
 
 ## Cache storage
 
-The computation cache currently exists within the `.tach` directory in your project root. The directory is managed by Tach, which means that your cached results are stored on-disk on each machine where tasks are run.
+The computation cache exists within the `.tach` directory in your project root. The directory is managed by Tach, and your cached results are stored on-disk on each machine where tasks are run.
 
-We are currently working on a _remote cache_ backend, which will allow multiple developers and CI environments to share a centralized cache to maximize the hit rate. If you are interested in this functionality, tell us on [Discord](https://discord.gg/a58vW8dnmw), through a [GitHub issue](https://github.com/gauge-sh/tach/issues), or reach out via email: [evan@gauge.sh](mailto://evan@gauge.sh); [caelean@gauge.sh](mailto://caelean@gauge.sh)
+We are currently working on a _remote cache_ backend, which will allow multiple developers and CI environments to share a centralized cache to maximize the hit rate. If you are interested in this functionality, reach out on [Discord](https://discord.gg/a58vW8dnmw), through a [GitHub issue](https://github.com/gauge-sh/tach/issues), or via email: [evan@gauge.sh](mailto://evan@gauge.sh); [caelean@gauge.sh](mailto://caelean@gauge.sh)!
 
 ## Disabling the cache
 
-The computation cache is enabled by default for commands such as [tach test](usage.md#tach-test). For any command which utilizes the cache, it can be disabled using the `--disable-cache` CLI flag. This will prevent all access to the cache and run the underlying command unconditionally.
+The computation cache is enabled by default for commands such as [tach test](usage.md#tach-test). It can be disabled using `--disable-cache`. This will prevent all access to the cache and run the underlying command unconditionally.

--- a/docs/usage/commands.mdx
+++ b/docs/usage/commands.mdx
@@ -75,8 +75,8 @@ options:
 An error will indicate:
 
 - the file path in which the error was detected
-- the tag associated with that file
-- the tag associated with the attempted import
+- the path associated with that file
+- the path associated with the attempted import
 
 If `--exact` is provided, additional errors will be raised if a dependency exists in `tach.yml` that does not exist in the code.
 

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -8,7 +8,7 @@ Aside from running `tach mod` and `tach sync`, you can configure Tach by creatin
 
 This is the project-level configuration file which should be in the root of your project.
 
-`modules` defines the modules in your project, and accepts the keys described [below.](#modules)
+`modules` defines the modules in your project, and accepts the keys described [below](#modules).
 
 `exclude` accepts a list of directory patterns to exclude from checking. These are treated as regex patterns which match from the beginning of a given file path. For example: `project/.*tests` would match any path beginning with `project/` and ending with `tests`.
 
@@ -24,7 +24,7 @@ modules:
     strict: true
   - path: tach.cache
     depends_on:
-      - tach.filesystem
+      - path: tach.filesystem
     strict: true
   - path: tach.filesystem
     depends_on: []
@@ -95,6 +95,8 @@ from module2.service import MyService
 Notice that these import paths (`module3`, `module2.service.MyService`) are rooted in the `backend/` folder, NOT the project root.
 
 To indicate this structure to Tach, set `source_root: backend` in your `tach.yml`, or use [`tach mod`](commands#tach-mod) and mark the `backend` folder as the source root.
+
+Tach also supports [deprecating individual dependencies](../usage/deprecate).
 
 In `tach.yml`, the `source_root` is always interpreted as a relative path from the project root.
 

--- a/docs/usage/deprecate.mdx
+++ b/docs/usage/deprecate.mdx
@@ -1,0 +1,39 @@
+---
+title: Deprecate Dependencies
+---
+
+A dependency can be marked as `deprecated` - this means that the intention is to remove it over time, but it is still allowed.
+`tach check` will not error on deprecated dependencies, but it will surface each import that uses the deprecated dependency.
+
+## Example
+
+Given modules called 'core' and 'parsing':
+
+```yaml
+# tach.yml
+modules:
+  - path: parsing
+    depends_on:
+    - path: core
+      deprecated: trued
+  - path: core
+    depends_on:
+    - path: parsing
+```
+
+Then, in `parsing.py`:
+
+```python
+from core.main import get_data # we want to remove this!
+
+get_data()
+```
+
+This import won't fail `tach check`, instead you'll see:
+```shell
+‼️ parsing.py[L1]: Import 'core.get_date' is deprecated. 'parsing' should not depend on 'core'.
+✅ All module dependencies validated!
+```
+
+Note that we still see that all module dependencies are valid! To fail on the dependency, simply remove it from the `depends_on` key.
+

--- a/docs/usage/deprecate.mdx
+++ b/docs/usage/deprecate.mdx
@@ -15,7 +15,7 @@ modules:
   - path: parsing
     depends_on:
     - path: core
-      deprecated: trued
+      deprecated: true
   - path: core
     depends_on:
     - path: parsing
@@ -31,7 +31,7 @@ get_data()
 
 This import won't fail `tach check`, instead you'll see:
 ```shell
-‼️ parsing.py[L1]: Import 'core.get_date' is deprecated. 'parsing' should not depend on 'core'.
+‼️ parsing.py[L1]: Import 'core.get_data' is deprecated. 'parsing' should not depend on 'core'.
 ✅ All module dependencies validated!
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     # Setup
     "pip==24.0",
     # Code Quality
-    "pyright==1.1.371",
+    "pyright==1.1.373",
     "ruff==0.5.2",
     # Build/Release
     "setuptools==69.5.1; python_version > '3.7'",
@@ -85,7 +85,7 @@ src = ["python"]
 exclude = ["python/tests/example"]
 target-version = "py38"
 lint.extend-select = ["I", "TCH", "UP"]
-ignore = ["UP006", "UP007"]
+lint.ignore = ["UP006", "UP007"]
 
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -11,14 +11,14 @@ from tach.extension import get_project_imports, set_excluded_paths
 from tach.parsing import build_module_tree
 
 if TYPE_CHECKING:
-    from tach.core import ModuleNode, ModuleTree, ProjectConfig
+    from tach.core import Dependency, ModuleNode, ModuleTree, ProjectConfig
 
 
 @dataclass
 class ErrorInfo:
     source_module: str = ""
     invalid_module: str = ""
-    allowed_modules: list[str] = field(default_factory=list)
+    allowed_modules: list[Dependency] = field(default_factory=list)
     exception_message: str = ""
 
     @property
@@ -97,7 +97,7 @@ def check_import(
     # The import must be explicitly allowed
     dependency_tags = file_nearest_module.config.depends_on
     if any(
-        dependency_tag == import_nearest_module_path
+        dependency_tag.path == import_nearest_module_path
         for dependency_tag in dependency_tags
     ):
         # The import matches at least one expected dependency

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -108,7 +108,7 @@ def check_import(
 
     # The import must be explicitly allowed
     dependencies = file_nearest_module.config.depends_on
-    #
+
     allowed_dependencies = [dep for dep in dependencies if not dep.deprecated]
     deprecated_dependencies = [dep for dep in dependencies if dep.deprecated]
     if any(dep.path == import_nearest_module_path for dep in allowed_dependencies):

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -18,12 +18,19 @@ if TYPE_CHECKING:
 class ErrorInfo:
     source_module: str = ""
     invalid_module: str = ""
-    allowed_modules: list[Dependency] = field(default_factory=list)
+    allowed_dependencies: list[Dependency] = field(default_factory=list)
+    deprecated_dependencies: list[Dependency] = field(default_factory=list)
     exception_message: str = ""
 
     @property
     def is_dependency_error(self) -> bool:
         return all((self.source_module, self.invalid_module))
+
+    @property
+    def is_deprecated(self) -> bool:
+        return self.is_dependency_error and self.invalid_module in [
+            dep.path for dep in self.deprecated_dependencies
+        ]
 
 
 def is_top_level_module_import(mod_path: str, module: ModuleNode) -> bool:
@@ -96,17 +103,26 @@ def check_import(
 
     # The import must be explicitly allowed
     dependency_tags = file_nearest_module.config.depends_on
-    if any(
-        dependency_tag.path == import_nearest_module_path
-        for dependency_tag in dependency_tags
-    ):
+    #
+    allowed_dependencies = [dep for dep in dependency_tags if not dep.deprecated]
+    deprecated_dependencies = [dep for dep in dependency_tags if dep.deprecated]
+    if any(dep.path == import_nearest_module_path for dep in allowed_dependencies):
         # The import matches at least one expected dependency
         return None
+    if any(dep.path == import_nearest_module_path for dep in deprecated_dependencies):
+        # Dependency exists but is deprecated
+        return ErrorInfo(
+            source_module=file_nearest_module_path,
+            invalid_module=import_nearest_module_path,
+            allowed_dependencies=allowed_dependencies,
+            deprecated_dependencies=deprecated_dependencies,
+        )
     # This means the import is not declared as a dependency of the file
     return ErrorInfo(
         source_module=file_nearest_module_path,
         invalid_module=import_nearest_module_path,
-        allowed_modules=dependency_tags,
+        allowed_dependencies=allowed_dependencies,
+        deprecated_dependencies=deprecated_dependencies,
     )
 
 
@@ -121,6 +137,7 @@ class BoundaryError:
 @dataclass
 class CheckResult:
     errors: list[BoundaryError] = field(default_factory=list)
+    deprecated_warnings: list[BoundaryError] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
 
@@ -142,6 +159,7 @@ def check(
         )
 
     boundary_errors: list[BoundaryError] = []
+    boundary_warnings: list[BoundaryError] = []
     warnings: list[str] = []
 
     if exclude_paths is not None and project_config.exclude is not None:
@@ -196,29 +214,32 @@ def check(
             continue
         for project_import in project_imports:
             found_at_least_one_project_import = True
-            check_error = check_import(
+            error_info = check_import(
                 module_tree=module_tree,
                 import_mod_path=project_import[0],
                 file_nearest_module=nearest_module,
                 file_mod_path=mod_path,
             )
-            if check_error is None:
+            if error_info is None:
                 continue
-
-            boundary_errors.append(
-                BoundaryError(
-                    file_path=file_path,
-                    import_mod_path=project_import[0],
-                    line_number=project_import[1],
-                    error_info=check_error,
-                )
+            boundary_error = BoundaryError(
+                file_path=file_path,
+                import_mod_path=project_import[0],
+                line_number=project_import[1],
+                error_info=error_info,
             )
+            if error_info.is_deprecated:
+                boundary_warnings.append(boundary_error)
+            else:
+                boundary_errors.append(boundary_error)
 
     if not found_at_least_one_project_import:
         warnings.append(
             "WARNING: No first-party imports were found. You may need to use 'tach mod' to update your Python source root. Docs: https://docs.gauge.sh/usage/configuration#source-root"
         )
-    return CheckResult(errors=boundary_errors, warnings=warnings)
+    return CheckResult(
+        errors=boundary_errors, deprecated_warnings=boundary_warnings, warnings=warnings
+    )
 
 
 __all__ = ["BoundaryError", "check"]

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -11,7 +11,12 @@ from tach.extension import get_project_imports, set_excluded_paths
 from tach.parsing import build_module_tree
 
 if TYPE_CHECKING:
-    from tach.core import Dependency, ModuleNode, ModuleTree, ProjectConfig
+    from tach.core import (
+        Dependency,  # noqa: TCH004
+        ModuleNode,
+        ModuleTree,
+        ProjectConfig,
+    )
 
 
 @dataclass
@@ -102,10 +107,10 @@ def check_import(
     import_nearest_module_path = import_nearest_module.config.path
 
     # The import must be explicitly allowed
-    dependency_tags = file_nearest_module.config.depends_on
+    dependencies = file_nearest_module.config.depends_on
     #
-    allowed_dependencies = [dep for dep in dependency_tags if not dep.deprecated]
-    deprecated_dependencies = [dep for dep in dependency_tags if dep.deprecated]
+    allowed_dependencies = [dep for dep in dependencies if not dep.deprecated]
+    deprecated_dependencies = [dep for dep in dependencies if dep.deprecated]
     if any(dep.path == import_nearest_module_path for dep in allowed_dependencies):
         # The import matches at least one expected dependency
         return None

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -463,7 +463,6 @@ def tach_check(
         if isinstance(e, TachCircularDependencyError):
             print_circular_dependency_error(e.cycles)
         else:
-            raise e
             print(str(e))
         sys.exit(1)
 
@@ -533,6 +532,7 @@ def tach_sync(
             exclude_paths=exclude_paths,
         )
     except Exception as e:
+        raise e
         print(str(e))
         sys.exit(1)
 

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -554,7 +554,7 @@ def tach_sync(
             exclude_paths=exclude_paths,
         )
     except Exception as e:
-        raise e
+        print(str(e))
         sys.exit(1)
 
     print(f"✅ {BCOLORS.OKGREEN}Synced dependencies.{BCOLORS.ENDC}")

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -27,7 +27,10 @@ from tach.mod import mod_edit_interactive
 from tach.parsing import parse_project_config
 from tach.report import report
 from tach.show import generate_module_graph_dot_file, generate_show_url
-from tach.sync import prune_dependency_constraints, sync_project
+from tach.sync import (
+    sync_dependency_constraints,
+    sync_project,
+)
 from tach.test import run_affected_tests
 
 if TYPE_CHECKING:
@@ -469,7 +472,7 @@ def tach_check(
 
         # If we're checking in strict mode, we want to verify that pruning constraints has no effect
         if exact:
-            pruned_config = prune_dependency_constraints(
+            pruned_config = sync_dependency_constraints(
                 project_root=project_root,
                 project_config=project_config,
                 exclude_paths=exclude_paths,
@@ -551,7 +554,7 @@ def tach_sync(
             exclude_paths=exclude_paths,
         )
     except Exception as e:
-        print(str(e))
+        raise e
         sys.exit(1)
 
     print(f"✅ {BCOLORS.OKGREEN}Synced dependencies.{BCOLORS.ENDC}")

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -122,7 +122,7 @@ def print_unused_dependencies(
     all_unused_dependencies: list[UnusedDependencies],
 ) -> None:
     constraint_messages = "\n".join(
-        f"\t{BCOLORS.WARNING}'{unused_dependencies.path}' does not depend on: {unused_dependencies.dependencies}{BCOLORS.ENDC}"
+        f"\t{BCOLORS.WARNING}'{unused_dependencies.path}' does not depend on: {[dependency.path for dependency in unused_dependencies.dependencies]}{BCOLORS.ENDC}"
         for unused_dependencies in all_unused_dependencies
     )
     print(
@@ -463,6 +463,7 @@ def tach_check(
         if isinstance(e, TachCircularDependencyError):
             print_circular_dependency_error(e.cycles)
         else:
+            raise e
             print(str(e))
         sys.exit(1)
 

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -125,10 +125,11 @@ def print_errors(error_list: list[BoundaryError], source_root: Path) -> None:
             build_error_message(error, source_root=source_root),
             file=sys.stderr,
         )
-    print(
-        f"{BCOLORS.WARNING}\nIf you intended to add a new dependency, run 'tach sync' to update your module configuration."
-        f"\nOtherwise, remove any disallowed imports and consider refactoring.\n{BCOLORS.ENDC}"
-    )
+    if not all(error.error_info.is_deprecated for error in sorted_results):
+        print(
+            f"{BCOLORS.WARNING}\nIf you intended to add a new dependency, run 'tach sync' to update your module configuration."
+            f"\nOtherwise, remove any disallowed imports and consider refactoring.\n{BCOLORS.ENDC}"
+        )
 
 
 def print_unused_dependencies(

--- a/python/tach/core/__init__.py
+++ b/python/tach/core/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from tach.core.config import (
+    Dependency,
     ModuleConfig,
     ProjectConfig,
     UnusedDependencies,
@@ -12,5 +13,6 @@ __all__ = [
     "ModuleConfig",
     "ModuleNode",
     "ModuleTree",
+    "Dependency",
     "UnusedDependencies",
 ]

--- a/python/tach/core/config.py
+++ b/python/tach/core/config.py
@@ -123,7 +123,7 @@ class ProjectConfig(Config):
             list(),  # type: ignore
         )
 
-    def add_dependency_to_module(self, module: str, dependency: str):
+    def add_dependency_to_module(self, module: str, dependency: Dependency):
         current_module_config = next(
             (
                 module_config
@@ -134,14 +134,10 @@ class ProjectConfig(Config):
         )
         if not current_module_config:
             # No configuration exists for tag, add default config with this dependency
-            self.modules.append(
-                ModuleConfig(path=module, depends_on=[Dependency(path=dependency)])
-            )
+            self.modules.append(ModuleConfig(path=module, depends_on=[dependency]))
         else:
             # Config already exists, set the union of existing dependencies and new ones
-            new_dependencies = set(current_module_config.depends_on) | {
-                Dependency(path=dependency)
-            }
+            new_dependencies = set(current_module_config.depends_on) | {dependency}
             current_module_config.depends_on = list(new_dependencies)
 
     def compare_dependencies(

--- a/python/tach/core/config.py
+++ b/python/tach/core/config.py
@@ -137,7 +137,7 @@ class ProjectConfig(Config):
             self.modules.append(ModuleConfig(path=module, depends_on=[dependency]))
         else:
             # Config already exists, set the union of existing dependencies and new ones
-            new_dependencies = set(current_module_config.depends_on) | {dependency}
+            new_dependencies = set(current_module_config.depends_on) | {dependency}  # pyright: ignore[reportUnhashable]
             current_module_config.depends_on = list(new_dependencies)
 
     def compare_dependencies(

--- a/python/tach/core/config.py
+++ b/python/tach/core/config.py
@@ -37,8 +37,7 @@ class Dependency(Config):
     path: str
     deprecated: bool = False
 
-    class Config:
-        frozen = True
+    model_config = {"frozen": True}
 
 
 def validate_root_path(path: str) -> str:

--- a/python/tach/core/config.py
+++ b/python/tach/core/config.py
@@ -157,15 +157,24 @@ class ProjectConfig(Config):
                     )
                 )
                 continue
-            own_module_dependencies = set(
-                self.dependencies_for_module(module=module_config.path)
+            own_module_dependency_paths = set(
+                dep.path
+                for dep in self.dependencies_for_module(module=module_config.path)
             )
-            extra_dependencies = set(module_config.depends_on) - own_module_dependencies
-            if extra_dependencies:
+            current_dependency_paths = set(dep.path for dep in module_config.depends_on)
+            extra_dependency_paths = (
+                current_dependency_paths - own_module_dependency_paths
+            )
+            if extra_dependency_paths:
+                extra_dependencies = [
+                    dep
+                    for dep in module_config.depends_on
+                    if dep.path in extra_dependency_paths
+                ]
                 all_unused_dependencies.append(
                     UnusedDependencies(
                         path=module_config.path,
-                        dependencies=list(extra_dependencies),
+                        dependencies=extra_dependencies,
                     )
                 )
 

--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
+import pydantic
 import yaml
 
 from tach import filesystem as fs
@@ -42,6 +44,17 @@ def dump_project_config_to_yaml(config: ProjectConfig) -> str:
     return language_server_directive + yaml_content
 
 
+# TODO remove after next major version upgrade
+def migrate_config(result: dict[Any, Any]) -> dict[Any, Any]:
+    if "modules" in result:
+        for module in result["modules"]:
+            if "depends_on" in module:
+                for index, path in enumerate(module["depends_on"]):
+                    if isinstance(path, str):
+                        module["depends_on"][index] = {"path": path}
+    return result
+
+
 def parse_project_config(root: Path | None = None) -> ProjectConfig | None:
     root = root or Path.cwd()
     file_path = fs.get_project_config_path(root)
@@ -52,5 +65,10 @@ def parse_project_config(root: Path | None = None) -> ProjectConfig | None:
         result = yaml.safe_load(f)
         if not result or not isinstance(result, dict):
             raise ValueError(f"Empty or invalid project config file: {file_path}")
-    config = ProjectConfig(**result)  # type: ignore
+    try:
+        config = ProjectConfig(**result)  # type: ignore
+    except pydantic.ValidationError:
+        result = migrate_config(result)  # type: ignore
+        config = ProjectConfig(**result)
+        print("Updating config to latest syntax...")
     return config

--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -71,5 +71,6 @@ def parse_project_config(root: Path | None = None) -> ProjectConfig | None:
         result = migrate_config(result)  # type: ignore
         config = ProjectConfig(**result)
         print("Updating config to latest syntax...")
-        dump_project_config_to_yaml(config)
+        config_yml_content = dump_project_config_to_yaml(config)
+        fs.write_file(str(file_path), config_yml_content)
     return config

--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -25,7 +25,7 @@ def dump_project_config_to_yaml(config: ProjectConfig) -> str:
         key=lambda mod: (mod.path == ROOT_MODULE_SENTINEL_TAG, mod.path)
     )
     for mod in config.modules:
-        mod.depends_on.sort()
+        mod.depends_on.sort(key=lambda dep: dep.path)
     # NOTE: setting 'exclude' explicitly here also interacts with the 'exclude_unset' option
     # being passed to 'model_dump'. It ensures that even on a fresh config, we will explicitly
     # show excluded paths.
@@ -71,4 +71,5 @@ def parse_project_config(root: Path | None = None) -> ProjectConfig | None:
         result = migrate_config(result)  # type: ignore
         config = ProjectConfig(**result)
         print("Updating config to latest syntax...")
+        dump_project_config_to_yaml(config)
     return config

--- a/python/tach/parsing/modules.py
+++ b/python/tach/parsing/modules.py
@@ -42,7 +42,7 @@ def find_cycles(
     # Add dependency edges
     for module in modules:
         for dependency in module.depends_on:
-            graph.add_edge(module.path, dependency)  # type: ignore
+            graph.add_edge(module.path, dependency.path)  # type: ignore
 
     all_cycles: list[list[str]] = list(nx.simple_cycles(graph))  # type: ignore
 

--- a/python/tach/show.py
+++ b/python/tach/show.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from tach.core import ProjectConfig
 
-TACH_SHOW_URL = "https://show.gauge.sh"
+TACH_SHOW_URL = "http://0.0.0.0:8000/"
 
 
 def generate_show_url(project_config: ProjectConfig) -> str | None:

--- a/python/tach/show.py
+++ b/python/tach/show.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from tach.core import ProjectConfig
 
-TACH_SHOW_URL = "http://0.0.0.0:8000/"
+TACH_SHOW_URL = "https://show.gauge.sh"
 
 
 def generate_show_url(project_config: ProjectConfig) -> str | None:

--- a/python/tach/sync.py
+++ b/python/tach/sync.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from tach import errors
 from tach import filesystem as fs
 from tach.check import check
+from tach.core import Dependency
 from tach.filesystem import get_project_config_path
 from tach.parsing import dump_project_config_to_yaml
 
@@ -18,52 +19,49 @@ def sync_dependency_constraints(
     project_root: Path,
     project_config: ProjectConfig,
     exclude_paths: list[str] | None = None,
+    prune: bool = True,
 ) -> ProjectConfig:
     """
     Update project configuration with auto-detected dependency constraints.
     This is additive, meaning it will create dependencies to resolve existing errors,
     but will not remove any constraints.
     """
+    if prune:
+        new_config = project_config.model_copy(
+            update={
+                "modules": [
+                    module.model_copy(update={"depends_on": []})
+                    for module in project_config.modules
+                ]
+            }
+        )
+    else:
+        new_config = project_config
     check_result = check(
         project_root=project_root,
-        project_config=project_config,
+        project_config=new_config,
         exclude_paths=exclude_paths,
     )
     for error in check_result.errors:
         error_info = error.error_info
         if error_info.is_dependency_error:
-            project_config.add_dependency_to_module(
-                error_info.source_module, error_info.invalid_module
+            new_config.add_dependency_to_module(
+                error_info.source_module, Dependency(path=error_info.invalid_module)
             )
-
-    return project_config
-
-
-def prune_dependency_constraints(
-    project_root: Path,
-    project_config: ProjectConfig,
-    exclude_paths: list[str] | None = None,
-) -> ProjectConfig:
-    """
-    Build a minimal project configuration with auto-detected module dependencies.
-    """
-    # Force module dependencies to be empty so that we can figure out the minimal set
-    project_config = project_config.model_copy(
-        update={
-            "modules": [
-                module.model_copy(update={"depends_on": []})
-                for module in project_config.modules
-            ]
-        }
-    )
-
-    sync_dependency_constraints(
+    deprecated_check_result = check(
         project_root=project_root,
         project_config=project_config,
         exclude_paths=exclude_paths,
     )
+    for error in deprecated_check_result.errors:
+        error_info = error.error_info
+        if error_info.is_dependency_error and error_info.is_dependency_error:
+            new_config.add_dependency_to_module(
+                error_info.source_module,
+                Dependency(path=error_info.invalid_module, deprecated=True),
+            )
 
-    return project_config
+    return new_config
 
 
 def sync_project(
@@ -78,21 +76,14 @@ def sync_project(
             "Unexpected error. Could not find configuration file during 'sync'."
         )
 
-    if add:
-        project_config = sync_dependency_constraints(
-            project_root=project_root,
-            project_config=project_config,
-            exclude_paths=exclude_paths,
-        )
-    else:
-        project_config = prune_dependency_constraints(
-            project_root=project_root,
-            project_config=project_config,
-            exclude_paths=exclude_paths,
-        )
-
+    project_config = sync_dependency_constraints(
+        project_root=project_root,
+        project_config=project_config,
+        exclude_paths=exclude_paths,
+        prune=not add,
+    )
     tach_yml_content = dump_project_config_to_yaml(project_config)
     fs.write_file(str(tach_yml_path), tach_yml_content)
 
 
-__all__ = ["sync_project", "prune_dependency_constraints"]
+__all__ = ["sync_project", "sync_dependency_constraints"]

--- a/python/tach/test.py
+++ b/python/tach/test.py
@@ -20,10 +20,10 @@ def build_module_consumer_map(modules: list[ModuleConfig]) -> dict[str, list[str
     consumer_map: dict[str, list[str]] = {}
     for module in modules:
         for dependency in module.depends_on:
-            if dependency in consumer_map:
-                consumer_map[dependency].append(module.mod_path)
+            if dependency.path in consumer_map:
+                consumer_map[dependency.path].append(module.mod_path)
             else:
-                consumer_map[dependency] = [module.mod_path]
+                consumer_map[dependency.path] = [module.mod_path]
     return consumer_map
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tach.core import (
+    Dependency,
+    ModuleConfig,
+    ModuleNode,
+    ModuleTree,
+)
+
+
+@pytest.fixture
+def example_dir() -> Path:
+    current_dir = Path(__file__).parent
+    return current_dir / "example"
+
+
+@pytest.fixture
+def test_config() -> ModuleConfig:
+    return ModuleConfig(path="test", strict=False)
+
+
+@pytest.fixture
+def module_tree() -> ModuleTree:
+    return ModuleTree(
+        root=ModuleNode(
+            is_end_of_path=False,
+            full_path="",
+            config=None,
+            children={
+                "domain_one": ModuleNode(
+                    is_end_of_path=True,
+                    full_path="domain_one",
+                    config=ModuleConfig(
+                        path="domain_one",
+                        depends_on=[
+                            Dependency(path="domain_one.subdomain", deprecated=True),
+                            Dependency(path="domain_three"),
+                        ],
+                        strict=True,
+                    ),
+                    interface_members=["public_fn"],
+                    children={
+                        "subdomain": ModuleNode(
+                            is_end_of_path=True,
+                            full_path="domain_one.subdomain",
+                            config=ModuleConfig(
+                                path="domain_one.subdomain", strict=True
+                            ),
+                            children={},
+                        )
+                    },
+                ),
+                "domain_two": ModuleNode(
+                    is_end_of_path=True,
+                    full_path="domain_two",
+                    config=ModuleConfig(
+                        path="domain_two",
+                        depends_on=[Dependency(path="domain_one")],
+                        strict=False,
+                    ),
+                    children={
+                        "subdomain": ModuleNode(
+                            is_end_of_path=True,
+                            full_path="domain_two.subdomain",
+                            config=ModuleConfig(
+                                path="domain_two",
+                                depends_on=[Dependency(path="domain_one")],
+                                strict=False,
+                            ),
+                            children={},
+                        )
+                    },
+                ),
+                "domain_three": ModuleNode(
+                    is_end_of_path=True,
+                    full_path="domain_three",
+                    config=ModuleConfig(path="domain_three", strict=False),
+                    children={},
+                ),
+            },
+        )
+    )

--- a/python/tests/example/cycles/tach.yml
+++ b/python/tests/example/cycles/tach.yml
@@ -1,18 +1,18 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.8.2/public/tach-yml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.8.3/public/tach-yml-schema.json
 modules:
   - path: domain_one
     depends_on:
-      - domain_two
-      - domain_three
+      - path: domain_three
+      - path: domain_two
   - path: domain_three
     depends_on:
-      - domain_one
+      - path: domain_one
   - path: domain_two
     depends_on:
-      - domain_three
+      - path: domain_three
   - path: <root>
     depends_on:
-      - domain_one
+      - path: domain_one
 exclude:
   - .*__pycache__
   - .*egg-info

--- a/python/tests/example/invalid/hidden/.hidden/__init__.py
+++ b/python/tests/example/invalid/hidden/.hidden/__init__.py
@@ -1,5 +1,0 @@
-from __future__ import annotations
-
-from unhidden.secret import shhhh
-
-__all__ = ["shhhh"]

--- a/python/tests/example/invalid/hidden/tach.yml
+++ b/python/tests/example/invalid/hidden/tach.yml
@@ -1,8 +1,0 @@
-constraints:
-- tag: unhidden
-  depends_on: []
-- tag: hidden
-  depends_on: []
-exclude:
-- tests
-- docs

--- a/python/tests/example/invalid/hidden/unhidden/secret.py
+++ b/python/tests/example/invalid/hidden/unhidden/secret.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-shhhh = "🤫"

--- a/python/tests/example/invalid/tach.yml
+++ b/python/tests/example/invalid/tach.yml
@@ -1,9 +1,10 @@
 exclude: ["domain_three"]
 constraints:
   one:
-    depends_on: ["two"]
+    depends_on:
+    - path: "two"
   two:
-    depends_on: ["one"]
+    depends_on: [ path: "one"]
   shared:
     depends_on: []
 unknown: 88

--- a/python/tests/example/monorepo/tach.yml
+++ b/python/tests/example/monorepo/tach.yml
@@ -1,18 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.8.3/public/tach-yml-schema.json
 modules:
-- path: mod1
-  depends_on: []
-  strict: true
-- path: mod2
-  depends_on: []
-  strict: true
-- path: mod3
-  depends_on:
-  - mod2
+  - path: mod1
+    depends_on: []
+    strict: true
+  - path: mod2
+    depends_on: []
+    strict: true
+  - path: mod3
+    depends_on:
+      - path: mod2
 exclude:
-- .*__pycache__
-- .*egg-info
-- docs
-- tests
-- venv
+  - .*__pycache__
+  - .*egg-info
+  - docs
+  - tests
+  - venv
 source_root: backend
 exact: true

--- a/python/tests/example/valid/tach.yml
+++ b/python/tests/example/valid/tach.yml
@@ -3,6 +3,7 @@ modules:
   - path: domain_one
     depends_on:
       - path: domain_two
+        deprecated: true
   - path: domain_three
     depends_on: []
   - path: domain_two
@@ -11,5 +12,11 @@ modules:
   - path: <root>
     depends_on:
       - path: domain_one
+exclude:
+  - .*__pycache__
+  - .*egg-info
+  - docs
+  - tests
+  - venv
 exact: true
 forbid_circular_dependencies: true

--- a/python/tests/example/valid/tach.yml
+++ b/python/tests/example/valid/tach.yml
@@ -1,14 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.8.3/public/tach-yml-schema.json
 modules:
   - path: domain_one
     depends_on:
-      - domain_two
-  - path: domain_two
-    depends_on:
-      - domain_three
-  - path: <root>
-    depends_on:
-      - domain_one
+      - path: domain_two
   - path: domain_three
     depends_on: []
+  - path: domain_two
+    depends_on:
+      - path: domain_three
+  - path: <root>
+    depends_on:
+      - path: domain_one
 exact: true
 forbid_circular_dependencies: true

--- a/python/tests/test_affected_modules.py
+++ b/python/tests/test_affected_modules.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tach.core.config import ModuleConfig, ProjectConfig, RootModuleConfig
+from tach.core.config import Dependency, ModuleConfig, ProjectConfig, RootModuleConfig
 from tach.core.modules import ModuleNode, ModuleTree
 from tach.test import get_affected_modules, get_changed_module_paths
 
@@ -17,97 +17,137 @@ from tach.test import get_affected_modules, get_changed_module_paths
 def modules() -> list[ModuleConfig]:
     return [
         ModuleConfig(path="tach", depends_on=[], strict=True),
-        ModuleConfig(path="tach.__main__", depends_on=["tach.start"], strict=True),
         ModuleConfig(
-            path="tach.cache", depends_on=["tach", "tach.filesystem"], strict=True
+            path="tach.__main__",
+            depends_on=[Dependency(path="tach.start")],
+            strict=True,
+        ),
+        ModuleConfig(
+            path="tach.cache",
+            depends_on=[Dependency(path="tach"), Dependency(path="tach.filesystem")],
+            strict=True,
         ),
         ModuleConfig(
             path="tach.check",
-            depends_on=["tach.errors", "tach.filesystem", "tach.parsing"],
+            depends_on=[
+                Dependency(path="tach.errors"),
+                Dependency(path="tach.filesystem"),
+                Dependency(path="tach.parsing"),
+            ],
             strict=True,
         ),
         ModuleConfig(
             path="tach.cli",
             depends_on=[
-                "tach",
-                "tach.cache",
-                "tach.check",
-                "tach.colors",
-                "tach.constants",
-                "tach.core",
-                "tach.errors",
-                "tach.filesystem",
-                "tach.logging",
-                "tach.mod",
-                "tach.parsing",
-                "tach.report",
-                "tach.show",
-                "tach.sync",
-                "tach.test",
+                Dependency(path="tach"),
+                Dependency(path="tach.cache"),
+                Dependency(path="tach.check"),
+                Dependency(path="tach.colors"),
+                Dependency(path="tach.constants"),
+                Dependency(path="tach.core"),
+                Dependency(path="tach.errors"),
+                Dependency(path="tach.filesystem"),
+                Dependency(path="tach.logging"),
+                Dependency(path="tach.mod"),
+                Dependency(path="tach.parsing"),
+                Dependency(path="tach.report"),
+                Dependency(path="tach.show"),
+                Dependency(path="tach.sync"),
+                Dependency(path="tach.test"),
             ],
             strict=True,
         ),
         ModuleConfig(path="tach.colors", depends_on=[], strict=True),
         ModuleConfig(path="tach.constants", depends_on=[], strict=True),
-        ModuleConfig(path="tach.core", depends_on=["tach.constants"], strict=True),
+        ModuleConfig(
+            path="tach.core",
+            depends_on=[Dependency(path="tach.constants")],
+            strict=True,
+        ),
         ModuleConfig(path="tach.errors", depends_on=[], strict=True),
         ModuleConfig(
             path="tach.filesystem",
             depends_on=[
-                "tach.colors",
-                "tach.constants",
-                "tach.core",
-                "tach.errors",
-                "tach.hooks",
+                Dependency(path="tach.colors"),
+                Dependency(path="tach.constants"),
+                Dependency(path="tach.core"),
+                Dependency(path="tach.errors"),
+                Dependency(path="tach.hooks"),
             ],
             strict=True,
         ),
         ModuleConfig(
-            path="tach.filesystem.git_ops", depends_on=["tach.errors"], strict=True
+            path="tach.filesystem.git_ops",
+            depends_on=[Dependency(path="tach.errors")],
+            strict=True,
         ),
-        ModuleConfig(path="tach.hooks", depends_on=["tach.constants"], strict=True),
+        ModuleConfig(
+            path="tach.hooks",
+            depends_on=[Dependency(path="tach.constants")],
+            strict=True,
+        ),
         ModuleConfig(
             path="tach.interactive",
-            depends_on=["tach.errors", "tach.filesystem"],
+            depends_on=[
+                Dependency(path="tach.errors"),
+                Dependency(path="tach.filesystem"),
+            ],
             strict=True,
         ),
         ModuleConfig(
             path="tach.logging",
-            depends_on=["tach", "tach.cache", "tach.parsing"],
+            depends_on=[
+                Dependency(path="tach"),
+                Dependency(path="tach.cache"),
+                Dependency(path="tach.parsing"),
+            ],
             strict=True,
         ),
         ModuleConfig(
             path="tach.mod",
             depends_on=[
-                "tach.colors",
-                "tach.constants",
-                "tach.errors",
-                "tach.filesystem",
-                "tach.interactive",
-                "tach.parsing",
+                Dependency(path="tach.colors"),
+                Dependency(path="tach.constants"),
+                Dependency(path="tach.errors"),
+                Dependency(path="tach.filesystem"),
+                Dependency(path="tach.interactive"),
+                Dependency(path="tach.parsing"),
             ],
             strict=True,
         ),
         ModuleConfig(
             path="tach.parsing",
-            depends_on=["tach.constants", "tach.core", "tach.filesystem"],
+            depends_on=[
+                Dependency(path="tach.constants"),
+                Dependency(path="tach.core"),
+                Dependency(path="tach.filesystem"),
+            ],
             strict=True,
         ),
-        ModuleConfig(path="tach.report", depends_on=["tach.errors"], strict=True),
+        ModuleConfig(
+            path="tach.report", depends_on=[Dependency(path="tach.errors")], strict=True
+        ),
         ModuleConfig(path="tach.show", depends_on=[], strict=True),
-        ModuleConfig(path="tach.start", depends_on=["tach.cli"], strict=True),
+        ModuleConfig(
+            path="tach.start", depends_on=[Dependency(path="tach.cli")], strict=True
+        ),
         ModuleConfig(
             path="tach.sync",
-            depends_on=["tach.check", "tach.errors", "tach.filesystem", "tach.parsing"],
+            depends_on=[
+                Dependency(path="tach.check"),
+                Dependency(path="tach.errors"),
+                Dependency(path="tach.filesystem"),
+                Dependency(path="tach.parsing"),
+            ],
             strict=True,
         ),
         ModuleConfig(
             path="tach.test",
             depends_on=[
-                "tach.errors",
-                "tach.filesystem",
-                "tach.filesystem.git_ops",
-                "tach.parsing",
+                Dependency(path="tach.errors"),
+                Dependency(path="tach.filesystem"),
+                Dependency(path="tach.filesystem.git_ops"),
+                Dependency(path="tach.parsing"),
             ],
             strict=False,
         ),
@@ -134,7 +174,7 @@ def module_tree() -> ModuleTree:
                             full_path="tach.__main__",
                             config=ModuleConfig(
                                 path="tach.__main__",
-                                depends_on=["tach.start"],
+                                depends_on=[Dependency(path="tach.start")],
                                 strict=True,
                             ),
                             interface_members=[],
@@ -145,7 +185,10 @@ def module_tree() -> ModuleTree:
                             full_path="tach.cache",
                             config=ModuleConfig(
                                 path="tach.cache",
-                                depends_on=["tach", "tach.filesystem"],
+                                depends_on=[
+                                    Dependency(path="tach"),
+                                    Dependency(path="tach.filesystem"),
+                                ],
                                 strict=True,
                             ),
                             interface_members=[
@@ -161,9 +204,9 @@ def module_tree() -> ModuleTree:
                             config=ModuleConfig(
                                 path="tach.check",
                                 depends_on=[
-                                    "tach.errors",
-                                    "tach.filesystem",
-                                    "tach.parsing",
+                                    Dependency(path="tach.errors"),
+                                    Dependency(path="tach.filesystem"),
+                                    Dependency(path="tach.parsing"),
                                 ],
                                 strict=True,
                             ),
@@ -176,21 +219,21 @@ def module_tree() -> ModuleTree:
                             config=ModuleConfig(
                                 path="tach.cli",
                                 depends_on=[
-                                    "tach",
-                                    "tach.cache",
-                                    "tach.check",
-                                    "tach.colors",
-                                    "tach.constants",
-                                    "tach.core",
-                                    "tach.errors",
-                                    "tach.filesystem",
-                                    "tach.logging",
-                                    "tach.mod",
-                                    "tach.parsing",
-                                    "tach.report",
-                                    "tach.show",
-                                    "tach.sync",
-                                    "tach.test",
+                                    Dependency(path="tach"),
+                                    Dependency(path="tach.cache"),
+                                    Dependency(path="tach.check"),
+                                    Dependency(path="tach.colors"),
+                                    Dependency(path="tach.constants"),
+                                    Dependency(path="tach.core"),
+                                    Dependency(path="tach.errors"),
+                                    Dependency(path="tach.filesystem"),
+                                    Dependency(path="tach.logging"),
+                                    Dependency(path="tach.mod"),
+                                    Dependency(path="tach.parsing"),
+                                    Dependency(path="tach.report"),
+                                    Dependency(path="tach.show"),
+                                    Dependency(path="tach.sync"),
+                                    Dependency(path="tach.test"),
                                 ],
                                 strict=True,
                             ),
@@ -227,7 +270,7 @@ def module_tree() -> ModuleTree:
                             full_path="tach.core",
                             config=ModuleConfig(
                                 path="tach.core",
-                                depends_on=["tach.constants"],
+                                depends_on=[Dependency(path="tach.constants")],
                                 strict=True,
                             ),
                             interface_members=[
@@ -258,11 +301,11 @@ def module_tree() -> ModuleTree:
                             config=ModuleConfig(
                                 path="tach.filesystem",
                                 depends_on=[
-                                    "tach.colors",
-                                    "tach.constants",
-                                    "tach.core",
-                                    "tach.errors",
-                                    "tach.hooks",
+                                    Dependency(path="tach.colors"),
+                                    Dependency(path="tach.constants"),
+                                    Dependency(path="tach.core"),
+                                    Dependency(path="tach.errors"),
+                                    Dependency(path="tach.hooks"),
                                 ],
                                 strict=True,
                             ),
@@ -291,7 +334,7 @@ def module_tree() -> ModuleTree:
                                     full_path="tach.filesystem.git_ops",
                                     config=ModuleConfig(
                                         path="tach.filesystem.git_ops",
-                                        depends_on=["tach.errors"],
+                                        depends_on=[Dependency(path="tach.errors")],
                                         strict=True,
                                     ),
                                     interface_members=["get_changed_files"],
@@ -304,7 +347,7 @@ def module_tree() -> ModuleTree:
                             full_path="tach.hooks",
                             config=ModuleConfig(
                                 path="tach.hooks",
-                                depends_on=["tach.constants"],
+                                depends_on=[Dependency(path="tach.constants")],
                                 strict=True,
                             ),
                             interface_members=["build_pre_commit_hook_content"],
@@ -315,7 +358,10 @@ def module_tree() -> ModuleTree:
                             full_path="tach.interactive",
                             config=ModuleConfig(
                                 path="tach.interactive",
-                                depends_on=["tach.errors", "tach.filesystem"],
+                                depends_on=[
+                                    Dependency(path="tach.errors"),
+                                    Dependency(path="tach.filesystem"),
+                                ],
                                 strict=True,
                             ),
                             interface_members=[
@@ -329,7 +375,11 @@ def module_tree() -> ModuleTree:
                             full_path="tach.logging",
                             config=ModuleConfig(
                                 path="tach.logging",
-                                depends_on=["tach", "tach.cache", "tach.parsing"],
+                                depends_on=[
+                                    Dependency(path="tach"),
+                                    Dependency(path="tach.cache"),
+                                    Dependency(path="tach.parsing"),
+                                ],
                                 strict=True,
                             ),
                             interface_members=["logger", "LogDataModel"],
@@ -341,12 +391,12 @@ def module_tree() -> ModuleTree:
                             config=ModuleConfig(
                                 path="tach.mod",
                                 depends_on=[
-                                    "tach.colors",
-                                    "tach.constants",
-                                    "tach.errors",
-                                    "tach.filesystem",
-                                    "tach.interactive",
-                                    "tach.parsing",
+                                    Dependency(path="tach.colors"),
+                                    Dependency(path="tach.constants"),
+                                    Dependency(path="tach.errors"),
+                                    Dependency(path="tach.filesystem"),
+                                    Dependency(path="tach.interactive"),
+                                    Dependency(path="tach.parsing"),
                                 ],
                                 strict=True,
                             ),
@@ -359,9 +409,9 @@ def module_tree() -> ModuleTree:
                             config=ModuleConfig(
                                 path="tach.parsing",
                                 depends_on=[
-                                    "tach.constants",
-                                    "tach.core",
-                                    "tach.filesystem",
+                                    Dependency(path="tach.constants"),
+                                    Dependency(path="tach.core"),
+                                    Dependency(path="tach.filesystem"),
                                 ],
                                 strict=True,
                             ),
@@ -378,7 +428,7 @@ def module_tree() -> ModuleTree:
                             full_path="tach.report",
                             config=ModuleConfig(
                                 path="tach.report",
-                                depends_on=["tach.errors"],
+                                depends_on=[Dependency(path="tach.errors")],
                                 strict=True,
                             ),
                             interface_members=["report"],
@@ -397,7 +447,9 @@ def module_tree() -> ModuleTree:
                             is_end_of_path=True,
                             full_path="tach.start",
                             config=ModuleConfig(
-                                path="tach.start", depends_on=["tach.cli"], strict=True
+                                path="tach.start",
+                                depends_on=[Dependency(path="tach.cli")],
+                                strict=True,
                             ),
                             interface_members=["start"],
                             children={},
@@ -408,10 +460,10 @@ def module_tree() -> ModuleTree:
                             config=ModuleConfig(
                                 path="tach.sync",
                                 depends_on=[
-                                    "tach.check",
-                                    "tach.errors",
-                                    "tach.filesystem",
-                                    "tach.parsing",
+                                    Dependency(path="tach.check"),
+                                    Dependency(path="tach.errors"),
+                                    Dependency(path="tach.filesystem"),
+                                    Dependency(path="tach.parsing"),
                                 ],
                                 strict=True,
                             ),
@@ -427,10 +479,10 @@ def module_tree() -> ModuleTree:
                             config=ModuleConfig(
                                 path="tach.test",
                                 depends_on=[
-                                    "tach.errors",
-                                    "tach.filesystem",
-                                    "tach.filesystem.git_ops",
-                                    "tach.parsing",
+                                    Dependency(path="tach.errors"),
+                                    Dependency(path="tach.filesystem"),
+                                    Dependency(path="tach.filesystem.git_ops"),
+                                    Dependency(path="tach.parsing"),
                                 ],
                                 strict=False,
                             ),

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from itertools import chain
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -9,87 +8,13 @@ import pytest
 from tach.check import check_import
 from tach.cli import tach_check
 from tach.core import (
-    Dependency,
     ModuleConfig,
-    ModuleNode,
-    ModuleTree,
 )
 from tach.core.config import RootModuleConfig
 from tach.filesystem import validate_project_modules
 
-
-@pytest.fixture
-def example_dir() -> Path:
-    current_dir = Path(__file__).parent
-    return current_dir / "example"
-
-
-@pytest.fixture
-def test_config() -> ModuleConfig:
-    return ModuleConfig(path="test", strict=False)
-
-
-@pytest.fixture
-def module_tree() -> ModuleTree:
-    return ModuleTree(
-        root=ModuleNode(
-            is_end_of_path=False,
-            full_path="",
-            config=None,
-            children={
-                "domain_one": ModuleNode(
-                    is_end_of_path=True,
-                    full_path="domain_one",
-                    config=ModuleConfig(
-                        path="domain_one",
-                        depends_on=[
-                            Dependency(path="domain_one.subdomain", deprecated=True),
-                            Dependency(path="domain_three"),
-                        ],
-                        strict=True,
-                    ),
-                    interface_members=["public_fn"],
-                    children={
-                        "subdomain": ModuleNode(
-                            is_end_of_path=True,
-                            full_path="domain_one.subdomain",
-                            config=ModuleConfig(
-                                path="domain_one.subdomain", strict=True
-                            ),
-                            children={},
-                        )
-                    },
-                ),
-                "domain_two": ModuleNode(
-                    is_end_of_path=True,
-                    full_path="domain_two",
-                    config=ModuleConfig(
-                        path="domain_two",
-                        depends_on=[Dependency(path="domain_one")],
-                        strict=False,
-                    ),
-                    children={
-                        "subdomain": ModuleNode(
-                            is_end_of_path=True,
-                            full_path="domain_two.subdomain",
-                            config=ModuleConfig(
-                                path="domain_two",
-                                depends_on=[Dependency(path="domain_one")],
-                                strict=False,
-                            ),
-                            children={},
-                        )
-                    },
-                ),
-                "domain_three": ModuleNode(
-                    is_end_of_path=True,
-                    full_path="domain_three",
-                    config=ModuleConfig(path="domain_three", strict=False),
-                    children={},
-                ),
-            },
-        )
-    )
+# from tests.conftest import *  # noqa
+# from tests.conftest import example_dir  # noqa
 
 
 @pytest.mark.parametrize(
@@ -164,11 +89,14 @@ def test_check_deprecated_import(module_tree):
     assert check_error.is_deprecated
 
 
-def test_valid_example_dir(example_dir):
+def test_valid_example_dir(example_dir, capfd):
     project_root = example_dir / "valid"
     with pytest.raises(SystemExit) as exc_info:
         tach_check(project_root=project_root)
     assert exc_info.value.code == 0
+    captured = capfd.readouterr()
+    assert "✅" in captured.out  # success state
+    assert "‼️" in captured.err  # deprecated warning
 
 
 def test_valid_example_dir_monorepo(example_dir):

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -13,9 +13,6 @@ from tach.core import (
 from tach.core.config import RootModuleConfig
 from tach.filesystem import validate_project_modules
 
-# from tests.conftest import *  # noqa
-# from tests.conftest import example_dir  # noqa
-
 
 @pytest.mark.parametrize(
     "valid_modules,invalid_modules",

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -9,6 +9,7 @@ import pytest
 from tach.check import check_import
 from tach.cli import tach_check
 from tach.core import (
+    Dependency,
     ModuleConfig,
     ModuleNode,
     ModuleTree,
@@ -41,7 +42,10 @@ def module_tree() -> ModuleTree:
                     full_path="domain_one",
                     config=ModuleConfig(
                         path="domain_one",
-                        depends_on=["domain_one.subdomain", "domain_three"],
+                        depends_on=[
+                            Dependency(path="domain_one.subdomain"),
+                            Dependency(path="domain_three"),
+                        ],
                         strict=True,
                     ),
                     interface_members=["public_fn"],
@@ -60,7 +64,9 @@ def module_tree() -> ModuleTree:
                     is_end_of_path=True,
                     full_path="domain_two",
                     config=ModuleConfig(
-                        path="domain_two", depends_on=["domain_one"], strict=False
+                        path="domain_two",
+                        depends_on=[Dependency(path="domain_one")],
+                        strict=False,
                     ),
                     children={
                         "subdomain": ModuleNode(
@@ -68,7 +74,7 @@ def module_tree() -> ModuleTree:
                             full_path="domain_two.subdomain",
                             config=ModuleConfig(
                                 path="domain_two",
-                                depends_on=["domain_one"],
+                                depends_on=[Dependency(path="domain_one")],
                                 strict=False,
                             ),
                             children={},

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -43,7 +43,7 @@ def module_tree() -> ModuleTree:
                     config=ModuleConfig(
                         path="domain_one",
                         depends_on=[
-                            Dependency(path="domain_one.subdomain"),
+                            Dependency(path="domain_one.subdomain", deprecated=True),
                             Dependency(path="domain_three"),
                         ],
                         strict=True,
@@ -128,7 +128,6 @@ def test_validate_project_modules_root_is_always_valid(tmp_path):
     "file_mod_path,import_mod_path,expected_result",
     [
         ("domain_one", "domain_one", True),
-        ("domain_one", "domain_one.subdomain", True),
         ("domain_one", "domain_one.core", True),
         ("domain_one", "domain_three", True),
         ("domain_two", "domain_one", True),
@@ -153,6 +152,16 @@ def test_check_import(module_tree, file_mod_path, import_mod_path, expected_resu
     )
     result = check_error is None
     assert result == expected_result
+
+
+def test_check_deprecated_import(module_tree):
+    check_error = check_import(
+        module_tree=module_tree,
+        file_mod_path="domain_one",
+        import_mod_path="domain_one.subdomain",
+    )
+    assert check_error is not None
+    assert check_error.is_deprecated
 
 
 def test_valid_example_dir(example_dir):

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -7,7 +7,7 @@ import pytest
 
 from tach import cli
 from tach.check import BoundaryError, CheckResult, ErrorInfo
-from tach.core import ModuleConfig, ProjectConfig
+from tach.core import Dependency, ModuleConfig, ProjectConfig
 
 
 @pytest.fixture
@@ -21,7 +21,9 @@ def mock_check(mocker) -> Mock:
 def mock_project_config(mocker) -> None:
     def mock_project_config(root: str = "") -> ProjectConfig:
         return ProjectConfig(
-            modules=[ModuleConfig(path="mocked", depends_on=["mocked"])]
+            modules=[
+                ModuleConfig(path="mocked", depends_on=[Dependency(path="mocked")])
+            ]
         )
 
     mocker.patch("tach.cli.parse_project_config", mock_project_config)

--- a/python/tests/test_parsing.py
+++ b/python/tests/test_parsing.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from tach.constants import ROOT_MODULE_SENTINEL_TAG
-from tach.core import ModuleConfig, ProjectConfig
+from tach.core import Dependency, ModuleConfig, ProjectConfig
 from tach.filesystem import file_to_module_path
 from tach.parsing import find_cycles, parse_project_config
 
@@ -37,10 +37,15 @@ def test_parse_valid_project_config(example_dir):
     result = parse_project_config(example_dir / "valid")
     assert result == ProjectConfig(
         modules=[
-            ModuleConfig(path="domain_one", depends_on=["domain_two"]),
-            ModuleConfig(path="domain_two", depends_on=["domain_three"]),
-            ModuleConfig(path=ROOT_MODULE_SENTINEL_TAG, depends_on=["domain_one"]),
+            ModuleConfig(path="domain_one", depends_on=[Dependency(path="domain_two")]),
             ModuleConfig(path="domain_three", depends_on=[]),
+            ModuleConfig(
+                path="domain_two", depends_on=[Dependency(path="domain_three")]
+            ),
+            ModuleConfig(
+                path=ROOT_MODULE_SENTINEL_TAG,
+                depends_on=[Dependency(path="domain_one")],
+            ),
         ],
         exact=True,
         forbid_circular_dependencies=True,

--- a/python/tests/test_parsing.py
+++ b/python/tests/test_parsing.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import pytest
 from pydantic import ValidationError
 
-from tach.constants import ROOT_MODULE_SENTINEL_TAG
+from tach.constants import DEFAULT_EXCLUDE_PATHS, ROOT_MODULE_SENTINEL_TAG
 from tach.core import Dependency, ModuleConfig, ProjectConfig
+from tach.core.config import CacheConfig
 from tach.filesystem import file_to_module_path
 from tach.parsing import find_cycles, parse_project_config
 
@@ -37,17 +38,29 @@ def test_parse_valid_project_config(example_dir):
     result = parse_project_config(example_dir / "valid")
     assert result == ProjectConfig(
         modules=[
-            ModuleConfig(path="domain_one", depends_on=[Dependency(path="domain_two")]),
-            ModuleConfig(path="domain_three", depends_on=[]),
             ModuleConfig(
-                path="domain_two", depends_on=[Dependency(path="domain_three")]
+                path="domain_one",
+                depends_on=[Dependency(path="domain_two", deprecated=True)],
+                strict=False,
+            ),
+            ModuleConfig(path="domain_three", depends_on=[], strict=False),
+            ModuleConfig(
+                path="domain_two",
+                depends_on=[Dependency(path="domain_three", deprecated=False)],
+                strict=False,
             ),
             ModuleConfig(
                 path=ROOT_MODULE_SENTINEL_TAG,
-                depends_on=[Dependency(path="domain_one")],
+                depends_on=[Dependency(path="domain_one", deprecated=False)],
+                strict=False,
             ),
         ],
+        cache=CacheConfig(backend="local", file_dependencies=[], env_dependencies=[]),
+        exclude=sorted(DEFAULT_EXCLUDE_PATHS),
+        source_root=PosixPath("."),
         exact=True,
+        disable_logging=False,
+        ignore_type_checking_imports=True,
         forbid_circular_dependencies=True,
     )
 

--- a/python/tests/test_sync.py
+++ b/python/tests/test_sync.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from tach.cli import tach_sync
+
+
+def test_valid_example_dir(example_dir, capfd):
+    project_root = example_dir / "valid"
+    with pytest.raises(SystemExit) as exc_info:
+        # TODO not a great test, can change the example fs
+        tach_sync(project_root=project_root)
+    assert exc_info.value.code == 0
+    captured = capfd.readouterr()
+    assert "✅" in captured.out  # success state

--- a/tach.yml
+++ b/tach.yml
@@ -110,6 +110,7 @@ modules:
       - path: tach.errors
       - path: tach.filesystem
       - path: tach.parsing
+      - path: tach.core
     strict: true
   - path: tach.test
     depends_on:

--- a/tach.yml
+++ b/tach.yml
@@ -21,7 +21,6 @@ modules:
   - path: tach.cli
     depends_on:
       - path: tach
-        deprecated: true
       - path: tach.cache
       - path: tach.check
       - path: tach.colors

--- a/tach.yml
+++ b/tach.yml
@@ -1,40 +1,40 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.8.2/public/tach-yml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.8.3/public/tach-yml-schema.json
 modules:
   - path: tach
     depends_on: []
     strict: true
   - path: tach.__main__
     depends_on:
-      - tach.start
+      - path: tach.start
     strict: true
   - path: tach.cache
     depends_on:
-      - tach
-      - tach.filesystem
+      - path: tach
+      - path: tach.filesystem
     strict: true
   - path: tach.check
     depends_on:
-      - tach.errors
-      - tach.filesystem
-      - tach.parsing
+      - path: tach.errors
+      - path: tach.filesystem
+      - path: tach.parsing
     strict: true
   - path: tach.cli
     depends_on:
-      - tach
-      - tach.cache
-      - tach.check
-      - tach.colors
-      - tach.constants
-      - tach.core
-      - tach.errors
-      - tach.filesystem
-      - tach.logging
-      - tach.mod
-      - tach.parsing
-      - tach.report
-      - tach.show
-      - tach.sync
-      - tach.test
+      - path: tach
+      - path: tach.cache
+      - path: tach.check
+      - path: tach.colors
+      - path: tach.constants
+      - path: tach.core
+      - path: tach.errors
+      - path: tach.filesystem
+      - path: tach.logging
+      - path: tach.mod
+      - path: tach.parsing
+      - path: tach.report
+      - path: tach.show
+      - path: tach.sync
+      - path: tach.test
     strict: true
   - path: tach.colors
     depends_on: []
@@ -44,78 +44,78 @@ modules:
     strict: true
   - path: tach.core
     depends_on:
-      - tach.constants
+      - path: tach.constants
     strict: true
   - path: tach.errors
     depends_on: []
     strict: true
   - path: tach.filesystem
     depends_on:
-      - tach.colors
-      - tach.constants
-      - tach.core
-      - tach.errors
-      - tach.hooks
+      - path: tach.colors
+      - path: tach.constants
+      - path: tach.core
+      - path: tach.errors
+      - path: tach.hooks
     strict: true
   - path: tach.filesystem.git_ops
     depends_on:
-      - tach.errors
+      - path: tach.errors
     strict: true
   - path: tach.hooks
     depends_on:
-      - tach.constants
+      - path: tach.constants
     strict: true
   - path: tach.interactive
     depends_on:
-      - tach.errors
-      - tach.filesystem
+      - path: tach.errors
+      - path: tach.filesystem
     strict: true
   - path: tach.logging
     depends_on:
-      - tach
-      - tach.cache
-      - tach.parsing
+      - path: tach
+      - path: tach.cache
+      - path: tach.parsing
     strict: true
   - path: tach.mod
     depends_on:
-      - tach.colors
-      - tach.constants
-      - tach.errors
-      - tach.filesystem
-      - tach.interactive
-      - tach.parsing
+      - path: tach.colors
+      - path: tach.constants
+      - path: tach.errors
+      - path: tach.filesystem
+      - path: tach.interactive
+      - path: tach.parsing
     strict: true
   - path: tach.parsing
     depends_on:
-      - tach.constants
-      - tach.core
-      - tach.errors
-      - tach.filesystem
+      - path: tach.constants
+      - path: tach.core
+      - path: tach.errors
+      - path: tach.filesystem
     strict: true
   - path: tach.report
     depends_on:
-      - tach.errors
+      - path: tach.errors
     strict: true
   - path: tach.show
     depends_on: []
     strict: true
   - path: tach.start
     depends_on:
-      - tach.cli
+      - path: tach.cli
     strict: true
   - path: tach.sync
     depends_on:
-      - tach.check
-      - tach.errors
-      - tach.filesystem
-      - tach.parsing
+      - path: tach.check
+      - path: tach.errors
+      - path: tach.filesystem
+      - path: tach.parsing
     strict: true
   - path: tach.test
     depends_on:
-      - tach.errors
-      - tach.filesystem
-      - tach.filesystem.git_ops
-      - tach.parsing
+      - path: tach.errors
+      - path: tach.filesystem
+      - path: tach.filesystem.git_ops
+      - path: tach.parsing
     strict: true
 cache:
   file_dependencies:

--- a/tach.yml
+++ b/tach.yml
@@ -21,6 +21,7 @@ modules:
   - path: tach.cli
     depends_on:
       - path: tach
+        deprecated: true
       - path: tach.cache
       - path: tach.check
       - path: tach.colors


### PR DESCRIPTION
Add support for specifying a dependency is `deprecated`. This involves a breaking change to the `tach.yml` spec:
From:
```yaml
modules:
  - path: domain_one
    depends_on:
      - domain_two
      - domain_three
```
to
```yaml
modules:
  - path: domain_one
    depends_on:
      - path: domain_two
        deprecated: true
      - path: domain_two
 ``` 
(if marking `domain_two` as a deprecated dependency)

Here's what it looks like in action!
![image](https://github.com/user-attachments/assets/a3e13889-e7c8-4892-baf9-5c8b695a5c3c)

This is necessary to support per-dependency configuration, which we'll likely expand in the future. Included is a migration handler which will auto-update every project config to the new format when it's run. 
Note that for now we'll still lose comments from the file when this happens.    

`deprecated` spits out a warning, but still returns the exit code 0. I debated adding a flag to fail on deprecations, but for now you can achieve the same thing by just removing the dependency from `depends_on`.

This is also a breaking change for `tach show --web` - I'll set up changes on the web server to go out alongside the release of this feature. Fixes #184!

Bonus - expanded the test suite a little bit and added caching for deps! Takes it from about 3 min -> 1 min 