### PR TITLE
Cycles detection is now binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "tach"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cached",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tach"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can validate that Tach is working by either:
 Give both a try and run `tach check` again. This will generate an error:
 
 ```bash
-❌ tach/check.py[L8]: Cannot import 'tach.filesystem'. Tag 'tach' cannot depend on 'tach.filesystem'.
+❌ tach/check.py[L8]: Cannot import 'tach.filesystem'. Module 'tach' cannot depend on 'tach.filesystem'.
 ```
 
 Each error indicates an import which violates your dependencies. If your terminal supports hyperlinks, click on the file path to go directly to the error.

--- a/docs/getting-started/getting-started.mdx
+++ b/docs/getting-started/getting-started.mdx
@@ -63,7 +63,7 @@ You can validate that Tach is working by either:
 Give both a try and run `tach check` again. This will generate an error:
 
 ```bash
-❌ tach/check.py[L8]: Cannot import 'tach.filesystem'. Tag 'tach' cannot depend on 'tach.filesystem'.
+❌ tach/check.py[L8]: Cannot import 'tach.filesystem'. Module 'tach' cannot depend on 'tach.filesystem'.
 ```
 
 Each error indicates an import which violates your dependencies. If your terminal supports hyperlinks, click on the file path to go directly to the error.

--- a/docs/usage/commands.mdx
+++ b/docs/usage/commands.mdx
@@ -174,7 +174,7 @@ If you use the [pre-commit framework](https://github.com/pre-commit/pre-commit),
 ```yaml
 repos:
   - repo: https://github.com/gauge-sh/tach-pre-commit
-    rev: v0.9.1 # change this to the latest tag!
+    rev: v0.9.2 # change this to the latest tag!
     hooks:
       - id: tach
 ```

--- a/docs/usage/commands.mdx
+++ b/docs/usage/commands.mdx
@@ -84,7 +84,7 @@ Example:
 
 ```bash
 > tach check
-❌ tach/check.py[L8]: Cannot import 'tach.filesystem'. Tag 'tach' cannot depend on 'tach.filesystem'.
+❌ tach/check.py[L8]: Cannot import 'tach.filesystem'. Module 'tach' cannot depend on 'tach.filesystem'.
 ```
 
 NOTE: If your terminal supports hyperlinks, you can click on the failing file path to go directly to the error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tach"
-version = "0.9.1"
+version = "0.9.2"
 authors = [
   { name="Caelean Barnes", email="caeleanb@gmail.com" },
   { name="Evan Doyle", email="evanmdoyle@gmail.com" },

--- a/python/tach/__init__.py
+++ b/python/tach/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 __all__ = ["__version__"]

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -122,7 +122,7 @@ def build_error_message(error: BoundaryError, source_roots: list[Path]) -> str:
 
     warning_message = (
         f"Import '{error.import_mod_path}' is deprecated. "
-        f"Module '{error_info.source_module}' should not depend on module '{error_info.invalid_module}'."
+        f"Module '{error_info.source_module}' should not depend on '{error_info.invalid_module}'."
     )
     if error_info.is_deprecated:
         return warning_template.format(message=warning_message)

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -117,12 +117,12 @@ def build_error_message(error: BoundaryError, source_roots: list[Path]) -> str:
 
     error_message = (
         f"Cannot import '{error.import_mod_path}'. "
-        f"'{error_info.source_module}' cannot depend on '{error_info.invalid_module}'."
+        f"Module '{error_info.source_module}' cannot depend on '{error_info.invalid_module}'."
     )
 
     warning_message = (
         f"Import '{error.import_mod_path}' is deprecated. "
-        f"'{error_info.source_module}' should not depend on '{error_info.invalid_module}'."
+        f"Module '{error_info.source_module}' should not depend on module '{error_info.invalid_module}'."
     )
     if error_info.is_deprecated:
         return warning_template.format(message=warning_message)
@@ -191,7 +191,7 @@ def print_circular_dependency_error(module_paths: list[str]) -> None:
     print(
         "\n".join(
             [
-                f"❌ {BCOLORS.FAIL}Circular dependency detected: {module_path}"
+                f"❌ {BCOLORS.FAIL}Circular dependency detected for module {BCOLORS.ENDC}'{module_path}'"
                 for module_path in module_paths
             ]
         )

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -187,13 +187,17 @@ def print_generated_module_graph_file(output_filepath: Path) -> None:
     )
 
 
-def print_circular_dependency_error(cycles: list[list[str]]) -> None:
+def print_circular_dependency_error(module_paths: list[str]) -> None:
     print(
-        f"❌ {BCOLORS.FAIL}Circular dependencies detected!\n"
-        + "\n".join(
-            f"{BCOLORS.ENDC}{' -> '.join(cycle)} -> {cycle[0]}" for cycle in cycles
+        "\n".join(
+            [
+                f"❌ {BCOLORS.FAIL}Circular dependency detected: {module_path}"
+                for module_path in module_paths
+            ]
         )
-        + f"\n\n{BCOLORS.WARNING}Resolve circular dependencies.\nRemove or unset 'forbid_circular_dependencies' from 'tach.yml' to allow circular dependencies.{BCOLORS.ENDC}"
+        + f"\n\n{BCOLORS.WARNING}Resolve circular dependencies.\n"
+        f"Remove or unset 'forbid_circular_dependencies' from "
+        f"'tach.yml' to allow circular dependencies.{BCOLORS.ENDC}"
     )
 
 
@@ -505,7 +509,7 @@ def tach_check(
                 exit_code = 1
     except Exception as e:
         if isinstance(e, TachCircularDependencyError):
-            print_circular_dependency_error(e.cycles)
+            print_circular_dependency_error(e.module_paths)
         else:
             print(str(e))
         sys.exit(1)

--- a/python/tach/constants/__init__.py
+++ b/python/tach/constants/__init__.py
@@ -6,7 +6,7 @@ CONFIG_FILE_NAME = TOOL_NAME
 PACKAGE_FILE_NAME = "package"
 ROOT_MODULE_SENTINEL_TAG = "<root>"
 TACH_YML_SCHEMA_URL = (
-    "https://raw.githubusercontent.com/gauge-sh/tach/v0.9.1/public/tach-yml-schema.json"
+    "https://raw.githubusercontent.com/gauge-sh/tach/v0.9.2/public/tach-yml-schema.json"
 )
 
 DEFAULT_EXCLUDE_PATHS = ["tests", "docs", "venv", ".*__pycache__", ".*egg-info"]

--- a/python/tach/errors/__init__.py
+++ b/python/tach/errors/__init__.py
@@ -11,8 +11,8 @@ class TachSetupError(TachError): ...
 
 
 class TachCircularDependencyError(TachError):
-    def __init__(self, cycles: list[list[str]]):
-        self.cycles = cycles
+    def __init__(self, module_paths: list[str]):
+        self.module_paths = module_paths
 
 
 __all__ = [

--- a/python/tach/parsing/__init__.py
+++ b/python/tach/parsing/__init__.py
@@ -5,12 +5,12 @@ from tach.parsing.config import (
     parse_project_config,
 )
 from tach.parsing.interface import parse_interface_members
-from tach.parsing.modules import build_module_tree, find_cycles
+from tach.parsing.modules import build_module_tree, find_modules_with_cycles
 
 __all__ = [
     "parse_project_config",
     "dump_project_config_to_yaml",
     "parse_interface_members",
     "build_module_tree",
-    "find_cycles",
+    "find_modules_with_cycles",
 ]

--- a/python/tach/parsing/modules.py
+++ b/python/tach/parsing/modules.py
@@ -47,11 +47,17 @@ def find_modules_with_cycles(
 
     modules_with_cycles: list[str] = []
     for module in modules:
+        module_path = module.path
         try:
-            nx.find_cycle(graph, source=module.path)  # type: ignore
-            modules_with_cycles.append(module.path)
+            # Find *any* cycle, starting with module_path
+            cycle: list[tuple[str, str]] = nx.find_cycle(graph, source=module_path)  # type: ignore
+            for edge in cycle:  # type: ignore
+                # Confirm that the cycle includes module_path
+                if module_path in edge:
+                    modules_with_cycles.append(module.path)
+                    break
         except NetworkXNoCycle:
-            pass
+            return []
 
     return modules_with_cycles
 

--- a/python/tests/example/cycles/tach.yml
+++ b/python/tests/example/cycles/tach.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.9.1/public/tach-yml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.9.2/public/tach-yml-schema.json
 modules:
   - path: domain_one
     depends_on:

--- a/python/tests/example/cycles/tach.yml
+++ b/python/tests/example/cycles/tach.yml
@@ -2,7 +2,6 @@
 modules:
   - path: domain_one
     depends_on:
-      - path: domain_three
       - path: domain_two
   - path: domain_three
     depends_on:
@@ -10,7 +9,7 @@ modules:
   - path: domain_two
     depends_on:
       - path: domain_three
-  - path: <root>
+  - path: leftover
     depends_on:
       - path: domain_one
 exclude:
@@ -19,4 +18,6 @@ exclude:
   - docs
   - tests
   - venv
+source_roots:
+  - .
 forbid_circular_dependencies: true

--- a/python/tests/example/monorepo/tach.yml
+++ b/python/tests/example/monorepo/tach.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.9.1/public/tach-yml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.9.2/public/tach-yml-schema.json
 modules:
   - path: mod1
     depends_on: []

--- a/python/tests/example/valid/tach.yml
+++ b/python/tests/example/valid/tach.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.9.1/public/tach-yml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.9.2/public/tach-yml-schema.json
 modules:
   - path: domain_one
     depends_on:

--- a/python/tests/test_parsing.py
+++ b/python/tests/test_parsing.py
@@ -91,10 +91,7 @@ def test_valid_circular_dependencies(example_dir):
 
 def test_cycles_circular_dependencies(example_dir):
     project_config = parse_project_config(example_dir / "cycles")
+    assert project_config
     modules = project_config.modules
-    all_cycles: list[list[str]] = find_modules_with_cycles(modules)
-    tuple_cycles: list[tuple[str]] = [tuple(cycle) for cycle in all_cycles]
-    assert set(tuple_cycles) == {
-        ("domain_one", "domain_two", "domain_three"),
-        ("domain_one", "domain_three"),
-    }
+    module_paths = find_modules_with_cycles(modules)
+    assert set(module_paths) == {"domain_one", "domain_two", "domain_three"}

--- a/python/tests/test_parsing.py
+++ b/python/tests/test_parsing.py
@@ -9,7 +9,7 @@ from tach.constants import DEFAULT_EXCLUDE_PATHS, ROOT_MODULE_SENTINEL_TAG
 from tach.core import Dependency, ModuleConfig, ProjectConfig
 from tach.core.config import CacheConfig
 from tach.filesystem import file_to_module_path
-from tach.parsing import find_cycles, parse_project_config
+from tach.parsing import find_modules_with_cycles, parse_project_config
 
 
 @pytest.fixture
@@ -83,15 +83,16 @@ def test_empty_project_config(example_dir):
 
 def test_valid_circular_dependencies(example_dir):
     project_config = parse_project_config(example_dir / "valid")
+    assert project_config
     modules = project_config.modules
-    all_cycles: list[list[str]] = find_cycles(modules)
-    assert all_cycles == []
+    modules_with_cycles = find_modules_with_cycles(modules)
+    assert modules_with_cycles == []
 
 
 def test_cycles_circular_dependencies(example_dir):
     project_config = parse_project_config(example_dir / "cycles")
     modules = project_config.modules
-    all_cycles: list[list[str]] = find_cycles(modules)
+    all_cycles: list[list[str]] = find_modules_with_cycles(modules)
     tuple_cycles: list[tuple[str]] = [tuple(cycle) for cycle in all_cycles]
     assert set(tuple_cycles) == {
         ("domain_one", "domain_two", "domain_three"),

--- a/tach.yml
+++ b/tach.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.9.1/public/tach-yml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/gauge-sh/tach/v0.9.2/public/tach-yml-schema.json
 modules:
   - path: tach
     depends_on: []


### PR DESCRIPTION
Detecting and printing all cycles is an unsafely bound operation on large repositories. 

Because of this, we are reducing the scope of `forbid_circular_dependencies` to just detect if _any_ cycle exists for each module in your tach.yml.

In the future, we may introduce tooling around exposing the _first found_ cycle for a given module.