### PR TITLE
Locally import slow modules

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -22,7 +22,6 @@ from tach.extension import (
 )
 from tach.filesystem import install_pre_commit
 from tach.logging import LogDataModel, logger
-from tach.mod import mod_edit_interactive
 from tach.parsing import parse_project_config
 from tach.report import external_dependency_report, report
 from tach.show import generate_module_graph_dot_file, generate_show_url
@@ -575,6 +574,9 @@ def tach_mod(
             ),
         },
     )
+    # Local import because prompt_toolkit takes about ~80ms to load
+    from tach.mod import mod_edit_interactive
+
     try:
         project_config = parse_project_config(root=project_root) or ProjectConfig()
         saved_changes, warnings = mod_edit_interactive(

--- a/python/tach/filesystem/git_ops.py
+++ b/python/tach/filesystem/git_ops.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError, Repo
-
 from tach.errors import TachError, TachSetupError
 
 
 def get_changed_files(
     project_root: Path, head: str = "", base: str = "main"
 ) -> list[Path]:
+    # Local import because git-python takes ~80ms to load
+    from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError, Repo
+
     try:
         repo = Repo(project_root, search_parent_directories=True)
     except (InvalidGitRepositoryError, NoSuchPathError):

--- a/python/tach/parsing/modules.py
+++ b/python/tach/parsing/modules.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import networkx as nx
-from networkx import NetworkXNoCycle
-
 from tach.core import ModuleTree
 from tach.errors import TachCircularDependencyError
 from tach.parsing import parse_interface_members
@@ -35,6 +32,10 @@ def canonical_form(cycle: list[str]) -> list[str]:
 def find_modules_with_cycles(
     modules: list[ModuleConfig],
 ) -> list[str]:
+    # Local import because networkx takes about ~100ms to load
+    import networkx as nx
+    from networkx import NetworkXNoCycle
+
     graph = nx.DiGraph()  # type: ignore
     # Add nodes
     for module in modules:

--- a/python/tach/show.py
+++ b/python/tach/show.py
@@ -5,8 +5,6 @@ from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING
 from urllib import error, request
 
-import networkx as nx
-
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -41,6 +39,9 @@ def generate_show_url(project_config: ProjectConfig) -> str | None:
 def generate_module_graph_dot_file(
     project_config: ProjectConfig, output_filepath: Path
 ) -> None:
+    # Local import because networkx takes about ~100ms to load
+    import networkx as nx
+
     graph = nx.DiGraph()  # type: ignore
     # Add nodes
     for module in project_config.modules:


### PR DESCRIPTION
Profiling showed that we were incurring startup latency of:
- ~100ms for networkx
- ~80ms for git-python
- ~80ms for prompt-toolkit

This PR moves these imports so that they are local to the codepaths which actually use them. This means for example that `tach check` doesn't spend time loading git-python or prompt-toolkit, and only optionally pulls in networkx for cycle detection.