### PR TITLE
Major Change: Support file globbing in exclude_paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1398,7 @@ version = "0.9.3"
 dependencies = [
  "cached",
  "criterion",
+ "glob",
  "globset",
  "once_cell",
  "pprof",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ cached = { version = "0.53.1", features = ["disk_store"] }
 globset = "0.4.14"
 toml = "0.8.19"
 thiserror = "1.0.63"
+glob = "0.3.1"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -10,7 +10,7 @@ This is the project-level configuration file which should be in the root of your
 
 `modules` defines the modules in your project, and accepts the keys described [below](#modules).
 
-`exclude` accepts a list of directory patterns to exclude from checking. These are treated as regex patterns which match from the beginning of a given file path. For example: `project/.*tests` would match any path beginning with `project/` and ending with `tests`.
+`exclude` accepts a list of directory patterns to exclude from checking. These are treated as glob paths which match from the beginning of a given file path. For example: `project/*.tests` would match any path beginning with `project/` and ending with `.tests`.
 
 `ignore_type_checking_imports` is a boolean which, when enabled, silences `tach check` failures caused by imports under a `TYPE_CHECKING` conditional block
 

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -190,7 +190,7 @@ def check(
 
     found_at_least_one_project_import = False
     # This informs the Rust extension ahead-of-time which paths are excluded.
-    # The extension builds regexes and uses them during `get_project_imports`
+    # The extension builds glob patterns and uses them during `get_project_imports`
     set_excluded_paths(
         project_root=str(project_root), exclude_paths=exclude_paths or []
     )

--- a/python/tach/check.py
+++ b/python/tach/check.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import re
+import fnmatch
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -147,9 +147,8 @@ class CheckResult:
 
 
 def is_path_excluded(path: Path, exclude_paths: list[str]) -> bool:
-    dirpath_for_matching = f"{path}/"
     return any(
-        re.match(exclude_path, dirpath_for_matching) for exclude_path in exclude_paths
+        fnmatch.fnmatch(str(path), exclude_path) for exclude_path in exclude_paths
     )
 
 

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -863,7 +863,6 @@ def main() -> None:
             f" ({__version__} -> {latest_version}). Upgrade to remove this warning.{BCOLORS.ENDC}"
         )
 
-    # TODO: rename throughout to 'exclude_patterns' to indicate that these are regex patterns
     exclude_paths = args.exclude.split(",") if getattr(args, "exclude", None) else None
 
     if args.command == "mod":

--- a/python/tach/constants/__init__.py
+++ b/python/tach/constants/__init__.py
@@ -9,7 +9,13 @@ TACH_YML_SCHEMA_URL = (
     "https://raw.githubusercontent.com/gauge-sh/tach/v0.9.3/public/tach-yml-schema.json"
 )
 
-DEFAULT_EXCLUDE_PATHS = ["tests", "docs", "venv", ".*__pycache__", ".*egg-info"]
+DEFAULT_EXCLUDE_PATHS = [
+    "**/tests/**",
+    "**/docs/**",
+    "**/venv/**",
+    "**/__pycache__/**",
+    "**/*egg-info/**",
+]
 
 __all__ = [
     "PACKAGE_NAME",

--- a/python/tests/example/cycles/tach.yml
+++ b/python/tests/example/cycles/tach.yml
@@ -12,12 +12,6 @@ modules:
   - path: leftover
     depends_on:
       - path: domain_one
-exclude:
-  - .*__pycache__
-  - .*egg-info
-  - docs
-  - tests
-  - venv
 source_roots:
   - .
 forbid_circular_dependencies: true

--- a/python/tests/example/monorepo/tach.yml
+++ b/python/tests/example/monorepo/tach.yml
@@ -14,12 +14,6 @@ modules:
       - path: myorg.utilpkg
   - path: myorg.utilpkg
     depends_on: []
-exclude:
-  - .*__pycache__
-  - .*egg-info
-  - docs
-  - tests
-  - venv
 source_roots:
   - backend
   - utils

--- a/python/tests/example/multi_package/tach.yml
+++ b/python/tests/example/multi_package/tach.yml
@@ -14,12 +14,6 @@ modules:
     depends_on: []
   - path: myorg.pack_g
     depends_on: []
-exclude:
-  - .*__pycache__
-  - .*egg-info
-  - docs
-  - tests
-  - venv
 source_roots:
   - src/pack-a/src
   - src/pack-b/src

--- a/python/tests/example/valid/tach.yml
+++ b/python/tests/example/valid/tach.yml
@@ -12,11 +12,5 @@ modules:
   - path: <root>
     depends_on:
       - path: domain_one
-exclude:
-  - .*__pycache__
-  - .*egg-info
-  - docs
-  - tests
-  - venv
 exact: true
 forbid_circular_dependencies: true

--- a/python/tests/test_parsing.py
+++ b/python/tests/test_parsing.py
@@ -62,7 +62,7 @@ def test_parse_valid_project_config(example_dir):
             ),
         ],
         cache=CacheConfig(backend="local", file_dependencies=[], env_dependencies=[]),
-        exclude=sorted(DEFAULT_EXCLUDE_PATHS),
+        exclude=DEFAULT_EXCLUDE_PATHS,
         source_roots=[PosixPath(".")],
         exact=True,
         disable_logging=False,

--- a/python/tests/test_sync.py
+++ b/python/tests/test_sync.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import shutil
+import tempfile
+from pathlib import Path
+
 import pytest
 
 from tach.cli import tach_sync
@@ -7,9 +11,14 @@ from tach.cli import tach_sync
 
 def test_valid_example_dir(example_dir, capfd):
     project_root = example_dir / "valid"
-    with pytest.raises(SystemExit) as exc_info:
-        # TODO not a great test, can change the example fs
-        tach_sync(project_root=project_root)
-    assert exc_info.value.code == 0
-    captured = capfd.readouterr()
-    assert "✅" in captured.out  # success state
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_project_root = Path(temp_dir) / "valid"
+        shutil.copytree(project_root, temp_project_root)
+
+        with pytest.raises(SystemExit) as exc_info:
+            tach_sync(project_root=temp_project_root)
+
+        assert exc_info.value.code == 0
+        captured = capfd.readouterr()
+        assert "✅" in captured.out  # success state

--- a/src/exclusion.rs
+++ b/src/exclusion.rs
@@ -1,5 +1,5 @@
-use once_cell::sync::Lazy;
 use glob::{Pattern, PatternError};
+use once_cell::sync::Lazy;
 use std::{
     path::{Path, PathBuf},
     sync::Mutex,

--- a/src/exclusion.rs
+++ b/src/exclusion.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use regex::{Error, Regex};
+use glob::{Pattern, PatternError};
 use std::{
     path::{Path, PathBuf},
     sync::Mutex,
@@ -11,17 +11,17 @@ pub struct PathExclusionError {
 
 pub type Result<T> = std::result::Result<T, PathExclusionError>;
 
-impl From<Error> for PathExclusionError {
-    fn from(_value: Error) -> Self {
+impl From<PatternError> for PathExclusionError {
+    fn from(_value: PatternError) -> Self {
         Self {
-            message: "Failed to build regex patterns for excluded paths".to_string(),
+            message: "Failed to build glob patterns for excluded paths".to_string(),
         }
     }
 }
 
 #[derive(Default)]
 pub struct PathExclusions {
-    regexes: Vec<Regex>,
+    patterns: Vec<Pattern>,
 }
 
 static PATH_EXCLUSIONS_SINGLETON: Lazy<Mutex<Option<PathExclusions>>> =
@@ -45,8 +45,8 @@ pub fn set_excluded_paths(project_root: &Path, exclude_paths: &[PathBuf]) -> Res
 
 impl PathExclusions {
     fn is_path_excluded(&self, path: &str) -> bool {
-        for re in &self.regexes {
-            if re.is_match(path) {
+        for pattern in &self.patterns {
+            if pattern.matches(path) {
                 return true;
             }
         }
@@ -57,11 +57,11 @@ impl PathExclusions {
 impl TryFrom<Vec<PathBuf>> for PathExclusions {
     type Error = PathExclusionError;
     fn try_from(value: Vec<PathBuf>) -> std::result::Result<Self, Self::Error> {
-        let mut regexes: Vec<Regex> = vec![];
+        let mut patterns: Vec<Pattern> = vec![];
         for pattern in value.iter() {
-            regexes.push(Regex::new(pattern.to_str().unwrap())?);
+            patterns.push(Pattern::new(pattern.to_str().unwrap())?);
         }
-        Ok(Self { regexes })
+        Ok(Self { patterns })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ fn get_external_imports(
 }
 
 /// Set excluded paths globally.
-/// This is called separately in order to set up a singleton instance holding regexes,
+/// This is called separately in order to set up a singleton instance holding glob patterns,
 /// since they would be expensive to build for every call.
 #[pyfunction]
 #[pyo3(signature = (project_root, exclude_paths))]

--- a/tach.yml
+++ b/tach.yml
@@ -143,13 +143,10 @@ external:
   exclude:
     - pytest
 exclude:
-  - .*__pycache__
-  - build/
-  - dist/
-  - docs/
-  - python/tests/
-  - tach.egg-info/
-  - venv/
+  - "**/tests/**"
+  - "build/**"
+  - "dist/**"
+  - "docs/**"
 source_roots:
   - python
 exact: true


### PR DESCRIPTION
Fixes: https://github.com/gauge-sh/tach/issues/124

1. This PR updates the code to use glob paths instead of regex patterns for the exclude property.
2. Documentation has been updated accordingly.