### PR TITLE
Show direct dependents when filtering modules in tach show

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -67,6 +67,7 @@ impl DependencyConfig {
 pub struct ModuleConfig {
     pub path: String,
     #[serde(default)]
+    #[pyo3(set)]
     pub depends_on: Vec<DependencyConfig>,
     #[serde(
         default = "default_visibility",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,7 @@ pub fn sync_project(
 fn extension(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<core::config::ProjectConfig>()?;
     m.add_class::<core::config::ModuleConfig>()?;
+    m.add_class::<core::config::DependencyConfig>()?;
     m.add_class::<test::TachPytestPluginHandler>()?;
     m.add_function(wrap_pyfunction_bound!(parse_project_config, m)?)?;
     m.add_function(wrap_pyfunction_bound!(get_project_imports, m)?)?;


### PR DESCRIPTION
From the previous implementation in #322 , the output of `tach show [...filepaths]` only included dependencies of included modules, not their dependents. It is much more useful to include direct dependents as well, since otherwise it is equivalent to looking at the 'depends_on' key in tach.toml.

Example with `python/tach/parsing`:
https://show.gauge.sh/?uid=f5c05a4e-1954-4ba5-8ccf-9f4fecf81c7b

![image](https://github.com/user-attachments/assets/3b3d375f-2256-4269-a6de-e0b19d556515)
