### PR TITLE
Use -p to load pytest plugin for compatibility with xdist and others

### DIFF
--- a/python/tach/pytest_plugin.py
+++ b/python/tach/pytest_plugin.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from copy import copy
+from pathlib import Path
+from typing import Any, Protocol
+
+import pytest
+
+from tach import filesystem as fs
+from tach.errors import TachSetupError
+from tach.extension import TachPytestPluginHandler
+from tach.filesystem.git_ops import get_changed_files
+from tach.parsing import parse_project_config
+
+
+class TachConfig(Protocol):
+    tach_handler: TachPytestPluginHandler
+
+    def getoption(self, name: str) -> Any: ...
+
+
+def pytest_addoption(parser: pytest.Parser):
+    group = parser.getgroup("tach")
+    group.addoption(
+        "--tach-base",
+        default="main",
+        help="Base commit to compare against when determining affected tests [default: main]",
+    )
+    group.addoption(
+        "--tach-head",
+        default="",
+        help="Head commit to compare against when determining affected tests [default: current filesystem]",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: TachConfig):
+    project_root = fs.find_project_config_root() or Path.cwd()
+    project_config = parse_project_config(root=project_root)
+    if project_config is None:
+        raise TachSetupError("In Tach pytest plugin: No project config found")
+
+    base = config.getoption("--tach-base")
+    head = config.getoption("--tach-head")
+
+    kwargs: dict[str, Any] = {"project_root": project_root}
+    if head:
+        kwargs["head"] = head
+    if base:
+        kwargs["base"] = base
+    changed_files = get_changed_files(**kwargs)
+
+    # Store the handler instance on the config object so other hooks can access it
+    config.tach_handler = TachPytestPluginHandler(
+        project_root=project_root,
+        project_config=project_config,
+        changed_files=changed_files,
+        all_affected_modules={changed_file.resolve() for changed_file in changed_files},
+    )
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session,
+    config: TachConfig,
+    items: list[pytest.Item],
+):
+    handler = config.tach_handler
+    seen: set[Path] = set()
+    for item in copy(items):
+        if not item.path:
+            continue
+        if str(item.path) in handler.removed_test_paths:
+            handler.num_removed_items += 1
+            items.remove(item)
+            continue
+        if item.path in seen:
+            continue
+
+        if str(item.path) in handler.all_affected_modules:
+            # If this test file was changed,
+            # then we know we need to rerun it
+            seen.add(item.path)
+            continue
+
+        if handler.should_remove_items(file_path=item.path.resolve()):
+            handler.num_removed_items += 1
+            items.remove(item)
+            handler.remove_test_path(item.path)
+
+        seen.add(item.path)
+
+
+def pytest_report_collectionfinish(
+    config: TachConfig,
+    start_path: Path,
+    startdir: Any,
+    items: list[pytest.Item],
+) -> str | list[str]:
+    handler = config.tach_handler
+    return [
+        f"[Tach] Skipped {len(handler.removed_test_paths)} test file{'s' if len(handler.removed_test_paths) > 1 else ''}"
+        f" ({handler.num_removed_items} tests)"
+        " since they were unaffected by current changes.",
+        *(
+            f"[Tach] > Skipped '{test_path}'"
+            for test_path in handler.removed_test_paths
+        ),
+    ]
+
+
+def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: TachConfig):
+    config.tach_handler.tests_ran_to_completion = True

--- a/tach.toml
+++ b/tach.toml
@@ -136,6 +136,15 @@ depends_on = [
 ]
 
 [[modules]]
+path = "tach.pytest_plugin"
+depends_on = [
+    { path =  "tach.filesystem" },
+    { path =  "tach.filesystem.git_ops" },
+    { path =  "tach.extension" },
+    { path =  "tach.parsing" },
+]
+
+[[modules]]
 path = "tach.report"
 strict = true
 depends_on = [
@@ -169,10 +178,7 @@ depends_on = [
 [[modules]]
 path = "tach.test"
 strict = true
-depends_on = [
-    { path = "tach.extension" },
-    { path = "tach.filesystem.git_ops" },
-]
+depends_on = []
 
 [[modules]]
 path = "tach.utils"


### PR DESCRIPTION
Fixes #386 

The issue with `tach test` not working alongside `pytest-xdist` was due to the use of an in-memory plugin instance passed to `pytest.main`. This instance is not easily provided to subprocesses, which `xdist` uses to run separate test workers.

This PR changes `tach test` to use a subprocess to invoke `pytest`, and moves the plugin logic to a separate file which is then referenced as `pytest -p tach.pytest_plugin`. Under-the-hood, this method allows `pytest-xdist` to pass the `-p` flag to each worker, which then independently loads the plugin.