### PR TITLE
Add unused dependencies to check-external diagnostics

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -162,13 +162,30 @@ def print_undeclared_dependencies(
     undeclared_dependencies: dict[str, list[str]],
 ) -> None:
     for file_path, dependencies in undeclared_dependencies.items():
-        print(
-            f"❌ {BCOLORS.FAIL}Undeclared dependencies in {BCOLORS.ENDC}{BCOLORS.WARNING}'{file_path}'{BCOLORS.ENDC}:"
-        )
-        for dependency in dependencies:
-            print(f"\t{BCOLORS.FAIL}{dependency}{BCOLORS.ENDC}")
+        if dependencies:
+            print(
+                f"❌ {BCOLORS.FAIL}Undeclared dependencies in {BCOLORS.ENDC}{BCOLORS.WARNING}'{file_path}'{BCOLORS.ENDC}:"
+            )
+            for dependency in dependencies:
+                print(f"\t{BCOLORS.FAIL}{dependency}{BCOLORS.ENDC}")
     print(
         f"{BCOLORS.WARNING}\nAdd the undeclared dependencies to the corresponding pyproject.toml file, "
+        f"or consider ignoring the dependencies by adding them to the 'external.exclude' list in {CONFIG_FILE_NAME}.toml.\n{BCOLORS.ENDC}"
+    )
+
+
+def print_unused_external_dependencies(
+    unused_dependencies: dict[str, list[str]],
+) -> None:
+    for pyproject_path, dependencies in unused_dependencies.items():
+        if dependencies:
+            print(
+                f"! {BCOLORS.WARNING}Unused dependencies from project at {BCOLORS.OKCYAN}'{pyproject_path}'{BCOLORS.ENDC}{BCOLORS.ENDC}:"
+            )
+            for dependency in dependencies:
+                print(f"\t{BCOLORS.WARNING}{dependency}{BCOLORS.ENDC}")
+    print(
+        f"{BCOLORS.OKCYAN}\nRemove the unused dependencies from the corresponding pyproject.toml file, "
         f"or consider ignoring the dependencies by adding them to the 'external.exclude' list in {CONFIG_FILE_NAME}.toml.\n{BCOLORS.ENDC}"
     )
 
@@ -580,6 +597,9 @@ def tach_check_external(project_root: Path, exclude_paths: list[str] | None = No
             project_config=project_config,
             exclude_paths=exclude_paths,
         )
+
+        if result.unused_dependencies:
+            print_unused_external_dependencies(result.unused_dependencies)
 
         if result.undeclared_dependencies:
             print_undeclared_dependencies(result.undeclared_dependencies)

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -23,7 +23,7 @@ def check_external_dependencies(
     source_roots: list[str],
     module_mappings: dict[str, list[str]],
     ignore_type_checking_imports: bool,
-) -> dict[str, list[str]]: ...
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]: ...
 def create_dependency_report(
     project_root: str,
     source_roots: list[str],

--- a/python/tests/example/multi_package/src/pack-a/pyproject.toml
+++ b/python/tests/example/multi_package/src/pack-a/pyproject.toml
@@ -8,13 +8,11 @@ version = "0.0.0"
 license.file = "LICENSE"
 readme = "README.md"
 description = "My organization's A package."
-authors = [
-    { name = "Janice Developer", email = "janice@my.org" },
-]
-dependencies = ["GitPython"]
+authors = [{ name = "Janice Developer", email = "janice@my.org" }]
+dependencies = ["GitPython", "Unused"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include=["myorg.*"]
+include = ["myorg.*"]
 namespaces = true
 exclude = ["test*."]

--- a/python/tests/test_check_external.py
+++ b/python/tests/test_check_external.py
@@ -41,8 +41,11 @@ def test_check_external_dependencies_multi_package_example(
         module_mappings=module_mapping,
         ignore_type_checking_imports=project_config.ignore_type_checking_imports,
     )
-    # Assert no undeclared dependencies
-    assert not result
+    undeclared_deps = result[0]
+    assert not undeclared_deps
+
+    unused_dependency_root = Path("src", "pack-a", "pyproject.toml")
+    assert "unused" in result[1][str(unused_dependency_root)]
 
 
 def test_check_external_dependencies_invalid_multi_package_example(
@@ -55,8 +58,9 @@ def test_check_external_dependencies_invalid_multi_package_example(
         module_mappings={},
         ignore_type_checking_imports=project_config.ignore_type_checking_imports,
     )
+    undeclared_deps = result[0]
     expected_failure_path = Path(
         "src", "pack-a", "src", "myorg", "pack_a", "__init__.py"
     )
-    assert set(result.keys()) == {str(expected_failure_path)}
-    assert set(result[str(expected_failure_path)]) == {"git"}
+    assert set(undeclared_deps.keys()) == {str(expected_failure_path)}
+    assert set(undeclared_deps[str(expected_failure_path)]) == {"git"}

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,3 +1,5 @@
+use pyo3::conversion::IntoPy;
+use pyo3::PyObject;
 use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -22,7 +24,19 @@ pub enum CheckError {
 
 pub type Result<T> = std::result::Result<T, CheckError>;
 
-pub type ExternalCheckDiagnostics = HashMap<String, Vec<String>>;
+#[derive(Default)]
+pub struct ExternalCheckDiagnostics {
+    // Undeclared dependencies by source filepath
+    undeclared_dependencies: HashMap<String, Vec<String>>,
+    // Unused dependencies by project configuration filepath
+    unused_dependencies: HashMap<String, Vec<String>>,
+}
+
+impl IntoPy<PyObject> for ExternalCheckDiagnostics {
+    fn into_py(self, py: pyo3::prelude::Python<'_>) -> PyObject {
+        (self.undeclared_dependencies, self.unused_dependencies).into_py(py)
+    }
+}
 
 pub fn check_external_dependencies(
     project_root: &Path,
@@ -30,9 +44,10 @@ pub fn check_external_dependencies(
     module_mappings: &HashMap<String, Vec<String>>,
     ignore_type_checking_imports: bool,
 ) -> Result<ExternalCheckDiagnostics> {
-    let mut diagnostics: ExternalCheckDiagnostics = HashMap::new();
+    let mut diagnostics = ExternalCheckDiagnostics::default();
     for pyproject in filesystem::walk_pyprojects(project_root.to_str().unwrap()) {
         let project_info = parse_pyproject_toml(&pyproject)?;
+        let mut all_dependencies = project_info.dependencies.clone();
         for source_root in &project_info.source_paths {
             let source_files = filesystem::walk_pyfiles(source_root.to_str().unwrap());
             for file_path in source_files {
@@ -54,19 +69,31 @@ pub fn check_external_dependencies(
                             .iter()
                             .map(|dist_name| normalize_package_name(dist_name))
                             .collect();
+                        for dist_name in distribution_names.iter() {
+                            all_dependencies.remove(dist_name);
+                        }
                         if !imports::is_project_import(source_roots, &import.module_path)?
                             && distribution_names
                                 .iter()
                                 .all(|dist_name| !project_info.dependencies.contains(dist_name))
                         {
-                            let diagnostic =
-                                diagnostics.entry(display_file_path.clone()).or_default();
-                            diagnostic.push(import.top_level_module_name().to_string());
+                            // Found a possible undeclared dependency in this file
+                            let undeclared_dep_entry: &mut Vec<String> = diagnostics
+                                .undeclared_dependencies
+                                .entry(display_file_path.clone())
+                                .or_default();
+                            undeclared_dep_entry.push(top_level_module_name.to_string());
                         }
                     }
                 }
             }
         }
+        diagnostics.unused_dependencies.insert(
+            relative_to(&pyproject, project_root)?
+                .to_string_lossy()
+                .to_string(),
+            all_dependencies.into_iter().collect(),
+        );
     }
 
     Ok(diagnostics)

--- a/tach.toml
+++ b/tach.toml
@@ -198,4 +198,4 @@ depends_on = []
 file_dependencies = ["python/tests/**", "src/*.rs"]
 
 [external]
-exclude = ["pytest"]
+exclude = ["pytest", "pydot", "eval_type_backport"]


### PR DESCRIPTION
Fixes: #294

Adds non-blocking warnings to check-external when it seems like an external dependency is unused.

![image](https://github.com/user-attachments/assets/cae03ff2-3ef6-49a8-a669-36f4c800ceca)
