### PR TITLE
Add report-external command

### DIFF
--- a/docs/usage/commands.mdx
+++ b/docs/usage/commands.mdx
@@ -168,6 +168,14 @@ This command also takes advantage of Tach's [computation cache](caching).
 ## tach check-external
 
 Tach can validate that the external imports in your Python packages match your declared package dependencies in `pyproject.toml`.
+```bash
+usage: tach check-external [-h]
+
+Perform checks related to third-party dependencies
+
+options:
+  -h, --help  show this help message and exit
+```
 
 For each `pyproject.toml` found from the project root, Tach will scan all imports in the associated Python source and compare them with the declared dependencies.
 Tach will report an error for any external import which is not satisfied by the declared dependencies - preventing your users from errors due to missing imports.
@@ -181,14 +189,42 @@ In case you would like to explicitly allow a certain external module, this can b
 
 <Note>It is recommended to run Tach within a virtual environment containing all of your dependencies across all packages. This is because Tach uses the distribution metadata to map module names like 'git' to their distributions ('GitPython').</Note>
 
-```bash
-usage: tach check-external [-h]
 
-Perform checks related to third-party dependencies
+
+## tach report-external
+
+Tach can determine what external packages are used in a given path in your project.
+```bash
+usage: tach report-external [-h] [--raw] path
+
+Create a report of third-party dependencies.
+
+positional arguments:
+  path        The path or directory path used to generate the report.
 
 options:
   -h, --help  show this help message and exit
+  --raw       Print machine-readable raw output. Each line will contain a PEP 508 dependency string.
 ```
+
+This is typically useful for 'tree-shaking' during a build process.
+For example, if you are building a deployable image with only a subset of your code, you would run:
+
+```bash
+> tach report-external --raw [source_path]
+pyyaml
+pydantic
+stdlib-list
+importlib-metadata
+gitpython
+prompt-toolkit
+networkx
+rich
+```
+
+to generate a minimal set of external dependencies for that source code.
+
+<Note>It is recommended to run Tach within a virtual environment containing all of your dependencies across all packages. This is because Tach uses the distribution metadata to map module names like 'git' to their distributions ('GitPython').</Note>
 
 
 

--- a/python/tach/check_external.py
+++ b/python/tach/check_external.py
@@ -1,86 +1,15 @@
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from tach.extension import check_external_dependencies, set_excluded_paths
+from tach.utils.external import get_module_mappings, is_stdlib_module
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from tach.core.config import ProjectConfig
-
-
-KNOWN_MODULE_SPECIAL_CASES = {
-    "__future__",
-    "typing_extensions",
-}
-
-
-def is_stdlib_module(module: str) -> bool:
-    if module in KNOWN_MODULE_SPECIAL_CASES:
-        return True
-
-    if sys.version_info >= (3, 10):
-        if module in sys.builtin_module_names:
-            return True
-        if module in sys.stdlib_module_names:
-            return True
-        return False
-    else:
-        from stdlib_list import in_stdlib  # type: ignore
-
-        return in_stdlib(module)  # type: ignore
-
-
-def get_installed_modules(dist: Any) -> list[str]:
-    # This method is best-effort, and is only used for Python < 3.10
-    module_names: set[str] = set()
-
-    # Method 1: Check top_level.txt
-    try:
-        top_level = dist.read_text("top_level.txt")
-        if top_level:
-            module_names.update(top_level.strip().split())
-    except Exception:
-        pass
-
-    # Method 2: Parse RECORD file
-    try:
-        record = dist.read_text("RECORD")
-        if record:
-            module_names.update(
-                line.split(",")[0].split("/")[0]
-                for line in record.splitlines()
-                if "/" in line and not line.startswith("__")
-            )
-    except Exception:
-        pass
-
-    # Method 3: Check entry points
-    for ep in dist.entry_points:
-        if "." in ep.value:
-            module_names.add(ep.value.split(":")[0])
-
-    return list(module_names)
-
-
-def get_module_mappings() -> dict[str, list[str]]:
-    if sys.version_info >= (3, 10):
-        from importlib.metadata import packages_distributions
-
-        return packages_distributions()  # type: ignore
-    else:
-        if sys.version_info >= (3, 8):  # noqa: UP036
-            from importlib.metadata import distributions
-        else:
-            from importlib_metadata import distributions  # type: ignore
-
-        return {
-            dist.metadata["Name"]: get_installed_modules(dist)
-            for dist in distributions()
-        }
 
 
 @dataclass

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -4,6 +4,17 @@ def get_project_imports(
     file_path: str,
     ignore_type_checking_imports: bool,
 ) -> list[tuple[str, int]]: ...
+def get_external_imports(
+    project_root: str,
+    source_roots: list[str],
+    file_path: str,
+    ignore_type_checking_imports: bool,
+) -> list[tuple[str, int]]: ...
+def get_normalized_imports(
+    source_roots: list[str],
+    file_path: str,
+    ignore_type_checking_imports: bool,
+) -> list[tuple[str, int]]: ...
 def set_excluded_paths(project_root: str, exclude_paths: list[str]) -> None: ...
 def check_external_dependencies(
     project_root: str,

--- a/python/tach/report.py
+++ b/python/tach/report.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tach import errors
-from tach.extension import create_dependency_report, set_excluded_paths
+from tach.colors import BCOLORS
+from tach.extension import (
+    create_dependency_report,
+    get_external_imports,
+    set_excluded_paths,
+)
+from tach.filesystem import walk_pyfiles
+from tach.utils.display import create_clickable_link
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from tach.core import ProjectConfig
 
 
@@ -54,4 +62,130 @@ def report(
     )
 
 
-__all__ = ["report"]
+@dataclass
+class ExternalDependency:
+    absolute_file_path: Path
+    import_module_path: str
+    import_line_number: int
+    package_name: str
+
+
+def render_external_dependency(
+    dependency: ExternalDependency, display_path: Path
+) -> str:
+    clickable_link = create_clickable_link(
+        file_path=dependency.absolute_file_path,
+        display_path=display_path,
+        line=dependency.import_line_number,
+    )
+    return (
+        f"{BCOLORS.OKGREEN}{clickable_link}{BCOLORS.ENDC}{BCOLORS.OKCYAN}: "
+        f"Import '{dependency.import_module_path}' from package '{dependency.package_name}'{BCOLORS.ENDC}"
+    )
+
+
+def render_external_dependency_report(
+    path: Path, dependencies: list[ExternalDependency], raw: bool = False
+) -> str:
+    if raw:
+        return "\n".join(dependency.package_name for dependency in dependencies)
+
+    title = f"[ External Dependencies in '{path}' ]"
+    divider = "-" * len(title)
+    lines = [title, divider]
+
+    if not dependencies:
+        lines.append(f"{BCOLORS.OKGREEN}No external dependencies found.{BCOLORS.ENDC}")
+        return "\n".join(lines)
+
+    for dependency in dependencies:
+        lines.append(
+            render_external_dependency(dependency=dependency, display_path=path)
+        )
+
+    return "\n".join(lines)
+
+
+PYPI_PACKAGE_REGEX = re.compile(r"[-_.]+")
+
+
+def normalize_package_name(import_module_path: str) -> str:
+    package_name = import_module_path.split(".")[0]
+    return PYPI_PACKAGE_REGEX.sub("-", package_name).lower()
+
+
+def get_external_dependencies(
+    project_root: str,
+    source_roots: list[str],
+    file_path: str,
+    ignore_type_checking_imports: bool,
+) -> list[ExternalDependency]:
+    external_imports = get_external_imports(
+        project_root=project_root,
+        source_roots=source_roots,
+        file_path=file_path,
+        ignore_type_checking_imports=ignore_type_checking_imports,
+    )
+    return [
+        ExternalDependency(
+            absolute_file_path=Path(file_path),
+            import_module_path=external_import[0],
+            import_line_number=external_import[1],
+            package_name=normalize_package_name(external_import[0]),
+        )
+        for external_import in external_imports
+    ]
+
+
+def external_dependency_report(
+    project_root: Path,
+    path: Path,
+    project_config: ProjectConfig,
+    raw: bool = False,
+    exclude_paths: list[str] | None = None,
+) -> str:
+    if not project_root.is_dir():
+        raise errors.TachSetupError(
+            f"The path '{project_root}' is not a valid directory."
+        )
+
+    if not path.exists():
+        raise errors.TachError(f"The path '{path}' does not exist.")
+
+    if exclude_paths is not None and project_config.exclude is not None:
+        exclude_paths.extend(project_config.exclude)
+    else:
+        exclude_paths = project_config.exclude
+
+    # This informs the Rust extension ahead-of-time which paths are excluded.
+    set_excluded_paths(
+        project_root=str(project_root), exclude_paths=exclude_paths or []
+    )
+    source_roots = [
+        str(project_root / source_root) for source_root in project_config.source_roots
+    ]
+
+    if path.is_file():
+        external_dependencies = get_external_dependencies(
+            project_root=str(project_root),
+            source_roots=source_roots,
+            file_path=str(path.resolve()),
+            ignore_type_checking_imports=project_config.ignore_type_checking_imports,
+        )
+        return render_external_dependency_report(path, external_dependencies, raw=raw)
+
+    all_external_dependencies: list[ExternalDependency] = []
+    for pyfile in walk_pyfiles(path):
+        all_external_dependencies.extend(
+            get_external_dependencies(
+                project_root=str(project_root),
+                source_roots=source_roots,
+                file_path=str(path / pyfile),
+                ignore_type_checking_imports=project_config.ignore_type_checking_imports,
+            )
+        )
+
+    return render_external_dependency_report(path, all_external_dependencies, raw=raw)
+
+
+__all__ = ["report", "external_dependency_report"]

--- a/python/tach/report.py
+++ b/python/tach/report.py
@@ -92,6 +92,8 @@ def render_external_dependency_report(
     path: Path, dependencies: list[ExternalDependency], raw: bool = False
 ) -> str:
     if not dependencies:
+        if raw:
+            return ""
         return f"{BCOLORS.OKCYAN}No external dependencies found in {BCOLORS.ENDC}{BCOLORS.OKGREEN}'{path}'.{BCOLORS.ENDC}"
 
     if raw:

--- a/python/tach/utils/display.py
+++ b/python/tach/utils/display.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from enum import Enum
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TerminalEnvironment(Enum):
+    UNKNOWN = 1
+    JETBRAINS = 2
+    VSCODE = 3
+
+
+@lru_cache(maxsize=None)
+def detect_environment() -> TerminalEnvironment:
+    if "jetbrains" in os.environ.get("TERMINAL_EMULATOR", "").lower():
+        return TerminalEnvironment.JETBRAINS
+    elif "vscode" in os.environ.get("TERM_PROGRAM", "").lower():
+        return TerminalEnvironment.VSCODE
+    return TerminalEnvironment.UNKNOWN
+
+
+def create_clickable_link(
+    file_path: Path, display_path: Path | None = None, line: int | None = None
+) -> str:
+    terminal_env = detect_environment()
+    abs_path = file_path.resolve()
+
+    if terminal_env == TerminalEnvironment.JETBRAINS:
+        link = f"file://{abs_path}:{line}" if line is not None else f"file://{abs_path}"
+    elif terminal_env == TerminalEnvironment.VSCODE:
+        link = (
+            f"vscode://file/{abs_path}:{line}"
+            if line is not None
+            else f"vscode://file/{abs_path}"
+        )
+    else:
+        # For generic terminals, use a standard file link
+        link = f"file://{abs_path}"
+
+    # ANSI escape codes for clickable link
+    if line:
+        # Show the line number if we have it
+        display_file_path = f"{display_path or file_path}[L{line}]"
+    else:
+        display_file_path = str(display_path) if display_path else str(file_path)
+    clickable_link = f"\033]8;;{link}\033\\{display_file_path}\033]8;;\033\\"
+    return clickable_link

--- a/python/tach/utils/external.py
+++ b/python/tach/utils/external.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+KNOWN_MODULE_SPECIAL_CASES = {
+    "__future__",
+    "typing_extensions",
+}
+
+
+def is_stdlib_module(module: str) -> bool:
+    if module in KNOWN_MODULE_SPECIAL_CASES:
+        return True
+
+    if sys.version_info >= (3, 10):
+        if module in sys.builtin_module_names:
+            return True
+        if module in sys.stdlib_module_names:
+            return True
+        return False
+    else:
+        from stdlib_list import in_stdlib  # type: ignore
+
+        return in_stdlib(module)  # type: ignore
+
+
+def get_installed_modules(dist: Any) -> list[str]:
+    # This method is best-effort, and is only used for Python < 3.10
+    module_names: set[str] = set()
+
+    # Method 1: Check top_level.txt
+    try:
+        top_level = dist.read_text("top_level.txt")
+        if top_level:
+            module_names.update(top_level.strip().split())
+    except Exception:
+        pass
+
+    # Method 2: Parse RECORD file
+    try:
+        record = dist.read_text("RECORD")
+        if record:
+            module_names.update(
+                line.split(",")[0].split("/")[0]
+                for line in record.splitlines()
+                if "/" in line and not line.startswith("__")
+            )
+    except Exception:
+        pass
+
+    # Method 3: Check entry points
+    for ep in dist.entry_points:
+        if "." in ep.value:
+            module_names.add(ep.value.split(":")[0])
+
+    return list(module_names)
+
+
+def get_module_mappings() -> dict[str, list[str]]:
+    if sys.version_info >= (3, 10):
+        from importlib.metadata import packages_distributions
+
+        return packages_distributions()  # type: ignore
+    else:
+        if sys.version_info >= (3, 8):  # noqa: UP036
+            from importlib.metadata import distributions
+        else:
+            from importlib_metadata import distributions  # type: ignore
+
+        return {
+            dist.metadata["Name"]: get_installed_modules(dist)
+            for dist in distributions()
+        }

--- a/python/tests/test_report_external.py
+++ b/python/tests/test_report_external.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from tach.core.config import ProjectConfig
+from tach.report import external_dependency_report
+
+
+@pytest.fixture
+def project_config():
+    return ProjectConfig(
+        source_roots=[
+            "src/pack-a/src",
+            "src/pack-b/src",
+            "src/pack-c/src",
+            "src/pack-d/src",
+            "src/pack-e/src",
+            "src/pack-f/src",
+            "src/pack-g/src",
+        ],
+        ignore_type_checking_imports=True,
+    )
+
+
+@pytest.fixture
+def module_mapping(mocker):
+    mock = Mock(return_value={"git": ["gitpython"]})
+    mocker.patch("tach.utils.external.get_module_mappings", mock)
+
+
+def test_report_multi_package_example(example_dir, project_config, module_mapping):
+    project_root = example_dir / "multi_package"
+    result = external_dependency_report(
+        project_root=project_root,
+        project_config=project_config,
+        path=project_root / "src/pack-a/src/myorg/pack_a/__init__.py",
+    )
+    assert "gitpython" in result
+
+
+def test_report_empty_multi_package_example(
+    example_dir, project_config, module_mapping
+):
+    project_root = example_dir / "multi_package"
+    result = external_dependency_report(
+        project_root=project_root,
+        project_config=project_config,
+        path=project_root / "src/pack-b/src/myorg/pack_b/__init__.py",
+    )
+    assert "No external dependencies" in result
+
+
+def test_report_raw_multi_package_example(example_dir, project_config, module_mapping):
+    project_root = example_dir / "multi_package"
+    result = external_dependency_report(
+        project_root=project_root,
+        project_config=project_config,
+        path=project_root / "src/pack-a/src/myorg/pack_a/__init__.py",
+        raw=True,
+    )
+    assert result == "gitpython"
+
+
+def test_report_empty_raw_multi_package_example(
+    example_dir, project_config, module_mapping
+):
+    project_root = example_dir / "multi_package"
+    result = external_dependency_report(
+        project_root=project_root,
+        project_config=project_config,
+        path=project_root / "src/pack-b/src/myorg/pack_b/__init__.py",
+        raw=True,
+    )
+    assert result == ""

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ fn get_normalized_imports(
     imports::get_normalized_imports(&source_roots, &file_path, ignore_type_checking_imports)
 }
 
-/// Get first-party imports from file_path relative to project_root
+/// Get first-party imports from file_path
 #[pyfunction]
 #[pyo3(signature = (project_root, source_roots, file_path, ignore_type_checking_imports=false))]
 fn get_project_imports(
@@ -85,7 +85,7 @@ fn get_project_imports(
     )
 }
 
-/// Get first-party imports from file_path relative to project_root
+/// Get third-party imports from file_path
 #[pyfunction]
 #[pyo3(signature = (project_root, source_roots, file_path, ignore_type_checking_imports=false))]
 fn get_external_imports(

--- a/tach.yml
+++ b/tach.yml
@@ -22,6 +22,7 @@ modules:
   - path: tach.check_external
     depends_on:
       - path: tach.extension
+      - path: tach.utils
   - path: tach.cli
     depends_on:
       - path: tach
@@ -41,6 +42,7 @@ modules:
       - path: tach.show
       - path: tach.sync
       - path: tach.test
+      - path: tach.utils
     strict: true
   - path: tach.colors
     depends_on: []
@@ -102,8 +104,11 @@ modules:
     strict: true
   - path: tach.report
     depends_on:
+      - path: tach.colors
       - path: tach.errors
       - path: tach.extension
+      - path: tach.filesystem
+      - path: tach.utils
     strict: true
   - path: tach.show
     depends_on: []
@@ -128,6 +133,8 @@ modules:
       - path: tach.filesystem.git_ops
       - path: tach.parsing
     strict: true
+  - path: tach.utils
+    depends_on: []
 cache:
   file_dependencies:
     - python/tests/**


### PR DESCRIPTION
cc: @devstein

This PR introduces `report-external`, which detects usages of third-party packages in a given file path. It can also be used with `--raw` to generate machine-readable output suitable for piping into a `requirements.in` during a build process.

Example:
```
> tach report-external --raw python/tach
pyyaml
pydantic
stdlib-list
importlib-metadata
gitpython
prompt-toolkit
networkx
rich
```