### PR TITLE
Unify report with report-external; incorporate module tree information

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -323,53 +323,51 @@ def build_parser() -> argparse.ArgumentParser:
     report_parser = subparsers.add_parser(
         "report",
         prog=f"{TOOL_NAME} report",
-        help="Create a report of dependencies and usages of the given path or directory.",
-        description="Create a report of dependencies and usages of the given path or directory.",
+        help="Create a report of dependencies and usages.",
+        description="Create a report of dependencies and usages.",
     )
     report_parser.add_argument(
         "path", help="The path or directory path used to generate the report."
     )
+    # Report type flags
+    report_parser.add_argument(
+        "--dependencies",
+        action="store_true",
+        help="Generate dependency report. When present, all reports must be explicitly enabled.",
+    )
+    report_parser.add_argument(
+        "--usages",
+        action="store_true",
+        help="Generate usage report. When present, all reports must be explicitly enabled.",
+    )
+    report_parser.add_argument(
+        "--external",
+        action="store_true",
+        help="Generate external dependency report. When present, all reports must be explicitly enabled.",
+    )
+    # Report options
     report_parser.add_argument(
         "-d",
-        "--dependencies",
+        "--dependency-modules",
         required=False,
         type=str,
         metavar="module_path,...",
         help="Comma separated module list of dependencies to include [includes everything by default]",
     )
     report_parser.add_argument(
-        "--no-deps",
-        action="store_true",
-        help="Do not include dependencies in the report.",
-    )
-    report_parser.add_argument(
         "-u",
-        "--usages",
+        "--usage-modules",
         required=False,
         type=str,
         metavar="module_path,...",
         help="Comma separated module list of usages to include [includes everything by default]",
     )
     report_parser.add_argument(
-        "--no-usages", action="store_true", help="Do not include usages in the report."
-    )
-    add_base_arguments(report_parser)
-
-    ## tach report-external
-    report_external_parser = subparsers.add_parser(
-        "report-external",
-        prog=f"{TOOL_NAME} report-external",
-        help="Create a report of third-party dependencies.",
-        description="Create a report of third-party dependencies.",
-    )
-    report_external_parser.add_argument(
-        "path", help="The path or directory path used to generate the report."
-    )
-    report_external_parser.add_argument(
         "--raw",
         action="store_true",
-        help="Print machine-readable raw output. Each line will contain a PEP 508 dependency string.",
+        help="Group lines by module and print each without any formatting.",
     )
+    add_base_arguments(report_parser)
 
     ## tach show
     show_parser = subparsers.add_parser(
@@ -800,8 +798,10 @@ def tach_report(
     path: str,
     include_dependency_modules: list[str] | None = None,
     include_usage_modules: list[str] | None = None,
-    skip_dependencies: bool = False,
-    skip_usages: bool = False,
+    dependencies: bool = False,
+    usages: bool = False,
+    external: bool = False,
+    raw: bool = False,
     exclude_paths: list[str] | None = None,
 ):
     logger.info(
@@ -809,6 +809,11 @@ def tach_report(
         extra={
             "data": LogDataModel(
                 function="tach_report",
+                parameters={
+                    "dependencies": dependencies,
+                    "usages": usages,
+                    "external": external,
+                },
             ),
         },
     )
@@ -823,55 +828,40 @@ def tach_report(
 
     report_path = Path(path)
     try:
-        print(
-            report(
-                project_root,
-                report_path,
-                project_config=project_config,
-                include_dependency_modules=include_dependency_modules,
-                include_usage_modules=include_usage_modules,
-                skip_dependencies=skip_dependencies,
-                skip_usages=skip_usages,
-                exclude_paths=exclude_paths,
+        # Generate reports based on flags
+        generate_all = not (dependencies or usages or external)
+        generate_dependencies = generate_all or dependencies
+        generate_usages = generate_all or usages
+        generate_external = generate_all or external
+
+        reports: list[str] = []
+        if generate_dependencies or generate_usages:
+            reports.append(
+                report(
+                    project_root,
+                    report_path,
+                    project_config=project_config,
+                    include_dependency_modules=include_dependency_modules,
+                    include_usage_modules=include_usage_modules,
+                    skip_dependencies=not generate_dependencies,
+                    skip_usages=not generate_usages,
+                    raw=raw,
+                    exclude_paths=exclude_paths,
+                )
             )
-        )
-        sys.exit(0)
-    except TachError as e:
-        print(f"Report failed: {e}")
-        sys.exit(1)
 
-
-def tach_report_external(
-    project_root: Path, path: str, raw: bool, exclude_paths: list[str] | None = None
-):
-    logger.info(
-        "tach report-external called",
-        extra={
-            "data": LogDataModel(
-                function="tach_report_external",
-            ),
-        },
-    )
-    project_config = parse_project_config(root=project_root)
-    if project_config is None:
-        print_no_config_found()
-        sys.exit(1)
-
-    exclude_paths = extend_and_validate(
-        exclude_paths, project_config.exclude, project_config.use_regex_matching
-    )
-
-    report_path = Path(path)
-    try:
-        print(
-            external_dependency_report(
-                project_root,
-                report_path,
-                raw=raw,
-                project_config=project_config,
-                exclude_paths=exclude_paths,
+        if generate_external:
+            reports.append(
+                external_dependency_report(
+                    project_root,
+                    report_path,
+                    raw=raw,
+                    project_config=project_config,
+                    exclude_paths=exclude_paths,
+                )
             )
-        )
+
+        print("\n".join(reports))
         sys.exit(0)
     except TachError as e:
         print(f"Report failed: {e}")
@@ -1155,31 +1145,21 @@ def main() -> None:
         tach_install(project_root=project_root, target=install_target)
     elif args.command == "report":
         include_dependency_modules = (
-            args.dependencies.split(",") if args.dependencies else None
+            args.dependency_modules.split(",") if args.dependency_modules else None
         )
-        include_usage_modules = args.usages.split(",") if args.usages else None
+        include_usage_modules = (
+            args.usage_modules.split(",") if args.usage_modules else None
+        )
         tach_report(
             project_root=project_root,
             path=args.path,
             include_dependency_modules=include_dependency_modules,
             include_usage_modules=include_usage_modules,
-            skip_dependencies=args.no_deps,
-            skip_usages=args.no_usages,
-            exclude_paths=exclude_paths,
-        )
-    elif args.command == "report-external":
-        tach_report_external(
-            project_root=project_root,
-            path=args.path,
+            dependencies=args.dependencies,
+            usages=args.usages,
+            external=args.external,
             raw=args.raw,
-        )
-    elif args.command == "test":
-        tach_test(
-            project_root=project_root,
-            head=args.head,
-            base=args.base,
-            disable_cache=args.disable_cache,
-            pytest_args=args.pytest_args,
+            exclude_paths=exclude_paths,
         )
     elif args.command == "show":
         tach_show(
@@ -1188,6 +1168,14 @@ def main() -> None:
             output_filepath=args.out,
             is_web=args.web,
             is_mermaid=args.mermaid,
+        )
+    elif args.command == "test":
+        tach_test(
+            project_root=project_root,
+            head=args.head,
+            base=args.base,
+            disable_cache=args.disable_cache,
+            pytest_args=args.pytest_args,
         )
     elif args.command == "export":
         tach_export(

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -30,14 +30,13 @@ def check_external_dependencies(
 ) -> tuple[dict[str, list[str]], dict[str, list[str]]]: ...
 def create_dependency_report(
     project_root: str,
-    source_roots: list[str],
+    project_config: ProjectConfig,
     path: str,
     include_dependency_modules: list[str] | None,
     include_usage_modules: list[str] | None,
     skip_dependencies: bool,
     skip_usages: bool,
-    ignore_type_checking_imports: bool,
-    include_string_imports: bool,
+    raw: bool,
 ) -> str: ...
 def create_computation_cache_key(
     project_root: str,

--- a/python/tests/test_report_external.py
+++ b/python/tests/test_report_external.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -12,13 +13,13 @@ from tach.report import external_dependency_report
 def project_config():
     p = ProjectConfig()
     p.source_roots = [
-        "src/pack-a/src",
-        "src/pack-b/src",
-        "src/pack-c/src",
-        "src/pack-d/src",
-        "src/pack-e/src",
-        "src/pack-f/src",
-        "src/pack-g/src",
+        Path("src/pack-a/src"),
+        Path("src/pack-b/src"),
+        Path("src/pack-c/src"),
+        Path("src/pack-d/src"),
+        Path("src/pack-e/src"),
+        Path("src/pack-f/src"),
+        Path("src/pack-g/src"),
     ]
     p.ignore_type_checking_imports = True
     return p
@@ -60,7 +61,9 @@ def test_report_raw_multi_package_example(example_dir, project_config, module_ma
         path=project_root / "src/pack-a/src/myorg/pack_a/__init__.py",
         raw=True,
     )
-    assert result == "gitpython"
+    assert [line for line in result.splitlines() if not line.startswith("#")] == [
+        "gitpython"
+    ]
 
 
 def test_report_empty_raw_multi_package_example(

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -34,7 +34,7 @@ pub enum ImportParseError {
 pub type Result<T> = std::result::Result<T, ImportParseError>;
 
 /// An import with a normalized module path and located line number
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NormalizedImport {
     pub module_path: String,
     pub line_no: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,31 +224,28 @@ fn check_external_dependencies(
 
 /// Create a report of dependencies and usages of a given path
 #[pyfunction]
-#[pyo3(signature = (project_root, source_roots, path, include_dependency_modules, include_usage_modules, skip_dependencies, skip_usages, ignore_type_checking_imports=false, include_string_imports=false))]
+#[pyo3(signature = (project_root, project_config, path, include_dependency_modules, include_usage_modules, skip_dependencies, skip_usages, raw))]
 fn create_dependency_report(
     project_root: String,
-    source_roots: Vec<String>,
+    project_config: &ProjectConfig,
     path: String,
     include_dependency_modules: Option<Vec<String>>,
     include_usage_modules: Option<Vec<String>>,
     skip_dependencies: bool,
     skip_usages: bool,
-    ignore_type_checking_imports: bool,
-    include_string_imports: bool,
+    raw: bool,
 ) -> reports::Result<String> {
     let project_root = PathBuf::from(project_root);
-    let source_roots: Vec<PathBuf> = source_roots.iter().map(PathBuf::from).collect();
     let file_path = PathBuf::from(path);
     reports::create_dependency_report(
         &project_root,
-        &source_roots,
+        project_config,
         &file_path,
         include_dependency_modules,
         include_usage_modules,
         skip_dependencies,
         skip_usages,
-        ignore_type_checking_imports,
-        include_string_imports,
+        raw,
     )
 }
 

--- a/src/parsing/error.rs
+++ b/src/parsing/error.rs
@@ -56,4 +56,6 @@ pub enum ModuleTreeError {
     ParseError(#[from] ParsingError),
     #[error("Cannot insert module with empty path.")]
     InsertNodeError,
+    #[error("Module not found: {0}")]
+    ModuleNotFound(String),
 }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -8,13 +8,19 @@ use thiserror::Error;
 use crate::colors::*;
 
 use crate::cli::create_clickable_link;
-use crate::filesystem::{file_to_module_path, walk_pyfiles, FileSystemError};
+use crate::core::config::{ProjectConfig, RootModuleTreatment};
+use crate::filesystem::{
+    file_to_module_path, validate_project_modules, walk_pyfiles, FileSystemError,
+};
 use crate::imports::{get_project_imports, ImportParseError, NormalizedImport};
+use crate::parsing::{error::ModuleTreeError, module::build_module_tree};
 
 struct Dependency {
     file_path: PathBuf,
     absolute_path: PathBuf,
     import: NormalizedImport,
+    source_module: String,
+    target_module: String,
 }
 
 #[derive(Error, Debug)]
@@ -27,6 +33,8 @@ pub enum ReportCreationError {
     ImportParse(#[from] ImportParseError),
     #[error("Nothing to report when skipping dependencies and usages.")]
     NothingToReport,
+    #[error("Module tree build error: {0}")]
+    ModuleTree(#[from] ModuleTreeError),
 }
 
 pub type Result<T> = std::result::Result<T, ReportCreationError>;
@@ -64,15 +72,51 @@ impl DependencyReport {
             &dependency.import.line_no,
         );
         format!(
-            "{green}{clickable_link}{end_color}: Import '{import_mod_path}'",
+            "{green}{clickable_link}{end_color}: {cyan}Import '{import_mod_path}'{end_color}",
             green = BColors::OKGREEN,
             clickable_link = clickable_link,
             end_color = BColors::ENDC,
+            cyan = BColors::OKCYAN,
             import_mod_path = dependency.import.module_path
         )
     }
 
-    fn render_to_string(&mut self, skip_dependencies: bool, skip_usages: bool) -> String {
+    fn render_to_string(
+        &mut self,
+        skip_dependencies: bool,
+        skip_usages: bool,
+        raw: bool,
+    ) -> String {
+        if raw {
+            let mut lines = Vec::new();
+
+            if !skip_dependencies && !self.dependencies.is_empty() {
+                lines.push("# Module Dependencies".to_string());
+                let mut module_paths: Vec<_> = self
+                    .dependencies
+                    .iter()
+                    .map(|dep| dep.target_module.clone())
+                    .collect();
+                module_paths.sort();
+                module_paths.dedup();
+                lines.extend(module_paths);
+            }
+
+            if !skip_usages && !self.usages.is_empty() {
+                lines.push("# Module Usages".to_string());
+                let mut using_modules: Vec<_> = self
+                    .usages
+                    .iter()
+                    .map(|usage| usage.source_module.clone())
+                    .collect();
+                using_modules.sort();
+                using_modules.dedup();
+                lines.extend(using_modules);
+            }
+
+            return lines.join("\n");
+        }
+
         let title = format!("Dependency Report for '{path}'", path = self.path.as_str());
         let mut result = format!(
             "[ {title} ]\n\
@@ -84,7 +128,11 @@ impl DependencyReport {
             let deps_title = format!("Dependencies of '{path}'", path = self.path.as_str());
             self.dependencies.sort_by(compare_dependencies);
             let deps_display: String = match self.dependencies.len() {
-                0 => "No dependencies found.".to_string(),
+                0 => format!(
+                    "{cyan}No dependencies found.{end_color}",
+                    cyan = BColors::WARNING,
+                    end_color = BColors::ENDC
+                ),
                 _ => self
                     .dependencies
                     .iter()
@@ -95,12 +143,10 @@ impl DependencyReport {
             };
             result.push_str(&format!(
                 "[ {deps_title} ]\n\
-                {cyan}{deps}{end_color}\n\
+                {deps}\n\
                 -------------------------------\n",
                 deps_title = deps_title,
                 deps = deps_display,
-                cyan = BColors::OKCYAN,
-                end_color = BColors::ENDC,
             ));
         }
 
@@ -108,7 +154,11 @@ impl DependencyReport {
             let usages_title = format!("Usages of '{path}'", path = self.path.as_str());
             self.usages.sort_by(compare_dependencies);
             let usages_display: String = match self.usages.len() {
-                0 => "No usages found.".to_string(),
+                0 => format!(
+                    "{cyan}No usages found.{end_color}",
+                    cyan = BColors::WARNING,
+                    end_color = BColors::ENDC
+                ),
                 _ => self
                     .usages
                     .iter()
@@ -119,12 +169,10 @@ impl DependencyReport {
             };
             result.push_str(&format!(
                 "[ {usages_title} ]\n\
-                {cyan}{usages}{end_color}\n\
+                {usages}\n\
                 -------------------------------\n",
                 usages_title = usages_title,
                 usages = usages_display,
-                cyan = BColors::OKCYAN,
-                end_color = BColors::ENDC,
             ));
         }
 
@@ -142,100 +190,133 @@ impl DependencyReport {
     }
 }
 
+fn is_module_prefix(prefix: &str, full_path: &str) -> bool {
+    if !full_path.starts_with(prefix) {
+        return false;
+    }
+    full_path.len() == prefix.len() || full_path[prefix.len()..].starts_with('.')
+}
+
 pub fn create_dependency_report(
     project_root: &PathBuf,
-    source_roots: &[PathBuf],
+    project_config: &ProjectConfig,
     path: &PathBuf,
     include_dependency_modules: Option<Vec<String>>,
     include_usage_modules: Option<Vec<String>>,
     skip_dependencies: bool,
     skip_usages: bool,
-    ignore_type_checking_imports: bool,
-    include_string_imports: bool,
+    raw: bool,
 ) -> Result<String> {
     if skip_dependencies && skip_usages {
         return Err(ReportCreationError::NothingToReport);
     }
+
+    let source_roots = project_config.prepend_roots(project_root);
+    let (valid_modules, _) =
+        validate_project_modules(&source_roots, project_config.modules.clone());
+    let module_tree = build_module_tree(
+        &source_roots,
+        valid_modules,
+        false,                      // skip circular dependency check in report
+        RootModuleTreatment::Allow, // skip root module check in report
+    )?;
+
     let absolute_path = project_root.join(path);
-    let module_path = file_to_module_path(source_roots, &absolute_path)?;
-    let mut report = DependencyReport::new(path.to_string_lossy().to_string());
+    let module_path = file_to_module_path(&source_roots, &absolute_path)?;
+    let target_module = module_tree.find_nearest(&module_path).ok_or_else(|| {
+        ReportCreationError::ModuleTree(ModuleTreeError::ModuleNotFound(module_path.clone()))
+    })?;
+
+    let mut report = DependencyReport::new(path.display().to_string());
 
     for pyfile in walk_pyfiles(project_root.to_str().unwrap()) {
         let absolute_pyfile = project_root.join(&pyfile);
+        let file_module_path = file_to_module_path(&source_roots, &absolute_pyfile)?;
+        let file_module = module_tree.find_nearest(&file_module_path);
+
         match get_project_imports(
-            source_roots,
+            &source_roots,
             &absolute_pyfile,
-            ignore_type_checking_imports,
-            include_string_imports,
+            project_config.ignore_type_checking_imports,
+            project_config.include_string_imports,
         ) {
             Ok(project_imports) => {
-                let pyfile_in_target_module = absolute_pyfile.starts_with(&absolute_path);
-                if pyfile_in_target_module && !skip_dependencies {
-                    // Any import from within the target module which points to an external mod_path
-                    // is an external dependency
+                let is_in_target_path = is_module_prefix(&module_path, &file_module_path);
+
+                if is_in_target_path && !skip_dependencies {
+                    // Add external dependencies
                     report.dependencies.extend(
                         project_imports
                             .imports
                             .into_iter()
+                            .filter_map(|import| {
+                                if let Some(import_module) =
+                                    module_tree.find_nearest(&import.module_path)
+                                {
+                                    if import_module == target_module {
+                                        return None; // Skip internal imports
+                                    }
+
+                                    // Check if module is in include list
+                                    include_dependency_modules.as_ref().map_or(
+                                        Some((import.clone(), import_module.clone())),
+                                        |included_modules| {
+                                            if included_modules.contains(&import_module.full_path) {
+                                                Some((import.clone(), import_module.clone()))
+                                            } else {
+                                                None
+                                            }
+                                        },
+                                    )
+                                } else {
+                                    None // Skip imports that don't match any module
+                                }
+                            })
+                            .map(|(import, import_module)| Dependency {
+                                file_path: pyfile.clone(),
+                                absolute_path: absolute_pyfile.clone(),
+                                import,
+                                source_module: target_module.full_path.clone(),
+                                target_module: import_module.full_path.clone(),
+                            }),
+                    );
+                } else if !is_in_target_path && !skip_usages {
+                    // Add external usages
+                    report.usages.extend(
+                        project_imports
+                            .imports
+                            .into_iter()
                             .filter(|import| {
-                                if import.module_path.starts_with(&module_path) {
-                                    // this is an internal import
-                                    return false;
+                                if !is_module_prefix(&module_path, &import.module_path) {
+                                    return false; // Skip imports not targeting our path
                                 }
 
-                                // for external imports,
-                                // if there is a filter list of dependencies, verify that the import is included
-                                include_dependency_modules.as_ref().map_or(
-                                    true,
-                                    |included_modules| {
-                                        included_modules.iter().any(|module_path| {
-                                            import.module_path.starts_with(module_path)
+                                // Check if using module is in include list
+                                file_module.as_ref().map_or(false, |m| {
+                                    include_usage_modules
+                                        .as_ref()
+                                        .map_or(true, |included_modules| {
+                                            included_modules.contains(&m.full_path)
                                         })
-                                    },
-                                )
+                                })
                             })
                             .map(|import| Dependency {
                                 file_path: pyfile.clone(),
                                 absolute_path: absolute_pyfile.clone(),
                                 import,
+                                source_module: file_module
+                                    .as_ref()
+                                    .map_or(String::new(), |m| m.full_path.clone()),
+                                target_module: target_module.full_path.clone(),
                             }),
                     );
-                } else if !pyfile_in_target_module && !skip_usages {
-                    // We are looking at imports from outside the target module,
-                    // so any import which points to the target module is an external usage
-                    for import in project_imports.imports {
-                        if !import.module_path.starts_with(&module_path) {
-                            // this import doesn't point to the target module
-                            continue;
-                        }
-
-                        let pyfile_mod_path = file_to_module_path(source_roots, &absolute_pyfile);
-                        if pyfile_mod_path.is_err() {
-                            // the current file doesn't belong to the source root
-                            continue;
-                        }
-
-                        if include_usage_modules.is_none()
-                            || include_usage_modules
-                                .as_ref()
-                                .is_some_and(|included_modules| {
-                                    included_modules.contains(&pyfile_mod_path.unwrap())
-                                })
-                        {
-                            report.usages.push(Dependency {
-                                file_path: pyfile.clone(),
-                                absolute_path: absolute_pyfile.clone(),
-                                import,
-                            });
-                        }
-                    }
                 }
             }
             Err(err) => {
-                // Failed to parse project imports
                 report.warnings.push(err.to_string());
             }
         }
     }
-    Ok(report.render_to_string(skip_dependencies, skip_usages))
+
+    Ok(report.render_to_string(skip_dependencies, skip_usages, raw))
 }


### PR DESCRIPTION
Fixes: #385 

Examples:
```shell
> tach report python/tach/sync.py --raw               
# Module Dependencies
tach.errors
tach.extension
tach.filesystem
# Module Usages
tach.cli
# External Dependencies
tomli
tomli-w
```

```shell
> tach report python/tach/sync.py --dependencies --usages
[ Dependency Report for 'python/tach/sync.py' ]
-------------------------------
[ Dependencies of 'python/tach/sync.py' ]
python/tach/sync.py[L8]: Import 'tach.errors'
python/tach/sync.py[L9]: Import 'tach.filesystem'
python/tach/sync.py[L11]: Import 'tach.extension.sync_project'
python/tach/sync.py[L13]: Import 'tach.filesystem.get_project_config_path'
-------------------------------
[ Usages of 'python/tach/sync.py' ]
python/tach/cli.py[L37]: Import 'tach.sync.sync_project'
-------------------------------
```

```shell
> tach report python/tach/sync.py --external             
[ External Dependencies in 'python/tach/sync.py' ]
--------------------------------------------------
python/tach/sync.py[L5]: Import 'tomli' from package 'tomli'
python/tach/sync.py[L6]: Import 'tomli_w' from package 'tomli-w'
```

```shell
tach report python/tach/sync.py           
[ Dependency Report for 'python/tach/sync.py' ]
-------------------------------
[ Dependencies of 'python/tach/sync.py' ]
python/tach/sync.py[L8]: Import 'tach.errors'
python/tach/sync.py[L9]: Import 'tach.filesystem'
python/tach/sync.py[L11]: Import 'tach.extension.sync_project'
python/tach/sync.py[L13]: Import 'tach.filesystem.get_project_config_path'
-------------------------------
[ Usages of 'python/tach/sync.py' ]
python/tach/cli.py[L37]: Import 'tach.sync.sync_project'
-------------------------------

[ External Dependencies in 'python/tach/sync.py' ]
--------------------------------------------------
python/tach/sync.py[L5]: Import 'tomli' from package 'tomli'
python/tach/sync.py[L6]: Import 'tomli_w' from package 'tomli-w'
```
