### PR TITLE
Fix handling relative imports at import depth > 1

### DIFF
--- a/python/tests/example/valid/domain_two/__init__.py
+++ b/python/tests/example/valid/domain_two/__init__.py
@@ -3,4 +3,7 @@ from __future__ import annotations
 from domain_four import ok
 from domain_three import x
 
+from .. import domain_three
+y = domain_three
+
 __all__ = ["x", "ok"]

--- a/python/tests/example/valid/domain_two/some_file.py
+++ b/python/tests/example/valid/domain_two/some_file.py
@@ -1,0 +1,3 @@
+from . import other
+
+__all__ = ["other"]

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -188,3 +188,34 @@ from external_module import something
         ("file1.c", 3),
     ]
     assert result == expected
+
+
+def test_relative_import_from_parent(temp_project):
+    # Create a nested directory structure
+    (temp_project / "parent" / "child").mkdir(parents=True, exist_ok=True)
+
+    # Create a file in the parent directory
+    parent_file_content = """
+def parent_function():
+    pass
+"""
+    create_temp_file(temp_project / "parent", "parent_module.py", parent_file_content)
+
+    # Create a file in the child directory with a relative import from the parent
+    child_file_content = """
+from .. import parent_module
+
+def child_function():
+    parent_module.parent_function()
+"""
+    create_temp_file(
+        temp_project / "parent" / "child", "child_module.py", child_file_content
+    )
+
+    result = get_project_imports(
+        [str(temp_project)],
+        str(temp_project / "parent" / "child" / "child_module.py"),
+        ignore_type_checking_imports=True,
+    )
+    expected = [("parent.parent_module", 2)]
+    assert result == expected

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -151,44 +151,53 @@ impl<'a> ImportVisitor<'a> {
         let mut imports = NormalizedImports::new();
 
         let import_depth: usize = import_statement.level.try_into().unwrap();
+        let num_paths_to_strip = if self.is_package {
+            import_depth.saturating_sub(1)
+        } else {
+            import_depth
+        };
+
+        let mod_path = match &self.file_mod_path {
+            Some(mod_path) => mod_path,
+            None => "",
+        };
+        // If our current file mod path is None, we are not within the source root
+        // so we assume that relative imports are also not within the source root
+        if mod_path.is_empty() && import_depth > 0 {
+            return imports;
+        };
+
+        let base_path_parts: Vec<&str> = mod_path.split('.').collect();
+        let base_path_parts = if num_paths_to_strip > 0 {
+            base_path_parts[..base_path_parts.len() - num_paths_to_strip].to_vec()
+        } else {
+            base_path_parts
+        };
 
         let base_mod_path = if let Some(ref module) = import_statement.module {
             if import_depth > 0 {
                 // For relative imports (level > 0), adjust the base module path
-                let num_paths_to_strip = if self.is_package {
-                    import_depth - 1
+
+                // base_mod_path becomes the current file's mod path
+                // minus the paths_to_strip (due to level of import)
+                // plus the module we are importing from
+                if base_path_parts.is_empty() {
+                    module.to_string()
                 } else {
-                    import_depth
-                };
-
-                // If our current file mod path is None, we are not within the source root
-                // so we assume that relative imports are also not within the source root
-                match &self.file_mod_path {
-                    None => return imports, // early return from the outer function
-                    Some(mod_path) => {
-                        let base_path_parts: Vec<&str> = mod_path.split('.').collect();
-                        let base_path_parts = if num_paths_to_strip > 0 {
-                            base_path_parts[..base_path_parts.len() - num_paths_to_strip].to_vec()
-                        } else {
-                            base_path_parts
-                        };
-
-                        if base_path_parts.is_empty() {
-                            module.to_string()
-                        } else {
-                            // base_mod_path is the current file's mod path
-                            // minus the paths_to_strip (due to level of import)
-                            // plus the module we are importing from
-                            format!("{}.{}", base_path_parts.join("."), module)
-                        }
-                    }
+                    format!("{}.{}", base_path_parts.join("."), module)
                 }
             } else {
                 module.to_string()
             }
         } else {
-            // We are importing from the current package ('.')
-            String::new()
+            // We are importing from the current package ('.') or a parent ('..' or more)
+            // We have already stripped parts from the current file's mod path based on the import depth,
+            // so we just need to join the remaining parts with a '.'
+            if base_path_parts.is_empty() {
+                // This means we are looking at a current package import outside of a source root
+                return imports;
+            }
+            base_path_parts.join(".")
         };
 
         let line_no = self
@@ -207,23 +216,19 @@ impl<'a> ImportVisitor<'a> {
         }
 
         for name in &import_statement.names {
-            let local_mod_path = format!(
-                "{}{}.{}",
-                ".".repeat(import_depth),
-                import_statement.module.as_deref().unwrap_or(""),
-                name.asname.as_deref().unwrap_or(name.name.as_ref())
-            );
             if let Some(ignored) = ignored_modules {
-                if ignored.contains(&local_mod_path) {
+                if ignored.contains(
+                    &name
+                        .asname
+                        .as_deref()
+                        .unwrap_or(name.name.as_ref())
+                        .to_string(),
+                ) {
                     continue; // This import is ignored by a directive
                 }
             }
 
-            let global_mod_path = match import_statement.module {
-                Some(_) => format!("{}.{}", base_mod_path, name.name.as_str()),
-                None => name.name.to_string(),
-            };
-
+            let global_mod_path = format!("{}.{}", base_mod_path, name.name.as_str());
             imports.push(NormalizedImport {
                 module_path: global_mod_path,
                 line_no: self


### PR DESCRIPTION
During investigation of #370 , I discovered that imports of the form `from .. import module` were being treated as if they were external imports, even though the package above was within a source root.

This is because the import visitor incorrectly assumed that a missing 'module' from an import AST node indicated a 'within-package' import, without handling parent traversal.

This PR fixes this issue and adds a regression test.