### PR TITLE
Allow same-line tach-ignore comments, support optional paren-enclosed 'reason'

### DIFF
--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -29,9 +29,22 @@ def temp_project():
 
         # Creating some sample Python files in a nested structure
         (project_root / "a" / "b").mkdir(parents=True, exist_ok=True)
-        (project_root / "d").mkdir(parents=True, exist_ok=True)
-        (project_root / "local" / "g").mkdir(parents=True, exist_ok=True)
+        (project_root / "d" / "e").mkdir(parents=True, exist_ok=True)
+        (project_root / "local" / "g" / "h").mkdir(parents=True, exist_ok=True)
+        (project_root / "local" / "m" / "n").mkdir(parents=True, exist_ok=True)
         (project_root / "parent").mkdir(parents=True, exist_ok=True)
+
+        # Create __init__.py files in each directory
+        (project_root / "a" / "__init__.py").touch()
+        (project_root / "a" / "b" / "__init__.py").touch()
+        (project_root / "d" / "__init__.py").touch()
+        (project_root / "d" / "e" / "__init__.py").touch()
+        (project_root / "local" / "__init__.py").touch()
+        (project_root / "local" / "g" / "__init__.py").touch()
+        (project_root / "local" / "g" / "h" / "__init__.py").touch()
+        (project_root / "local" / "m" / "__init__.py").touch()
+        (project_root / "local" / "m" / "n" / "__init__.py").touch()
+        (project_root / "parent" / "__init__.py").touch()
 
         file1_content = """
 import os
@@ -45,10 +58,13 @@ if TYPE_CHECKING:
     from local.file2 import c
 """
         file4_content = """
-# tach-ignore
+# tach-ignore(external dependency)
 from a.b import c
-# tach-ignore d.e.f
-from d.e import f
+from d.e import f  # tach-ignore(legacy import) f
+from local.g.h import i, j  # tach-ignore(deprecated, using j instead) i
+
+# tach-ignore(temporary workaround) k
+from local.m.n import k, l
 
 import file3
 """
@@ -66,6 +82,7 @@ def test_regular_imports(temp_project):
         [str(temp_project)],
         str(temp_project / "file1.py"),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
     expected = [("local.file2.b", 3)]
     assert result == expected
@@ -76,6 +93,7 @@ def test_relative_imports(temp_project):
         [str(temp_project)],
         str(temp_project / "local/file2.py"),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
     expected = [("file1.y", 2)]
     assert result == expected
@@ -86,6 +104,7 @@ def test_ignore_type_checking_imports(temp_project):
         [str(temp_project)],
         str(temp_project / "file3.py"),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
     expected = []
     assert result == expected
@@ -96,6 +115,7 @@ def test_include_type_checking_imports(temp_project):
         [str(temp_project)],
         str(temp_project / "file3.py"),
         ignore_type_checking_imports=False,
+        include_string_imports=False,
     )
     expected = [("local.file2.c", 3)]
     assert result == expected
@@ -113,6 +133,7 @@ from ..file1 import x
         [str(temp_project)],
         str(temp_project / "local/file4.py"),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
     expected = [("file1.x", 5)]
     assert result == expected
@@ -121,6 +142,7 @@ from ..file1 import x
         [str(temp_project)],
         str(temp_project / "local/file4.py"),
         ignore_type_checking_imports=False,
+        include_string_imports=False,
     )
     expected = [("local.file2.c", 4), ("file1.x", 5)]
     assert result == expected
@@ -136,6 +158,7 @@ from external_module import something
         [str(temp_project)],
         str(temp_project / "file5.py"),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
     expected = []  # 'os' and 'external_module' are not within the project root
     assert result == expected
@@ -152,6 +175,7 @@ from external_module import something
         [str(temp_project)],
         str(temp_project / "file6.py"),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
     expected = [
         ("file1.c", 3),
@@ -164,8 +188,13 @@ def test_ignored_imports(temp_project):
         [str(temp_project)],
         str(temp_project / "file4.py"),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
-    expected = [("file3", 7)]
+    expected = [
+        ("local.g.h.j", 5),  # only 'i' is ignored, 'j' is included
+        ("local.m.n.l", 8),  # only 'k' is ignored, 'l' is included
+        ("file3", 10),
+    ]
     assert result == expected
 
 
@@ -183,6 +212,7 @@ from external_module import something
         [str(temp_project)],
         str(path_outside_source_root),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
     expected = [
         ("file1.c", 3),
@@ -216,6 +246,34 @@ def child_function():
         [str(temp_project)],
         str(temp_project / "parent" / "child" / "child_module.py"),
         ignore_type_checking_imports=True,
+        include_string_imports=False,
     )
     expected = [("parent.parent_module", 2)]
+    assert result == expected
+
+
+def test_ignore_comments(temp_project):
+    """Test different variations of tach-ignore comments"""
+    content = """
+# tach-ignore(skip all imports on next line)
+from a.b import c, d
+
+from d.e import f  # tach-ignore(deprecated) f
+from local.g.h import i, j  # tach-ignore(using j instead) i
+
+# tach-ignore(temporary) k
+from local.m.n import k, l
+"""
+    create_temp_file(temp_project, "ignore_test.py", content)
+
+    result = get_project_imports(
+        [str(temp_project)],
+        str(temp_project / "ignore_test.py"),
+        ignore_type_checking_imports=True,
+        include_string_imports=False,
+    )
+    expected = [
+        ("local.g.h.j", 6),  # only 'i' is ignored
+        ("local.m.n.l", 9),  # only 'k' is ignored
+    ]
     assert result == expected


### PR DESCRIPTION
Previously, "tach-ignore" only worked when on the preceding line of an import. This PR retains this behavior when the comment starts immediately on the line, but allows trailing comments to ignore an import on the same line.

Example:
```python
# tach-ignore
from module import member

from module import member2 # tach-ignore
```

This PR also introduces the ability to add a reason alongside the ignore comment:
```python
# tach-ignore(required due to current architecture)
from module import member

from module import oldMember, newMember # tach-ignore(still need oldMember here) oldMember
```

The 'reason' is not used for anything other than documentation right now, but the intention is to allow configuration like 'force_ignore_reason', among other uses.

Note also that this coexists with the previous behavior of scoping the ignore comment to a specific member.

This PR adds a test case which exercises several of these cases.