### PR TITLE
Fix report external

### DIFF
--- a/python/tach/report.py
+++ b/python/tach/report.py
@@ -98,7 +98,9 @@ def render_external_dependency_report(
         return f"{BCOLORS.OKCYAN}No external dependencies found in {BCOLORS.ENDC}{BCOLORS.OKGREEN}'{path}'.{BCOLORS.ENDC}"
 
     if raw:
-        return "\n".join({dependency.package_name for dependency in dependencies})
+        return "\n".join(
+            sorted({dependency.package_name for dependency in dependencies})
+        )
 
     title = f"[ External Dependencies in '{path}' ]"
     divider = "-" * len(title)


### PR DESCRIPTION
Fixing #370

This sorts the report-external raw output for deterministic behavior, and fixes the generation of the 'module mapping' on lower versions of Python. This is how Tach determines that a package called `GitPython` provides the `git` external module for example.

This mapping was constructed incorrectly in two ways:
1. Parsing of distribution metadata was broken, pulling in incorrect names from `RECORD` files in some cases among other issues
2. The final mapping was inverted, mapping package names to their provided modules, even though lookups need to be done based on the provided modules themselves.

Both these issues are addressed by this PR.