### PR TITLE
Add 'visibility' configuration

### DIFF
--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -100,6 +100,7 @@ class DependencyConfig:
 class ModuleConfig:
     path: str
     depends_on: list[DependencyConfig]
+    visibility: list[str]
     strict: bool
 
     @staticmethod

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -71,8 +71,11 @@ def sync_project(
     add: bool = False,
 ) -> str: ...
 
-class TachCircularDependencyError(Exception):
+class TachCircularDependencyError(ValueError):
     dependencies: list[str]
+
+class TachVisibilityError(ValueError):
+    visibility_errors: list[tuple[str, str, list[str]]]
 
 class ErrorInfo:
     def is_dependency_error(self) -> bool: ...

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -20,8 +20,12 @@ fn default_excludes() -> Vec<String> {
         .collect()
 }
 
-fn default_visibility() -> Vec<String> {
+pub fn global_visibility() -> Vec<String> {
     vec!["*".to_string()]
+}
+
+fn default_visibility() -> Vec<String> {
+    global_visibility()
 }
 
 fn is_default_visibility(value: &Vec<String>) -> bool {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -20,6 +20,14 @@ fn default_excludes() -> Vec<String> {
         .collect()
 }
 
+fn default_visibility() -> Vec<String> {
+    vec!["*".to_string()]
+}
+
+fn is_default_visibility(value: &Vec<String>) -> bool {
+    value == &default_visibility()
+}
+
 fn is_true(value: &bool) -> bool {
     *value
 }
@@ -42,7 +50,7 @@ impl DependencyConfig {
             deprecated: true,
         }
     }
-    pub fn from_undeprecated_path(path: impl Into<String>) -> Self {
+    pub fn from_path(path: impl Into<String>) -> Self {
         Self {
             path: path.into(),
             deprecated: false,
@@ -50,14 +58,30 @@ impl DependencyConfig {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[pyclass(get_all, eq, module = "tach.extension")]
 pub struct ModuleConfig {
     pub path: String,
     #[serde(default)]
     pub depends_on: Vec<DependencyConfig>,
+    #[serde(
+        default = "default_visibility",
+        skip_serializing_if = "is_default_visibility"
+    )]
+    pub visibility: Vec<String>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub strict: bool,
+}
+
+impl Default for ModuleConfig {
+    fn default() -> Self {
+        Self {
+            path: String::default(),
+            depends_on: Vec::default(),
+            visibility: default_visibility(),
+            strict: false,
+        }
+    }
 }
 
 #[pymethods]
@@ -67,6 +91,7 @@ impl ModuleConfig {
         Self {
             path: path.to_string(),
             depends_on: vec![],
+            visibility: default_visibility(),
             strict,
         }
     }

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -58,21 +58,25 @@ mod tests {
                         path: "domain_one".to_string(),
                         depends_on: vec![DependencyConfig::from_deprecated_path("domain_two")],
                         strict: false,
+                        ..Default::default()
                     },
                     ModuleConfig {
                         path: "domain_three".to_string(),
                         depends_on: vec![],
                         strict: false,
+                        ..Default::default()
                     },
                     ModuleConfig {
                         path: "domain_two".to_string(),
-                        depends_on: vec![DependencyConfig::from_undeprecated_path("domain_three")],
+                        depends_on: vec![DependencyConfig::from_path("domain_three")],
                         strict: false,
+                        ..Default::default()
                     },
                     ModuleConfig {
                         path: ROOT_MODULE_SENTINEL_TAG.to_string(),
-                        depends_on: vec![DependencyConfig::from_undeprecated_path("domain_one")],
+                        depends_on: vec![DependencyConfig::from_path("domain_one")],
                         strict: false,
+                        ..Default::default()
                     }
                 ],
                 cache: CacheConfig::default(),

--- a/src/parsing/error.rs
+++ b/src/parsing/error.rs
@@ -2,6 +2,8 @@ use std::io;
 use thiserror::Error;
 
 use crate::filesystem::FileSystemError;
+use pyo3::conversion::IntoPy;
+use pyo3::PyObject;
 use ruff_python_parser::ParseError;
 
 #[derive(Error, Debug)]
@@ -20,12 +22,32 @@ pub enum ParsingError {
 
 pub type Result<T> = std::result::Result<T, ParsingError>;
 
+#[derive(Debug, Clone)]
+pub struct VisibilityErrorInfo {
+    pub dependent_module: String,
+    pub dependency_module: String,
+    pub visibility: Vec<String>,
+}
+
+impl IntoPy<PyObject> for VisibilityErrorInfo {
+    fn into_py(self, py: pyo3::prelude::Python<'_>) -> PyObject {
+        (
+            self.dependent_module,
+            self.dependency_module,
+            self.visibility,
+        )
+            .into_py(py)
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ModuleTreeError {
     #[error(
         "Failed to build module tree. The following modules were defined more than once: {0:?}"
     )]
     DuplicateModules(Vec<String>),
+    #[error("Module configuration error: Visibility configuration conflicts with dependency configuration.")]
+    VisibilityViolation(Vec<VisibilityErrorInfo>),
     #[error("Circular dependency detected: {0:?}")]
     CircularDependency(Vec<String>),
     #[error("Parsing Error while building module tree.\n{0}")]

--- a/src/tests/check_int.rs
+++ b/src/tests/check_int.rs
@@ -26,9 +26,10 @@ pub mod fixtures {
                                 path: "domain_one".to_string(),
                                 depends_on: vec![
                                     DependencyConfig::from_deprecated_path("domain_one.subdomain"),
-                                    DependencyConfig::from_undeprecated_path("domain_three"),
+                                    DependencyConfig::from_path("domain_three"),
                                 ],
                                 strict: true,
+                                ..Default::default()
                             }),
                             interface_members: vec!["public_fn".to_string()],
                             children: HashMap::from([(
@@ -50,10 +51,9 @@ pub mod fixtures {
                             full_path: "domain_two".to_string(),
                             config: Some(ModuleConfig {
                                 path: "domain_two".to_string(),
-                                depends_on: vec![DependencyConfig::from_undeprecated_path(
-                                    "domain_one",
-                                )],
+                                depends_on: vec![DependencyConfig::from_path("domain_one")],
                                 strict: false,
+                                ..Default::default()
                             }),
                             interface_members: vec![],
                             children: HashMap::from([(
@@ -63,10 +63,9 @@ pub mod fixtures {
                                     full_path: "domain_two.subdomain".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "domain_two".to_string(),
-                                        depends_on: vec![DependencyConfig::from_undeprecated_path(
-                                            "domain_one",
-                                        )],
+                                        depends_on: vec![DependencyConfig::from_path("domain_one")],
                                         strict: false,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec![],
                                     children: HashMap::new(),

--- a/src/tests/test.rs
+++ b/src/tests/test.rs
@@ -14,22 +14,25 @@ pub mod fixtures {
             ModuleConfig::new("tach", true),
             ModuleConfig {
                 path: "tach.__main__".to_string(),
-                depends_on: vec![DependencyConfig::from_undeprecated_path("tach.start")],
+                depends_on: vec![DependencyConfig::from_path("tach.start")],
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.cache".to_string(),
                 depends_on: ["tach", "tach.filesystem"]
-                    .map(DependencyConfig::from_undeprecated_path)
+                    .map(DependencyConfig::from_path)
                     .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.check".to_string(),
                 depends_on: ["tach.errors", "tach.filesystem", "tach.parsing"]
-                    .map(DependencyConfig::from_undeprecated_path)
+                    .map(DependencyConfig::from_path)
                     .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.cli".to_string(),
@@ -50,16 +53,18 @@ pub mod fixtures {
                     "tach.sync",
                     "tach.test",
                 ]
-                .map(DependencyConfig::from_undeprecated_path)
+                .map(DependencyConfig::from_path)
                 .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig::new("tach.colors", true),
             ModuleConfig::new("tach.constants", true),
             ModuleConfig {
                 path: "tach.core".to_string(),
-                depends_on: vec![DependencyConfig::from_undeprecated_path("tach.constants")],
+                depends_on: vec![DependencyConfig::from_path("tach.constants")],
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig::new("tach.errors", true),
             ModuleConfig {
@@ -71,33 +76,38 @@ pub mod fixtures {
                     "tach.errors",
                     "tach.hooks",
                 ]
-                .map(DependencyConfig::from_undeprecated_path)
+                .map(DependencyConfig::from_path)
                 .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.filesystem.git_ops".to_string(),
-                depends_on: vec![DependencyConfig::from_undeprecated_path("tach.errors")],
+                depends_on: vec![DependencyConfig::from_path("tach.errors")],
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.hooks".to_string(),
-                depends_on: vec![DependencyConfig::from_undeprecated_path("tach.constants")],
+                depends_on: vec![DependencyConfig::from_path("tach.constants")],
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.interactive".to_string(),
                 depends_on: ["tach.errors", "tach.filesystem"]
-                    .map(DependencyConfig::from_undeprecated_path)
+                    .map(DependencyConfig::from_path)
                     .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.logging".to_string(),
                 depends_on: ["tach", "tach.cache", "tach.parsing"]
-                    .map(DependencyConfig::from_undeprecated_path)
+                    .map(DependencyConfig::from_path)
                     .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.mod".to_string(),
@@ -109,27 +119,31 @@ pub mod fixtures {
                     "tach.interactive",
                     "tach.parsing",
                 ]
-                .map(DependencyConfig::from_undeprecated_path)
+                .map(DependencyConfig::from_path)
                 .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.parsing".to_string(),
                 depends_on: ["tach.constants", "tach.core", "tach.filesystem"]
-                    .map(DependencyConfig::from_undeprecated_path)
+                    .map(DependencyConfig::from_path)
                     .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.report".to_string(),
-                depends_on: vec![DependencyConfig::from_undeprecated_path("tach.errors")],
+                depends_on: vec![DependencyConfig::from_path("tach.errors")],
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig::new("tach.show", true),
             ModuleConfig {
                 path: "tach.start".to_string(),
-                depends_on: vec![DependencyConfig::from_undeprecated_path("tach.cli")],
+                depends_on: vec![DependencyConfig::from_path("tach.cli")],
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.sync".to_string(),
@@ -139,9 +153,10 @@ pub mod fixtures {
                     "tach.filesystem",
                     "tach.parsing",
                 ]
-                .map(DependencyConfig::from_undeprecated_path)
+                .map(DependencyConfig::from_path)
                 .into(),
                 strict: true,
+                ..Default::default()
             },
             ModuleConfig {
                 path: "tach.test".to_string(),
@@ -151,9 +166,10 @@ pub mod fixtures {
                     "tach.filesystem.git_ops",
                     "tach.parsing",
                 ]
-                .map(DependencyConfig::from_undeprecated_path)
+                .map(DependencyConfig::from_path)
                 .into(),
                 strict: false,
+                ..Default::default()
             },
         ]
     }
@@ -181,10 +197,9 @@ pub mod fixtures {
                                     full_path: "tach.__main__".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.__main__".to_string(),
-                                        depends_on: vec![DependencyConfig::from_undeprecated_path(
-                                            "tach.start",
-                                        )],
+                                        depends_on: vec![DependencyConfig::from_path("tach.start")],
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec![],
                                     children: HashMap::new(),
@@ -198,9 +213,10 @@ pub mod fixtures {
                                     config: Some(ModuleConfig {
                                         path: "tach.cache".to_string(),
                                         depends_on: ["tach", "tach.filesystem"]
-                                            .map(DependencyConfig::from_undeprecated_path)
+                                            .map(DependencyConfig::from_path)
                                             .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec![
                                         "get_uid".to_string(),
@@ -222,9 +238,10 @@ pub mod fixtures {
                                             "tach.filesystem",
                                             "tach.parsing",
                                         ]
-                                        .map(DependencyConfig::from_undeprecated_path)
+                                        .map(DependencyConfig::from_path)
                                         .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec![
                                         "BoundaryError".to_string(),
@@ -257,9 +274,10 @@ pub mod fixtures {
                                             "tach.sync",
                                             "tach.test",
                                         ]
-                                        .map(DependencyConfig::from_undeprecated_path)
+                                        .map(DependencyConfig::from_path)
                                         .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec!["main".to_string()],
                                     children: HashMap::new(),
@@ -301,10 +319,11 @@ pub mod fixtures {
                                     full_path: "tach.core".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.core".to_string(),
-                                        depends_on: vec![DependencyConfig::from_undeprecated_path(
+                                        depends_on: vec![DependencyConfig::from_path(
                                             "tach.constants",
                                         )],
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: [
                                         "ProjectConfig",
@@ -348,9 +367,10 @@ pub mod fixtures {
                                             "tach.errors",
                                             "tach.hooks",
                                         ]
-                                        .map(DependencyConfig::from_undeprecated_path)
+                                        .map(DependencyConfig::from_path)
                                         .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: [
                                         "get_cwd",
@@ -380,12 +400,11 @@ pub mod fixtures {
                                             full_path: "tach.filesystem.git_ops".to_string(),
                                             config: Some(ModuleConfig {
                                                 path: "tach.filesystem.git_ops".to_string(),
-                                                depends_on: vec![
-                                                    DependencyConfig::from_undeprecated_path(
-                                                        "tach.errors",
-                                                    ),
-                                                ],
+                                                depends_on: vec![DependencyConfig::from_path(
+                                                    "tach.errors",
+                                                )],
                                                 strict: true,
+                                                ..Default::default()
                                             }),
                                             interface_members: vec!["get_changed_files".to_string()],
                                             children: HashMap::new(),
@@ -400,10 +419,11 @@ pub mod fixtures {
                                     full_path: "tach.hooks".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.hooks".to_string(),
-                                        depends_on: vec![DependencyConfig::from_undeprecated_path(
+                                        depends_on: vec![DependencyConfig::from_path(
                                             "tach.constants",
                                         )],
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec![
                                         "build_pre_commit_hook_content".to_string()
@@ -419,9 +439,10 @@ pub mod fixtures {
                                     config: Some(ModuleConfig {
                                         path: "tach.interactive".to_string(),
                                         depends_on: ["tach.errors", "tach.filesystem"]
-                                            .map(DependencyConfig::from_undeprecated_path)
+                                            .map(DependencyConfig::from_path)
                                             .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: [
                                         "get_selected_modules_interactive",
@@ -440,9 +461,10 @@ pub mod fixtures {
                                     config: Some(ModuleConfig {
                                         path: "tach.logging".to_string(),
                                         depends_on: ["tach", "tach.cache", "tach.parsing"]
-                                            .map(DependencyConfig::from_undeprecated_path)
+                                            .map(DependencyConfig::from_path)
                                             .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: [
                                         "logger".to_string(),
@@ -467,9 +489,10 @@ pub mod fixtures {
                                             "tach.interactive",
                                             "tach.parsing",
                                         ]
-                                        .map(DependencyConfig::from_undeprecated_path)
+                                        .map(DependencyConfig::from_path)
                                         .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec!["mod_edit_interactive".to_string()],
                                     children: HashMap::new(),
@@ -487,9 +510,10 @@ pub mod fixtures {
                                             "tach.core",
                                             "tach.filesystem",
                                         ]
-                                        .map(DependencyConfig::from_undeprecated_path)
+                                        .map(DependencyConfig::from_path)
                                         .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: [
                                         "parse_project_config",
@@ -509,10 +533,11 @@ pub mod fixtures {
                                     full_path: "tach.report".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.report".to_string(),
-                                        depends_on: vec![DependencyConfig::from_undeprecated_path(
+                                        depends_on: vec![DependencyConfig::from_path(
                                             "tach.errors",
                                         )],
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec!["report".to_string()],
                                     children: HashMap::new(),
@@ -535,10 +560,9 @@ pub mod fixtures {
                                     full_path: "tach.start".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.start".to_string(),
-                                        depends_on: vec![DependencyConfig::from_undeprecated_path(
-                                            "tach.cli",
-                                        )],
+                                        depends_on: vec![DependencyConfig::from_path("tach.cli")],
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec!["start".to_string()],
                                     children: HashMap::new(),
@@ -557,9 +581,10 @@ pub mod fixtures {
                                             "tach.filesystem",
                                             "tach.parsing",
                                         ]
-                                        .map(DependencyConfig::from_undeprecated_path)
+                                        .map(DependencyConfig::from_path)
                                         .into(),
                                         strict: true,
+                                        ..Default::default()
                                     }),
                                     interface_members: [
                                         "sync_project",
@@ -583,9 +608,10 @@ pub mod fixtures {
                                             "tach.filesystem.git_ops",
                                             "tach.parsing",
                                         ]
-                                        .map(DependencyConfig::from_undeprecated_path)
+                                        .map(DependencyConfig::from_path)
                                         .into(),
                                         strict: false,
+                                        ..Default::default()
                                     }),
                                     interface_members: vec![],
                                     children: HashMap::new(),

--- a/tach.toml
+++ b/tach.toml
@@ -108,8 +108,8 @@ depends_on = [
 
 [[modules]]
 path = "tach.icons"
-strict = true
 depends_on = []
+strict = true
 
 [[modules]]
 path = "tach.interactive"


### PR DESCRIPTION
Ref: #119 

This adds `visibility` as a configuration option for modules. This value will determine which modules are allowed to depend on a given module (the inverse of `depends_on`). By default, this is set to `['*']`, which means 'this module can be depended on by any other module'.

```
[[modules]]
path = 'tach.core'
depends_on = []
// DEFAULT: globally visible
visibility = ['*'] 

[[modules]]
path = 'tach.core'
depends_on = []
// ISOLATED: no other module may depend on this module
visibility = [] 

[[modules]]
path = 'tach.core'
depends_on = []
// PARTIALLY ISOLATED: only modules with paths starting with `tach.` may depend on this module
visibility = ['tach.*'] 

[[modules]]
path = 'tach.core'
depends_on = []
// PARTIALLY ISOLATED: only modules with paths starting with `tach.` or matching `utils` may depend on this module
visibility = ['tach.*', 'utils'] 
```

Errors are given when running `tach check`. Running `tach sync` will ignore the `visibility` settings, and sync `depends_on` as usual.
Errors look like this:

```
❌ Module configuration error: 'tach.cli' cannot depend on 'tach.constants' because 'tach.cli' does not match its visibility: [].
Adjust 'visibility' for 'tach.constants' to include 'tach.cli', or remove the dependency.

❌ Module configuration error: 'tach.filesystem' cannot depend on 'tach.constants' because 'tach.filesystem' does not match its visibility: [].
Adjust 'visibility' for 'tach.constants' to include 'tach.filesystem', or remove the dependency.

❌ Module configuration error: 'tach.hooks' cannot depend on 'tach.constants' because 'tach.hooks' does not match its visibility: [].
Adjust 'visibility' for 'tach.constants' to include 'tach.hooks', or remove the dependency.
```