### PR TITLE
Allow filtering by filesystem paths in 'tach show'

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -843,7 +843,9 @@ def tach_show(
 
     try:
         if is_web:
-            result = generate_show_url(project_config)
+            result = generate_show_url(
+                project_root, project_config, included_paths=included_paths
+            )
             if result:
                 print("View your dependency graph here:")
                 print(result)

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -330,18 +330,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Paths to include in the module graph. If not provided, the entire project is included.",
     )
     show_parser.add_argument(
-        "--all-dependencies",
-        "-d",
-        action="store_true",
-        help="Include all dependencies in the module graph, even if not in the included paths.",
-    )
-    show_parser.add_argument(
-        "--all-usages",
-        "-u",
-        action="store_true",
-        help="Include all usages in the module graph, even if not in the included paths.",
-    )
-    show_parser.add_argument(
         "--web",
         action="store_true",
         help="Open your dependency graph in a remote web viewer.",
@@ -839,8 +827,6 @@ def tach_show(
     project_root: Path,
     included_paths: list[Path] | None = None,
     is_web: bool = False,
-    all_dependencies: bool = False,
-    all_usages: bool = False,
     output_filepath: Path | None = None,
 ):
     logger.info(
@@ -868,10 +854,9 @@ def tach_show(
             print_show_web_suggestion()
             output_filepath = output_filepath or Path(f"{TOOL_NAME}_module_graph.dot")
             generate_module_graph_dot_file(
+                project_root,
                 project_config,
                 included_paths=included_paths,
-                all_dependencies=all_dependencies,
-                all_usages=all_usages,
                 output_filepath=output_filepath,
             )
             print_generated_module_graph_file(output_filepath)
@@ -1021,8 +1006,6 @@ def main() -> None:
         tach_show(
             project_root=project_root,
             included_paths=args.included_paths,
-            all_dependencies=args.all_dependencies,
-            all_usages=args.all_usages,
             output_filepath=args.out,
             is_web=args.web,
         )

--- a/python/tach/show.py
+++ b/python/tach/show.py
@@ -37,7 +37,11 @@ def generate_show_url(project_config: ProjectConfig) -> str | None:
 
 
 def generate_module_graph_dot_file(
-    project_config: ProjectConfig, output_filepath: Path
+    project_config: ProjectConfig,
+    output_filepath: Path,
+    included_paths: list[Path] | None = None,
+    all_dependencies: bool = False,
+    all_usages: bool = False,
 ) -> None:
     # Local import because networkx takes about ~100ms to load
     import networkx as nx
@@ -45,11 +49,14 @@ def generate_module_graph_dot_file(
     graph = nx.DiGraph()  # type: ignore
     # Add nodes
     for module in project_config.modules:
+        # If included_paths is provided, only include the modules that resolve to contained paths
         graph.add_node(module.path)  # type: ignore
 
     # Add dependency edges
     for module in project_config.modules:
+        # if all_usages is True, include any dependency which points into the included paths
         for dependency in module.depends_on:
+            # if all_dependencies is False, only include the dependencies that resolve to contained paths
             graph.add_edge(module.path, dependency.path)  # type: ignore
 
     pydot_graph: pydot.Dot = nx.nx_pydot.to_pydot(graph)  # type: ignore

--- a/tach.toml
+++ b/tach.toml
@@ -161,8 +161,10 @@ depends_on = [
 
 [[modules]]
 path = "tach.show"
-depends_on = []
 strict = true
+depends_on = [
+    { path = "tach.filesystem" },
+]
 
 [[modules]]
 path = "tach.start"

--- a/tach.toml
+++ b/tach.toml
@@ -163,6 +163,7 @@ depends_on = [
 path = "tach.show"
 strict = true
 depends_on = [
+    { path = "tach.extension" },
     { path = "tach.filesystem" },
 ]
 


### PR DESCRIPTION
Fixes: #322 

Examples:
`> tach show --web python/tach/parsing python/tach/utils`
https://show.gauge.sh/?uid=5da52380-c7cd-497b-a048-49c609c5a01c

`> tach show --web python/tach/`
https://show.gauge.sh/?uid=3baebffb-5bed-4fce-bed3-5f3d3115d61d

`> tach show --web python/tach/filesystem python/tach/report.py`
https://show.gauge.sh/?uid=ec1453f1-f0d0-472f-9126-a54c3163c6ad