### PR TITLE
Fix tach report on Windows

### DIFF
--- a/python/tach/report.py
+++ b/python/tach/report.py
@@ -49,6 +49,10 @@ def report(
         use_regex_matching=project_config.use_regex_matching,
     )
 
+    # We prefer resolving symlinks and relative paths in Python
+    # because Rust's canonicalize adds an 'extended length path' prefix on Windows
+    # which breaks downstream code that compares to Python-resolved paths (project root, source roots, etc.)
+    path = path.resolve().relative_to(project_root)
     try:
         return create_dependency_report(
             project_root=str(project_root),

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::fmt::Debug;
-use std::fs;
 use std::io;
 use std::path::PathBuf;
 
@@ -156,12 +155,12 @@ pub fn create_dependency_report(
     if skip_dependencies && skip_usages {
         return Err(ReportCreationError::NothingToReport);
     }
-    let absolute_path = fs::canonicalize(path)?;
+    let absolute_path = project_root.join(path);
     let module_path = file_to_module_path(source_roots, &absolute_path)?;
     let mut report = DependencyReport::new(path.to_string_lossy().to_string());
 
     for pyfile in walk_pyfiles(project_root.to_str().unwrap()) {
-        let absolute_pyfile = PathBuf::from(&project_root).join(&pyfile);
+        let absolute_pyfile = project_root.join(&pyfile);
         match get_project_imports(source_roots, &absolute_pyfile, ignore_type_checking_imports) {
             Ok(project_imports) => {
                 let pyfile_in_target_module = absolute_pyfile.starts_with(&absolute_path);


### PR DESCRIPTION
Fixes #361 

The issue is that `fs::canonicalize` uses 'extended length path' syntax for the resulting path on Windows, which does not match the source roots (which are resolved using `pathlib.Path.resolve` in Python).

To work around this, this PR canonicalizes the path using `pathlib.Path.resolve` in Python to avoid the extended length path syntax, and avoids the call to `fs::canonicalize` in Rust.