### PR TITLE
Allow configuring rename rules for external modules

### DIFF
--- a/python/tach/check_external.py
+++ b/python/tach/check_external.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from tach.errors import TachError
 from tach.extension import check_external_dependencies, set_excluded_paths
 from tach.utils.external import get_module_mappings, is_stdlib_module
 
@@ -19,7 +20,14 @@ class ExternalCheckDiagnosticts:
 
 
 def extract_module_mappings(rename: list[str]) -> dict[str, list[str]]:
-    return {module: [name] for module, name in [module.split(":") for module in rename]}
+    try:
+        return {
+            module: [name] for module, name in [module.split(":") for module in rename]
+        }
+    except ValueError as e:
+        raise TachError(
+            "Invalid rename format: expected format is a list of 'module:name' pairs, e.g. ['PIL:pillow']"
+        ) from e
 
 
 def check_external(

--- a/python/tach/check_external.py
+++ b/python/tach/check_external.py
@@ -18,6 +18,10 @@ class ExternalCheckDiagnosticts:
     unused_dependencies: dict[str, list[str]]
 
 
+def extract_module_mappings(rename: list[str]) -> dict[str, list[str]]:
+    return {module: [name] for module, name in [module.split(":") for module in rename]}
+
+
 def check_external(
     project_root: Path,
     project_config: ProjectConfig,
@@ -32,10 +36,15 @@ def check_external(
         use_regex_matching=project_config.use_regex_matching,
     )
 
+    metadata_module_mappings = get_module_mappings()
+    if project_config.external.rename:
+        metadata_module_mappings.update(
+            extract_module_mappings(project_config.external.rename)
+        )
     diagnostics = check_external_dependencies(
         project_root=str(project_root),
         source_roots=serialized_source_roots,
-        module_mappings=get_module_mappings(),
+        module_mappings=metadata_module_mappings,
         ignore_type_checking_imports=project_config.ignore_type_checking_imports,
     )
     undeclared_dependencies_by_file = diagnostics[0]

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -223,7 +223,7 @@ def print_unused_external_dependencies(
     for pyproject_path, dependencies in unused_dependencies.items():
         if dependencies:
             print(
-                f"{icons.WARNING} {BCOLORS.WARNING}Unused dependencies from project at {BCOLORS.OKCYAN}'{pyproject_path}'{BCOLORS.ENDC}{BCOLORS.ENDC}:"
+                f"{icons.WARNING}  {BCOLORS.WARNING}Unused dependencies from project at {BCOLORS.OKCYAN}'{pyproject_path}'{BCOLORS.ENDC}{BCOLORS.ENDC}:"
             )
             for dependency in dependencies:
                 print(f"\t{BCOLORS.WARNING}{dependency}{BCOLORS.ENDC}")

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -130,6 +130,7 @@ class CacheConfig:
 
 class ExternalDependencyConfig:
     exclude: list[str]
+    rename: list[str]
 
 class UnusedDependencies:
     path: str

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -194,6 +194,8 @@ impl CacheConfig {
 pub struct ExternalDependencyConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exclude: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rename: Vec<String>,
 }
 
 impl ExternalDependencyConfig {


### PR DESCRIPTION
Given cases like #414 , we cannot make the assumption that metadata resolution will always find the appropriate package for a module name.

This PR provides an 'escape hatch' in `external.rename`, a configured list of rename rules to fix external module resolution.

For example, if your code uses `pillow` through the `PIL` module, but `check-external` is failing to resolve this, you can add the following config to your `tach.toml`:

```toml
[external]
rename = ["PIL:pillow"]
```

In general, the `rename` field takes a list of strings in the format `[module name]:[package name]`.