### PR TITLE
Fix excludes on Windows

### DIFF
--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from tach.extension import get_project_imports
+from tach.constants import DEFAULT_EXCLUDE_PATHS
+from tach.extension import get_project_imports, set_excluded_paths
 
 
 # Utility function to create temporary files with content
@@ -21,6 +22,11 @@ def create_temp_file(directory, filename, content):
 def temp_project():
     with tempfile.TemporaryDirectory() as project_root:
         project_root = Path(project_root)
+        # This is tech debt!!
+        set_excluded_paths(
+            str(project_root), DEFAULT_EXCLUDE_PATHS, use_regex_matching=True
+        )
+
         # Creating some sample Python files in a nested structure
         (project_root / "a" / "b").mkdir(parents=True, exist_ok=True)
         (project_root / "d").mkdir(parents=True, exist_ok=True)

--- a/src/check_int.rs
+++ b/src/check_int.rs
@@ -266,7 +266,7 @@ pub fn check(
     for source_root in &source_roots {
         for file_path in fs::walk_pyfiles(&source_root.display().to_string()) {
             let abs_file_path = &source_root.join(&file_path);
-            if is_path_excluded(&abs_file_path.display().to_string())? {
+            if is_path_excluded(abs_file_path)? {
                 continue;
             }
             let mod_path = fs::file_to_module_path(&source_roots, abs_file_path)?;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -192,7 +192,7 @@ fn is_hidden(entry: &DirEntry) -> bool {
 }
 
 fn direntry_is_excluded(entry: &DirEntry) -> bool {
-    is_path_excluded(entry.path().to_str().unwrap()).unwrap_or(false)
+    is_path_excluded(entry.path()).unwrap_or(false)
 }
 
 fn is_pyfile_or_dir(entry: &DirEntry) -> bool {

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -281,9 +281,7 @@ pub fn is_project_import<P: AsRef<Path>>(source_roots: &[P], mod_path: &str) -> 
     let resolved_module = filesystem::module_to_file_path(source_roots, mod_path, true);
     if let Some(module) = resolved_module {
         // This appears to be a project import, verify it is not excluded
-        Ok(!exclusion::is_path_excluded(
-            module.file_path.as_path().to_str().unwrap(),
-        )?)
+        Ok(!exclusion::is_path_excluded(module.file_path)?)
     } else {
         // This is not a project import
         Ok(false)


### PR DESCRIPTION
Fixes: #326 

This fixes Tach on Windows by using forward slashes as the canonical form in exclude patterns.

More specifically, checking exclude patterns will now always use paths with forward slash separators, which also means users should always use forward slashes in the exclude patterns themselves.