### PR TITLE
Fix LSP diagnostics on Windows

### DIFF
--- a/src/lsp/error.rs
+++ b/src/lsp/error.rs
@@ -26,4 +26,6 @@ pub enum ServerError {
     Lint(#[from] CheckError),
     #[error("Failed to initialize LSP server")]
     Initialize,
+    #[error("Internal error: {0}")]
+    Internal(String),
 }


### PR DESCRIPTION
Fixes: #424 

On Windows, the VSCode extension doesn't show any diagnostics. This is because the comparison between the file URI in the onChange/onSave notifications was not being compared accurately with filepaths within the project root.

This PR uses the `path` and `decode` functionality from fluent URI (through `lsp_types`) to consistently build an absolute path for comparison.