### PR TITLE
Improve error message when tach report runs on an exact source root

### DIFF
--- a/python/tach/report.py
+++ b/python/tach/report.py
@@ -48,19 +48,22 @@ def report(
         use_regex_matching=project_config.use_regex_matching,
     )
 
-    return create_dependency_report(
-        project_root=str(project_root),
-        source_roots=[
-            str(project_root / source_root)
-            for source_root in project_config.source_roots
-        ],
-        path=str(path),
-        include_dependency_modules=include_dependency_modules,
-        include_usage_modules=include_usage_modules,
-        skip_dependencies=skip_dependencies,
-        skip_usages=skip_usages,
-        ignore_type_checking_imports=project_config.ignore_type_checking_imports,
-    )
+    try:
+        return create_dependency_report(
+            project_root=str(project_root),
+            source_roots=[
+                str(project_root / source_root)
+                for source_root in project_config.source_roots
+            ],
+            path=str(path),
+            include_dependency_modules=include_dependency_modules,
+            include_usage_modules=include_usage_modules,
+            skip_dependencies=skip_dependencies,
+            skip_usages=skip_usages,
+            ignore_type_checking_imports=project_config.ignore_type_checking_imports,
+        )
+    except ValueError as e:
+        raise errors.TachError(str(e))
 
 
 @dataclass

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -62,6 +62,14 @@ pub fn file_to_module_path(source_roots: &[PathBuf], file_path: &PathBuf) -> Res
     // Get the relative path from the matching root
     let relative_path = file_path.strip_prefix(matching_root)?;
 
+    // If the relative path is empty, return an error
+    // indicating that the path cannot be a source root itself
+    if relative_path.as_os_str().is_empty() {
+        return Err(FileSystemError {
+            message: "Filepath cannot be a source root.".to_string(),
+        });
+    }
+
     // Convert the relative path to a module path
     let mut components: Vec<_> = relative_path
         .parent()


### PR DESCRIPTION
Fixes #274

![image](https://github.com/user-attachments/assets/009116a8-3f4a-4b8b-a432-10f184f1a753)

Given that `tach report` provides a report on usages and dependencies across the boundary of the module, passing the path to an exact source root is an error. There is no content which is considered 'external' to the source root, so there can be no usages or dependencies.

As an example, if I have a source root at `./python`, that means that my Python imports are _relative to_ this path. That is, importing from `./python/a.py` would be done as `import a`. Importing the source root itself is not possible.