### PR TITLE
Restore `TachCircularDependecyError` pretty print

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -13,9 +13,10 @@ from tach import filesystem as fs
 from tach.check_external import check_external
 from tach.colors import BCOLORS
 from tach.constants import CONFIG_FILE_NAME, TOOL_NAME
-from tach.errors import TachCircularDependencyError, TachError
+from tach.errors import TachError
 from tach.extension import (
     ProjectConfig,
+    TachCircularDependencyError,
     check,
     check_computation_cache,
     create_computation_cache_key,
@@ -549,7 +550,7 @@ def tach_check(
                 exit_code = 1
     except Exception as e:
         if isinstance(e, TachCircularDependencyError):
-            print_circular_dependency_error(e.module_paths)
+            print_circular_dependency_error(e.dependencies)
         else:
             print(str(e))
         sys.exit(1)

--- a/python/tach/errors/__init__.py
+++ b/python/tach/errors/__init__.py
@@ -4,20 +4,10 @@ from __future__ import annotations
 class TachError(Exception): ...
 
 
-class TachParseError(TachError): ...
-
-
 class TachSetupError(TachError): ...
-
-
-class TachCircularDependencyError(TachError):
-    def __init__(self, module_paths: list[str]):
-        self.module_paths = module_paths
 
 
 __all__ = [
     "TachError",
-    "TachParseError",
     "TachSetupError",
-    "TachCircularDependencyError",
 ]

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -71,6 +71,9 @@ def sync_project(
     add: bool = False,
 ) -> str: ...
 
+class TachCircularDependencyError(Exception):
+    dependencies: list[str]
+
 class ErrorInfo:
     def is_dependency_error(self) -> bool: ...
     def to_pystring(self) -> str: ...


### PR DESCRIPTION
Regression introduced during porting to Rust

Before

```
Module tree error: Circular dependency detected: ["domain_one", "domain_two", "domain_three"]
```

After

```
❌ Circular dependency detected for module 'domain_one'
❌ Circular dependency detected for module 'domain_two'
❌ Circular dependency detected for module 'domain_three'

Resolve circular dependencies.
Remove or unset 'forbid_circular_dependencies' from 'tach.toml' to allow circular dependencies.
```