### PR TITLE
Better error handling

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,22 +4,17 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
+use thiserror::Error;
 use toml::Value;
 
 use crate::filesystem::{self, walk_pyfiles};
 
-pub struct CacheError;
-
-impl From<DiskCacheError> for CacheError {
-    fn from(_: DiskCacheError) -> Self {
-        CacheError
-    }
-}
-
-impl From<DiskCacheBuildError> for CacheError {
-    fn from(_: DiskCacheBuildError) -> Self {
-        CacheError
-    }
+#[derive(Error, Debug)]
+pub enum CacheError {
+    #[error("Disk cache error: {0}")]
+    DiskCache(#[from] DiskCacheError),
+    #[error("Disk cache build error: {0}")]
+    DiskCacheBuild(#[from] DiskCacheBuildError),
 }
 
 pub type Result<T> = std::result::Result<T, CacheError>;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::fs;
 use std::io;
 use std::io::Read;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -193,13 +193,9 @@ pub fn module_to_file_path<P: AsRef<Path>>(roots: &[P], mod_path: &str) -> Optio
 }
 
 pub fn read_file_content<P: AsRef<Path>>(path: P) -> Result<String> {
-    let mut file = fs::File::open(path.as_ref()).map_err(|_| {
-        FileSystemError::Other(format!("Could not open path: {}", path.as_ref().display()))
-    })?;
+    let mut file = fs::File::open(path.as_ref())?;
     let mut content = String::new();
-    file.read_to_string(&mut content).map_err(|_| {
-        FileSystemError::Other(format!("Could not read path: {}", path.as_ref().display()))
-    })?;
+    file.read_to_string(&mut content)?;
     Ok(content)
 }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -305,7 +305,10 @@ pub fn get_normalized_imports(
     let file_contents =
         filesystem::read_file_content(file_path).map_err(|err| ImportParseError {
             err_type: ImportParseErrorType::FILESYSTEM,
-            message: format!("Failed to parse project imports. Failure: {}", err.message),
+            message: format!(
+                "Failed to parse project imports. Failure: {}",
+                err.to_string()
+            ),
         })?;
     let file_ast = parse_python_source(&file_contents).map_err(|err| ImportParseError {
         err_type: ImportParseErrorType::PARSING,

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt::{self, Debug};
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
 use pyo3::conversion::IntoPy;

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -11,28 +11,23 @@ use regex::Regex;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::{Expr, Mod, Stmt, StmtIf, StmtImport, StmtImportFrom};
 use ruff_source_file::Locator;
+use thiserror::Error;
 
 use crate::parsing::py_ast::parse_python_source;
-use crate::{exclusion, filesystem};
+use crate::{exclusion, filesystem, parsing};
 
-#[derive(Debug)]
-pub enum ImportParseErrorType {
-    FILESYSTEM,
-    PARSING,
-}
-
-#[derive(Debug)]
-pub struct ImportParseError {
-    pub err_type: ImportParseErrorType,
-    pub message: String,
-}
-
-impl std::error::Error for ImportParseError {}
-
-impl fmt::Display for ImportParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", &self.message)
-    }
+#[derive(Error, Debug)]
+pub enum ImportParseError {
+    #[error("Failed to parse project imports.\nFile: {file}\nFailure: {source}")]
+    Parsing {
+        file: String,
+        #[source]
+        source: parsing::ParsingError,
+    },
+    #[error("Failed to parse project imports.\n{0}")]
+    Filesystem(#[from] filesystem::FileSystemError),
+    #[error("Failed to check if path is excluded.\n{0}")]
+    Exclusion(#[from] exclusion::PathExclusionError),
 }
 
 pub type Result<T> = std::result::Result<T, ImportParseError>;
@@ -283,14 +278,9 @@ pub fn is_project_import<P: AsRef<Path>>(source_roots: &[P], mod_path: &str) -> 
     let resolved_module = filesystem::module_to_file_path(source_roots, mod_path);
     if let Some(module) = resolved_module {
         // This appears to be a project import, verify it is not excluded
-        return match exclusion::is_path_excluded(module.file_path.as_path().to_str().unwrap()) {
-            Ok(true) => Ok(false),
-            Ok(false) => Ok(true),
-            Err(_) => Err(ImportParseError {
-                err_type: ImportParseErrorType::FILESYSTEM,
-                message: "Failed to check if path is excluded".to_string(),
-            }),
-        };
+        Ok(!exclusion::is_path_excluded(
+            module.file_path.as_path().to_str().unwrap(),
+        )?)
     } else {
         // This is not a project import
         Ok(false)
@@ -302,22 +292,12 @@ pub fn get_normalized_imports(
     file_path: &PathBuf,
     ignore_type_checking_imports: bool,
 ) -> Result<NormalizedImports> {
-    let file_contents =
-        filesystem::read_file_content(file_path).map_err(|err| ImportParseError {
-            err_type: ImportParseErrorType::FILESYSTEM,
-            message: format!(
-                "Failed to parse project imports. Failure: {}",
-                err.to_string()
-            ),
+    let file_contents = filesystem::read_file_content(file_path)?;
+    let file_ast =
+        parse_python_source(&file_contents).map_err(|err| ImportParseError::Parsing {
+            file: file_path.to_str().unwrap().to_string(),
+            source: err,
         })?;
-    let file_ast = parse_python_source(&file_contents).map_err(|err| ImportParseError {
-        err_type: ImportParseErrorType::PARSING,
-        message: format!(
-            "Failed to parse project imports. File: {:?} Failure: {:?}",
-            file_path.to_str().unwrap(),
-            err
-        ),
-    })?;
     let is_package = file_path.ends_with("__init__.py");
     let ignore_directives = get_ignore_directives(file_contents.as_str());
     let locator = Locator::new(&file_contents);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,10 @@ impl From<imports::ImportParseError> for PyErr {
 
 impl From<exclusion::PathExclusionError> for PyErr {
     fn from(err: exclusion::PathExclusionError) -> Self {
-        PyValueError::new_err(err.message)
+        match err {
+            exclusion::PathExclusionError::ConcurrencyError => PyOSError::new_err(err.to_string()),
+            _ => PyValueError::new_err(err.to_string()),
+        }
     }
 }
 
@@ -38,19 +41,14 @@ impl From<reports::ReportCreationError> for PyErr {
 }
 
 impl From<cache::CacheError> for PyErr {
-    fn from(_: cache::CacheError) -> Self {
-        PyValueError::new_err("Failure accessing computation cache.")
+    fn from(err: cache::CacheError) -> Self {
+        PyValueError::new_err(err.to_string())
     }
 }
 
 impl From<check::CheckError> for PyErr {
     fn from(err: check::CheckError) -> Self {
-        match err {
-            check::CheckError::Parse(err) => PyOSError::new_err(err.to_string()),
-            check::CheckError::ImportParse(err) => err.into(),
-            check::CheckError::Io(err) => PyOSError::new_err(err.to_string()),
-            check::CheckError::Filesystem(err) => PyOSError::new_err(err.to_string()),
-        }
+        PyOSError::new_err(err.to_string())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,11 @@ use pyo3::prelude::*;
 
 impl From<imports::ImportParseError> for PyErr {
     fn from(err: imports::ImportParseError) -> Self {
-        match err.err_type {
-            imports::ImportParseErrorType::FILESYSTEM => PyOSError::new_err(err.message),
-            imports::ImportParseErrorType::PARSING => PySyntaxError::new_err(err.message),
+        match err {
+            imports::ImportParseError::Parsing { file: _, source: _ } => {
+                PySyntaxError::new_err(err.to_string())
+            }
+            _ => PyOSError::new_err(err.to_string()),
         }
     }
 }
@@ -36,7 +38,7 @@ impl From<exclusion::PathExclusionError> for PyErr {
 
 impl From<reports::ReportCreationError> for PyErr {
     fn from(err: reports::ReportCreationError) -> Self {
-        PyValueError::new_err(err.message)
+        PyValueError::new_err(err.to_string())
     }
 }
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -17,26 +17,20 @@ impl PatternMatcher {
     }
 
     pub fn from_regex(pattern: &str) -> Result<Self, PathExclusionError> {
-        Ok(PatternMatcher::Regex(regex::Regex::new(pattern)?))
+        Ok(PatternMatcher::Regex(regex::Regex::new(pattern).map_err(
+            |e| PathExclusionError::RegexPatternError {
+                exclude: pattern.to_string(),
+                source: e,
+            },
+        )?))
     }
 
     pub fn from_glob(pattern: &str) -> Result<Self, PathExclusionError> {
-        Ok(PatternMatcher::Glob(glob::Pattern::new(pattern)?))
-    }
-}
-
-impl From<glob::PatternError> for PathExclusionError {
-    fn from(_value: glob::PatternError) -> Self {
-        Self {
-            message: "Failed to build glob patterns for excluded paths".to_string(),
-        }
-    }
-}
-
-impl From<regex::Error> for PathExclusionError {
-    fn from(_value: regex::Error) -> Self {
-        Self {
-            message: "Failed to build regex patterns for excluded paths".to_string(),
-        }
+        Ok(PatternMatcher::Glob(glob::Pattern::new(pattern).map_err(
+            |e| PathExclusionError::GlobPatternError {
+                exclude: pattern.to_string(),
+                source: e,
+            },
+        )?))
     }
 }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::fmt::{self, Debug};
+use std::fmt::Debug;
 use std::fs;
 use std::io;
 use std::path::PathBuf;

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -38,7 +38,7 @@ impl From<ImportParseError> for ReportCreationError {
 impl From<FileSystemError> for ReportCreationError {
     fn from(value: FileSystemError) -> Self {
         ReportCreationError {
-            message: value.message,
+            message: value.to_string(),
         }
     }
 }


### PR DESCRIPTION
This PR is to support and prepare #284 for the restructure.
Uses `thiserror` module to restructure and make error handling more consistent.

Also handles a critical bug of infinite recursion and crash due to `err.into()` in Line 50
https://github.com/gauge-sh/tach/blob/b53cb3e45ffe1e428300d45832c4b0311c7c423e/src/lib.rs#L46-L50