### PR TITLE
Add configuration for treatment of <root> module

### DIFF
--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -22,6 +22,8 @@ This is the project-level configuration file which should be in the root of your
 
 `forbid_circular_dependencies` is a boolean which, when enabled, causes `tach check` to fail if any circular dependencies are detected.
 
+`root_module` takes a string enum value, and determines how Tach treats code which lives within the project but is not covered by an explicit module. This is described in detail [below](#the_root_module)
+
 `use_regex_matching` is a boolean which, when enabled, uses regex (default) matching to exclude patterns else uses globs matching.
 
 ```toml
@@ -38,6 +40,8 @@ source_roots = ["python"]
 exact = true
 ignore_type_checking_imports = true
 forbid_circular_dependencies = true
+
+root_module = "allow"
 
 [[modules]]
 path = "tach"
@@ -92,6 +96,39 @@ Each module listed under the `modules` key above can accept the following attrib
 <Note>
   Tach also supports [deprecating individual dependencies](../usage/deprecate).
 </Note>
+
+## The Root Module
+
+By default, Tach checks all of the source files beneath all of the configured [source roots](#source_roots).
+This means that some code may not be contained within any configured [module](#modules).
+
+For example, given the file tree below:
+
+```
+my_repo/
+  tach.toml
+  script.py
+  lib/
+    module1.py
+    module2/
+      __init__.py
+      service.py
+    module3.py
+  docs/
+  tests/
+```
+
+If `lib.module1`, `lib.module2`, and `lib.module3` are the only configured modules, then the code in `script.py` would be automatically part of the `<root>` module.
+
+This module can declare its own dependencies with `depends_on` and use the rest of the available module configuration.
+Further, other modules need to declare an explicit dependency on `<root>` to use code which rolls up to the root.
+
+Tach allows configuring how the root module should be treated through the `root_module` key in `tach.toml`. It may take one of the following values:
+
+- **(default)** `"allow"`: Treat `<root>` as a catch-all rollup module which must be explicitly declared as a dependency and must declare its own dependencies on other modules.
+- **(permissive)** `"ignore"`: Disable all checks related to the `<root>` module. `tach check` will never fail due to code in the `<root>` module, and `tach sync` will never add `<root>` to `tach.toml`
+- **(stricter)** `"dependenciesonly"`: Forbid any module from listing `<root>` as a dependency, but allow `<root>` to declare its own dependencies.
+- **(strictest)** `"forbid"`: Forbid any reference to the `<root>` module in tach.toml. This means that all code in [source roots](#source_roots) MUST be contained within an explicitly configured [module](#modules).
 
 ## Source Roots
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -205,7 +205,7 @@ impl IntoPy<PyObject> for RootModuleTreatment {
             Self::Allow => "allow".to_object(py),
             Self::Forbid => "forbid".to_object(py),
             Self::Ignore => "ignore".to_object(py),
-            Self::DependenciesOnly => "dependencies_only".to_object(py),
+            Self::DependenciesOnly => "dependenciesonly".to_object(py),
         }
     }
 }

--- a/src/core/module.rs
+++ b/src/core/module.rs
@@ -46,6 +46,10 @@ impl ModuleNode {
         }
     }
 
+    pub fn is_root(&self) -> bool {
+        self.full_path == "." && self.is_end_of_path
+    }
+
     pub fn fill(
         &mut self,
         config: ModuleConfig,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@ impl From<sync::SyncError> for PyErr {
         match err {
             SyncError::FileWrite(err) => PyOSError::new_err(err.to_string()),
             SyncError::TomlSerialize(err) => PyOSError::new_err(err.to_string()),
+            SyncError::CheckError(err) => err.into(),
+            SyncError::RootModuleViolation(err) => PyValueError::new_err(err.to_string()),
         }
     }
 }
@@ -298,7 +300,7 @@ fn sync_dependency_constraints(
     project_config: ProjectConfig,
     exclude_paths: Vec<String>,
     prune: bool,
-) -> ProjectConfig {
+) -> Result<ProjectConfig, SyncError> {
     sync::sync_dependency_constraints(project_root, project_config, exclude_paths, prune)
 }
 

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -40,7 +40,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        core::config::{CacheConfig, DependencyConfig, ExternalDependencyConfig, ModuleConfig},
+        core::config::{DependencyConfig, ModuleConfig},
         tests::fixtures::example_dir,
     };
     use filesystem::DEFAULT_EXCLUDE_PATHS;
@@ -79,7 +79,7 @@ mod tests {
                         ..Default::default()
                     }
                 ],
-                cache: CacheConfig::default(),
+                cache: Default::default(),
                 exclude: DEFAULT_EXCLUDE_PATHS
                     .into_iter()
                     .chain(["domain_four"].into_iter())
@@ -91,7 +91,8 @@ mod tests {
                 ignore_type_checking_imports: true,
                 forbid_circular_dependencies: true,
                 use_regex_matching: true,
-                external: ExternalDependencyConfig::default(),
+                external: Default::default(),
+                root_module: Default::default(),
             }
         );
     }

--- a/src/parsing/error.rs
+++ b/src/parsing/error.rs
@@ -50,6 +50,8 @@ pub enum ModuleTreeError {
     VisibilityViolation(Vec<VisibilityErrorInfo>),
     #[error("Circular dependency detected: {0:?}")]
     CircularDependency(Vec<String>),
+    #[error("Root module violation: {0:?}")]
+    RootModuleViolation(String),
     #[error("Parsing Error while building module tree.\n{0}")]
     ParseError(#[from] ParsingError),
     #[error("Cannot insert module with empty path.")]

--- a/src/test.rs
+++ b/src/test.rs
@@ -59,6 +59,7 @@ impl TachPytestPluginHandler {
             &source_roots,
             valid_modules,
             project_config.forbid_circular_dependencies,
+            project_config.root_module.clone(),
         )
         .unwrap();
 


### PR DESCRIPTION
Fixes #310 

This PR introduces the `root_module` configuration option to `tach.toml`.

It takes one of four values:
- `allow`: this matches the previous behavior, treating `<root>` as a catch-all rollup module which must be explicitly declared as a dependency and must declare its own dependencies on other modules.
- `ignore`: this disables all checks related to the `<root>` module. Tach check will never fail due to code in the `<root>` module, and Tach sync will never add `<root>` to tach.toml
- `forbid`: this makes Tach stricter, and disallows any reference to the `<root>` module in tach.toml. This means that Tach check will fail if any reference exists, and Tach sync will fail if it would need to add a `<root>` reference.
- `dependenciesonly`: this makes Tach slightly stricter, and will forbid any module from listing `<root>` as a dependency, but allow `<root>` to appear in tach.toml and require it to declare its own dependencies.