### PR TITLE
Fix check-external detecting pyproject.toml in hidden/excluded dirs

### DIFF
--- a/python/tach/constants/__init__.py
+++ b/python/tach/constants/__init__.py
@@ -7,7 +7,7 @@ PACKAGE_FILE_NAME = "package"
 ROOT_MODULE_SENTINEL_TAG = "<root>"
 TACH_YML_SCHEMA_URL = "https://raw.githubusercontent.com/gauge-sh/tach/v0.10.5/public/tach-yml-schema.json"
 
-DEFAULT_EXCLUDE_PATHS = ["tests", "docs", "venv", ".*__pycache__", ".*egg-info"]
+DEFAULT_EXCLUDE_PATHS = ["tests", "docs", ".*__pycache__", ".*egg-info"]
 
 __all__ = [
     "PACKAGE_NAME",

--- a/python/tests/example/valid/tach.toml
+++ b/python/tests/example/valid/tach.toml
@@ -1,7 +1,6 @@
 exclude = [
     'tests',
     'docs',
-    'venv',
     '.*__pycache__',
     '.*egg-info',
     'domain_four',

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -264,6 +264,7 @@ pub fn walk_pyfiles(root: &str) -> impl Iterator<Item = PathBuf> {
 pub fn walk_pyprojects(root: &str) -> impl Iterator<Item = PathBuf> {
     WalkDir::new(root)
         .into_iter()
+        .filter_entry(move |e| !is_hidden(e) && !direntry_is_excluded(e))
         .filter_map(|entry| entry.ok())
         .filter(|entry| entry.file_type().is_file())
         .filter(|entry| entry.file_name() == "pyproject.toml")

--- a/tach.toml
+++ b/tach.toml
@@ -5,7 +5,6 @@ exclude = [
      "docs/**",
      "**/tests/**",
      "tach.egg-info/**",
-     "venv/**",
 ]
 
 use_regex_matching = false


### PR DESCRIPTION
```
>>> tach check-external
Checking /Users/sparsh/Code/rust/tach/python/tests/example/multi_package/src/pack-f/pyproject.toml
Checking /Users/sparsh/Code/rust/tach/python/tests/example/multi_package/src/pack-a/pyproject.toml
Checking /Users/sparsh/Code/rust/tach/python/tests/example/multi_package/src/pack-g/pyproject.toml
Checking /Users/sparsh/Code/rust/tach/python/tests/example/multi_package/src/pack-b/pyproject.toml
Checking /Users/sparsh/Code/rust/tach/python/tests/example/multi_package/src/pack-e/pyproject.toml
Checking /Users/sparsh/Code/rust/tach/python/tests/example/multi_package/src/pack-d/pyproject.toml
Checking /Users/sparsh/Code/rust/tach/python/tests/example/multi_package/src/pack-c/pyproject.toml
Checking /Users/sparsh/Code/rust/tach/pyproject.toml
Checking /Users/sparsh/Code/rust/tach/.venv/lib/python3.12/site-packages/pandas/pyproject.toml
```

(These are the entries in the output of `walk_pyprojects` in `filesystem.rs`)
This resulted in multiple errors in pandas library inside my .venv even though its hidden

After:
```
>>> tach check-external
Checking /Users/sparsh/Code/rust/tach/pyproject.toml
```