### PR TITLE
Print warning when ignore directive applied to valid import

### DIFF
--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -123,6 +123,11 @@ class UnusedDependencies:
     path: str
     dependencies: list[DependencyConfig]
 
+RuleSetting = Literal["error", "warn", "off"]
+
+class RulesConfig:
+    unused_ignore_directives: RuleSetting
+
 class ProjectConfig:
     modules: list[ModuleConfig]
     cache: CacheConfig
@@ -134,6 +139,7 @@ class ProjectConfig:
     ignore_type_checking_imports: bool
     forbid_circular_dependencies: bool
     use_regex_matching: bool
+    rules: RulesConfig
 
     def __new__(cls) -> ProjectConfig: ...
     def module_paths(self) -> list[str]: ...

--- a/src/check_ext.rs
+++ b/src/check_ext.rs
@@ -55,12 +55,12 @@ pub fn check_external_dependencies(
                 let display_file_path = relative_to(&absolute_file_path, project_root)?
                     .to_string_lossy()
                     .to_string();
-                if let Ok(imports) = imports::get_normalized_imports(
+                if let Ok(normalized_imports) = imports::get_normalized_imports(
                     source_roots,
                     &absolute_file_path,
                     ignore_type_checking_imports,
                 ) {
-                    for import in imports {
+                    for import in normalized_imports.imports {
                         let top_level_module_name = import.top_level_module_name();
                         let default_distribution_names = vec![top_level_module_name.to_string()];
                         let distribution_names: Vec<String> = module_mappings

--- a/src/check_int.rs
+++ b/src/check_int.rs
@@ -299,6 +299,7 @@ pub fn check(
             {
                 continue;
             }
+
             let project_imports = match get_project_imports(
                 &source_roots,
                 abs_file_path,
@@ -328,7 +329,7 @@ pub fn check(
                 }
             };
 
-            for import in project_imports {
+            for import in project_imports.imports {
                 found_at_least_one_project_import = true;
                 let Err(error_info) = check_import(
                     &import.module_path,
@@ -349,6 +350,20 @@ pub fn check(
                     boundary_warnings.push(boundary_error);
                 } else {
                     boundary_errors.push(boundary_error);
+                }
+            }
+            for directive_ignored_import in project_imports.directive_ignored_imports {
+                if let Ok(()) = check_import(
+                    &directive_ignored_import.module_path,
+                    &mod_path,
+                    &module_tree,
+                    Some(Arc::clone(&nearest_module)),
+                    project_config.root_module.clone(),
+                ) {
+                    warnings.push(format!(
+                        "Import '{}' is unnecessarily ignored by a directive.",
+                        directive_ignored_import.module_path
+                    ));
                 }
             }
         }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -213,6 +213,75 @@ impl IntoPy<PyObject> for RootModuleTreatment {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleSetting {
+    Error,
+    Warn,
+    Off,
+}
+
+impl RuleSetting {
+    // These are just necessary for serde macros
+    fn warn() -> Self {
+        Self::Warn
+    }
+
+    fn is_warn(&self) -> bool {
+        *self == Self::Warn
+    }
+
+    fn error() -> Self {
+        Self::Error
+    }
+
+    fn is_error(&self) -> bool {
+        *self == Self::Error
+    }
+
+    fn off() -> Self {
+        Self::Off
+    }
+
+    fn is_off(&self) -> bool {
+        *self == Self::Off
+    }
+}
+
+impl IntoPy<PyObject> for RuleSetting {
+    fn into_py(self, py: Python) -> PyObject {
+        match self {
+            Self::Error => "error".to_object(py),
+            Self::Warn => "warn".to_object(py),
+            Self::Off => "off".to_object(py),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[pyclass(get_all, module = "tach.extension")]
+pub struct RulesConfig {
+    #[serde(
+        default = "RuleSetting::warn",
+        skip_serializing_if = "RuleSetting::is_warn"
+    )]
+    pub unused_ignore_directives: RuleSetting,
+}
+
+impl Default for RulesConfig {
+    fn default() -> Self {
+        Self {
+            unused_ignore_directives: RuleSetting::warn(),
+        }
+    }
+}
+
+impl RulesConfig {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[pyclass(get_all, module = "tach.extension")]
 pub struct ProjectConfig {
@@ -240,6 +309,8 @@ pub struct ProjectConfig {
     pub use_regex_matching: bool,
     #[serde(default, skip_serializing_if = "RootModuleTreatment::is_default")]
     pub root_module: RootModuleTreatment,
+    #[serde(default, skip_serializing_if = "RulesConfig::is_default")]
+    pub rules: RulesConfig,
 }
 
 impl Default for ProjectConfig {
@@ -256,6 +327,7 @@ impl Default for ProjectConfig {
             forbid_circular_dependencies: Default::default(),
             use_regex_matching: default_true(),
             root_module: Default::default(),
+            rules: Default::default(),
         }
     }
 }
@@ -324,6 +396,7 @@ impl ProjectConfig {
             forbid_circular_dependencies: self.forbid_circular_dependencies,
             use_regex_matching: self.use_regex_matching,
             root_module: self.root_module.clone(),
+            rules: self.rules.clone(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,10 +121,13 @@ fn get_normalized_imports(
     source_roots: Vec<String>,
     file_path: String,
     ignore_type_checking_imports: bool,
-) -> imports::Result<imports::NormalizedImports> {
+) -> imports::Result<Vec<imports::NormalizedImport>> {
     let source_roots: Vec<PathBuf> = source_roots.iter().map(PathBuf::from).collect();
     let file_path = PathBuf::from(file_path);
-    imports::get_normalized_imports(&source_roots, &file_path, ignore_type_checking_imports)
+    Ok(
+        imports::get_normalized_imports(&source_roots, &file_path, ignore_type_checking_imports)?
+            .imports,
+    )
 }
 
 /// Get first-party imports from file_path
@@ -134,10 +137,13 @@ fn get_project_imports(
     source_roots: Vec<String>,
     file_path: String,
     ignore_type_checking_imports: bool,
-) -> imports::Result<imports::NormalizedImports> {
+) -> imports::Result<Vec<imports::NormalizedImport>> {
     let source_roots: Vec<PathBuf> = source_roots.iter().map(PathBuf::from).collect();
     let file_path = PathBuf::from(file_path);
-    imports::get_project_imports(&source_roots, &file_path, ignore_type_checking_imports)
+    Ok(
+        imports::get_project_imports(&source_roots, &file_path, ignore_type_checking_imports)?
+            .imports,
+    )
 }
 
 /// Get third-party imports from file_path
@@ -147,11 +153,12 @@ fn get_external_imports(
     source_roots: Vec<String>,
     file_path: String,
     ignore_type_checking_imports: bool,
-) -> imports::Result<imports::NormalizedImports> {
+) -> imports::Result<Vec<imports::NormalizedImport>> {
     let source_roots: Vec<PathBuf> = source_roots.iter().map(PathBuf::from).collect();
     let file_path = PathBuf::from(file_path);
     Ok(
         imports::get_normalized_imports(&source_roots, &file_path, ignore_type_checking_imports)?
+            .imports
             .into_iter()
             .filter_map(|import| {
                 imports::is_project_import(&source_roots, &import.module_path).map_or(

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -93,6 +93,7 @@ mod tests {
                 use_regex_matching: true,
                 external: Default::default(),
                 root_module: Default::default(),
+                rules: Default::default(),
             }
         );
     }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -169,6 +169,7 @@ pub fn create_dependency_report(
                     // is an external dependency
                     report.dependencies.extend(
                         project_imports
+                            .imports
                             .into_iter()
                             .filter(|import| {
                                 if import.module_path.starts_with(&module_path) {
@@ -196,7 +197,7 @@ pub fn create_dependency_report(
                 } else if !pyfile_in_target_module && !skip_usages {
                     // We are looking at imports from outside the target module,
                     // so any import which points to the target module is an external usage
-                    for import in project_imports {
+                    for import in project_imports.imports {
                         if !import.module_path.starts_with(&module_path) {
                             // this import doesn't point to the target module
                             continue;

--- a/src/test.rs
+++ b/src/test.rs
@@ -87,7 +87,7 @@ impl TachPytestPluginHandler {
         let project_imports = get_project_imports(&self.source_roots, &file_path, true).unwrap();
         let mut should_remove = true;
 
-        for import in project_imports {
+        for import in project_imports.imports {
             if let Some(nearest_module) = self.module_tree.find_nearest(&import.module_path) {
                 if self.affected_modules.contains(&nearest_module.full_path) {
                     // If the module is affected, break early and don't remove the item

--- a/tach.toml
+++ b/tach.toml
@@ -197,3 +197,6 @@ exclude = [
     "pydot",
     "eval_type_backport",
 ]
+
+[rules]
+unused_ignore_directives = "error"


### PR DESCRIPTION
Fixes: #425 

![image](https://github.com/user-attachments/assets/e188ba31-7379-4679-b4e3-b5550f344328)

![image](https://github.com/user-attachments/assets/9e834809-969b-4011-9688-c40978228d4a)

This adds the `rules` table to Tach config. Right now, the only allowed key will be `unused_ignore_directives`, and the allowed values are "error", "warn" (default) and "off".

```toml

[rules]
unused_ignore_directives = "error"

```