### PR TITLE
Fix ignore globs

### DIFF
--- a/tach.toml
+++ b/tach.toml
@@ -1,10 +1,10 @@
 exclude = [
-    "**/__pycache__/**",
-    "**/tests/**",
-    "build/**",
-    "dist/**",
-    "docs/**",
-    "tach.egg-info/**",
+    "**/__pycache__",
+    "**/tests",
+    "build",
+    "dist",
+    "docs",
+    "tach.egg-info",
 ]
 source_roots = [
     "python",


### PR DESCRIPTION
`tach mod` was showing directories like `__pycache__` because the glob patterns in `tach.toml` didn't play nicely with `fnmatch`. The trailing slashes were causing matches only on directories, not the underlying files which actually needed to be excluded.