### PR TITLE
Fix wildcard import always treated as external

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -96,10 +96,14 @@ pub struct ResolvedModule {
     pub member_name: Option<String>,
 }
 
-fn is_potential_python_module(s: &str) -> bool {
+fn is_potential_python_module_path(s: &str) -> bool {
     !s.is_empty()
-        && s.split('.')
-            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_alphanumeric() || c == '_'))
+        && s.split('.').all(|part| {
+            !part.is_empty()
+                && part
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '_' || c == '*')
+        })
 }
 
 pub fn module_to_file_path<P: AsRef<Path>>(
@@ -108,7 +112,7 @@ pub fn module_to_file_path<P: AsRef<Path>>(
     check_members: bool,
 ) -> Option<ResolvedModule> {
     // Fast check because this may run on every string literal in every source file
-    if !is_potential_python_module(mod_path) {
+    if !is_potential_python_module_path(mod_path) {
         return None;
     }
 


### PR DESCRIPTION
Fixes #433 

This is due to the interaction of two issues. The first is that determining whether a module path is internal or external depends on fully resolving the module path to a filepath within the project. Separately, this should be changed to only check whether the first level of the module path is found within a source root, and the path itself is well-formed.

The second issue (fixed in this PR) is that paths like `pkg.*` were treated as external due to a bad up-front heuristic which assumed paths must be only alphanumeric + `_` characters. This simply adds the asterisk as a possible character. Technically this is too permissive, but actual filesystem checks follow, so it is not a real concern.