### PR TITLE
Fix 'tach test' in Rust

### DIFF
--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -145,8 +145,8 @@ class ProjectConfig:
     def dump_project_config_to_toml(self, project_config: ProjectConfig) -> str: ...
 
 class TachPytestPluginHandler:
-    removed_test_paths: set[Path]
-    all_affected_modules: set[Path]
+    removed_test_paths: set[str]
+    all_affected_modules: set[str]
     num_removed_items: int
     tests_ran_to_completion: bool
     def __new__(
@@ -156,4 +156,5 @@ class TachPytestPluginHandler:
         changed_files: list[Path],
         all_affected_modules: set[Path],
     ) -> TachPytestPluginHandler: ...
+    def remove_test_path(self, path: Path) -> None: ...
     def should_remove_items(self, file_path: Path) -> bool: ...

--- a/python/tach/test.py
+++ b/python/tach/test.py
@@ -47,14 +47,14 @@ def run_affected_tests(
             for item in copy(items):
                 if not item.path:
                     continue
-                if item.path in self.handler.removed_test_paths:
+                if str(item.path) in self.handler.removed_test_paths:
                     self.handler.num_removed_items += 1
                     items.remove(item)
                     continue
                 if item.path in seen:
                     continue
 
-                if item.path in self.handler.all_affected_modules:
+                if str(item.path) in self.handler.all_affected_modules:
                     # If this test file was changed,
                     # then we know we need to rerun it
                     seen.add(item.path)
@@ -63,7 +63,7 @@ def run_affected_tests(
                 if self.handler.should_remove_items(file_path=item.path.resolve()):
                     self.handler.num_removed_items += 1
                     items.remove(item)
-                    self.handler.removed_test_paths.add(item.path)
+                    self.handler.remove_test_path(item.path)
 
                 seen.add(item.path)
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -77,6 +77,10 @@ impl TachPytestPluginHandler {
         }
     }
 
+    pub fn remove_test_path(&mut self, file_path: PathBuf) {
+        self.removed_test_paths.insert(file_path);
+    }
+
     pub fn should_remove_items(&self, file_path: PathBuf) -> bool {
         // TODO: Remove unwrap
         let project_imports = get_project_imports(&self.source_roots, &file_path, true).unwrap();


### PR DESCRIPTION
Fields within the Rust version of the pytest plugin were not actually being updated, and the return type of getting its fields were strings, not Paths (which broke comparison).