### PR TITLE
Add rules config to require ignore directives have reasons attached

### DIFF
--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -139,6 +139,7 @@ RuleSetting = Literal["error", "warn", "off"]
 
 class RulesConfig:
     unused_ignore_directives: RuleSetting
+    require_ignore_directive_reasons: RuleSetting
 
 class ProjectConfig:
     modules: list[ModuleConfig]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -291,12 +291,18 @@ pub struct RulesConfig {
         skip_serializing_if = "RuleSetting::is_warn"
     )]
     pub unused_ignore_directives: RuleSetting,
+    #[serde(
+        default = "RuleSetting::off",
+        skip_serializing_if = "RuleSetting::is_off"
+    )]
+    pub require_ignore_directive_reasons: RuleSetting,
 }
 
 impl Default for RulesConfig {
     fn default() -> Self {
         Self {
             unused_ignore_directives: RuleSetting::warn(),
+            require_ignore_directive_reasons: RuleSetting::off(),
         }
     }
 }

--- a/tach.toml
+++ b/tach.toml
@@ -333,3 +333,4 @@ exclude = [
 
 [rules]
 unused_ignore_directives = "error"
+require_ignore_directive_reasons = "error"


### PR DESCRIPTION
```toml
[rules]
require_ignore_directive_reasons = "error"  # default "off"
```

![image](https://github.com/user-attachments/assets/d926be0b-7840-4279-8fd4-98d5dcd8ed73)


This rule is useful to collect reasons for deviations from Tach config.