### PR TITLE
Fix `source_roots` in JSON schema

### DIFF
--- a/public/tach-yml-schema.json
+++ b/public/tach-yml-schema.json
@@ -92,9 +92,12 @@
       },
       "description": "List of paths to exclude while checking module boundaries"
     },
-    "source_root": {
-      "type": "string",
-      "description": "Root directory for Python source code"
+    "source_roots": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Root directories for Python source code"
     },
     "exact": {
       "type": "boolean",


### PR DESCRIPTION
Hi 👋

Trying out tach for the first time in some personal and work projects and already loving it!

I noticed the JSON schema is outdated, so this PR is a small patch to fix it.

Maybe it's worth doing something like https://github.com/astral-sh/ruff/commit/4888afd423c3d730e7840399d34227e2f4679277 and publish the schema to https://github.com/SchemaStore/schemastore?
