### PR TITLE
Fix regex exclusion patterns

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -17,12 +17,19 @@ impl PatternMatcher {
     }
 
     pub fn from_regex(pattern: &str) -> Result<Self, PathExclusionError> {
-        Ok(PatternMatcher::Regex(regex::Regex::new(pattern).map_err(
-            |e| PathExclusionError::RegexPatternError {
-                exclude: pattern.to_string(),
-                source: e,
-            },
-        )?))
+        let pattern_from_start = if pattern.starts_with(r"^") {
+            pattern.to_string()
+        } else {
+            format!(r"^{}", pattern)
+        };
+        Ok(PatternMatcher::Regex(
+            regex::Regex::new(&pattern_from_start).map_err(|e| {
+                PathExclusionError::RegexPatternError {
+                    exclude: pattern.to_string(),
+                    source: e,
+                }
+            })?,
+        ))
     }
 
     pub fn from_glob(pattern: &str) -> Result<Self, PathExclusionError> {


### PR DESCRIPTION
The docs describe `exclude` paths as matching 'from the beginning of a given file path'. https://docs.gauge.sh/usage/configuration#tach-toml

However, the actual logic was looking for a match anywhere in the file path. This was discovered when the exclude pattern `docs` was excluding `fastapi/openapi/docs.py`, leading to an incorrect reporting of those imports as external.

This PR adds a start-of-haystack anchor if one doesn't already exist in regex exclude patterns.