### PR TITLE
Support multiple path syntax for `modules`; string literal for `depends_on`

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -195,8 +195,10 @@ mod tests {
         #[case] expected_mod_paths: &[&str],
     ) {
         let project_root = env::temp_dir();
-        let mut project_config = ProjectConfig::default();
-        project_config.source_roots = vec![PathBuf::from(source_root)];
+        let project_config = ProjectConfig {
+            source_roots: vec![PathBuf::from(source_root)],
+            ..Default::default()
+        };
         let changed_files = changed_files
             .iter()
             .map(|filepath| project_root.join(filepath))

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -168,12 +168,7 @@ impl<'a> ImportVisitor<'a> {
                         .map(|alias| DirectiveIgnoredImport {
                             import: NormalizedImport {
                                 module_path: alias.name.to_string(),
-                                line_no: self
-                                    .locator
-                                    .compute_line_index(alias.range.start())
-                                    .get()
-                                    .try_into()
-                                    .unwrap(),
+                                line_no: self.locator.compute_line_index(alias.range.start()).get(),
                             },
                             reason: ignored.reason.clone(),
                         }),
@@ -185,12 +180,7 @@ impl<'a> ImportVisitor<'a> {
         for alias in &import_statement.names {
             let import = NormalizedImport {
                 module_path: alias.name.to_string(),
-                line_no: self
-                    .locator
-                    .compute_line_index(alias.range.start())
-                    .get()
-                    .try_into()
-                    .unwrap(),
+                line_no: self.locator.compute_line_index(alias.range.start()).get(),
             };
 
             if let Some(ignored) = ignored_directive {
@@ -280,12 +270,7 @@ impl<'a> ImportVisitor<'a> {
                         .push(DirectiveIgnoredImport {
                             import: NormalizedImport {
                                 module_path: global_mod_path,
-                                line_no: self
-                                    .locator
-                                    .compute_line_index(name.range.start())
-                                    .get()
-                                    .try_into()
-                                    .unwrap(),
+                                line_no: self.locator.compute_line_index(name.range.start()).get(),
                             },
                             reason: ignored.reason.clone(),
                         });
@@ -298,12 +283,7 @@ impl<'a> ImportVisitor<'a> {
             let global_mod_path = format!("{}.{}", base_mod_path, name.name.as_str());
             let import = NormalizedImport {
                 module_path: global_mod_path,
-                line_no: self
-                    .locator
-                    .compute_line_index(name.range.start())
-                    .get()
-                    .try_into()
-                    .unwrap(),
+                line_no: self.locator.compute_line_index(name.range.start()).get(),
             };
 
             if let Some(ignored) = ignored_directive {

--- a/src/interfaces/data_types.rs
+++ b/src/interfaces/data_types.rs
@@ -56,7 +56,7 @@ impl TypeCheckCache {
 
 #[derive(Debug)]
 struct FunctionParameter {
-    name: String,
+    _name: String,
     annotation: Option<String>,
 }
 
@@ -73,7 +73,7 @@ enum InterfaceMemberNode {
 }
 
 #[derive(Debug)]
-struct InterfaceMember {
+pub struct InterfaceMember {
     name: String,
     node: InterfaceMemberNode,
 }
@@ -165,7 +165,7 @@ impl StatementVisitor<'_> for ModuleInterfaceVisitor<'_> {
                             .parameters
                             .iter_non_variadic_params()
                             .map(|p| FunctionParameter {
-                                name: p.parameter.name.to_string(),
+                                _name: p.parameter.name.to_string(),
                                 annotation: match &p.parameter.annotation {
                                     Some(annotation) => match annotation.as_ref() {
                                         Expr::Name(name) => Some(name.id.clone()),
@@ -369,11 +369,11 @@ mod tests {
         // Test primitive function
         let primitive_func = vec![
             FunctionParameter {
-                name: "a".to_string(),
+                _name: "a".to_string(),
                 annotation: Some("int".to_string()),
             },
             FunctionParameter {
-                name: "b".to_string(),
+                _name: "b".to_string(),
                 annotation: Some("str".to_string()),
             },
         ];
@@ -388,7 +388,7 @@ mod tests {
 
         // Test non-primitive function
         let non_primitive_func = vec![FunctionParameter {
-            name: "a".to_string(),
+            _name: "a".to_string(),
             annotation: Some("CustomType".to_string()),
         }];
         let return_type = Some("bool".to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ fn run_server(
 }
 
 #[pymodule]
-fn extension(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn extension(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<config::ProjectConfig>()?;
     m.add_class::<config::ModuleConfig>()?;
     m.add_class::<config::InterfaceConfig>()?;

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -104,7 +104,6 @@ impl LSPServer {
                     save: Some(lsp_types::TextDocumentSyncSaveOptions::Supported(true)),
                     will_save: Some(false),
                     will_save_wait_until: Some(false),
-                    ..Default::default()
                 },
             )),
             ..Default::default()

--- a/src/modules/parsing.rs
+++ b/src/modules/parsing.rs
@@ -167,7 +167,7 @@ fn validate_root_module_treatment(
 }
 
 pub fn build_module_tree(
-    source_roots: &[PathBuf],
+    _source_roots: &[PathBuf],
     modules: &[ModuleConfig],
     forbid_circular_dependencies: bool,
     root_module_treatment: RootModuleTreatment,

--- a/tach.toml
+++ b/tach.toml
@@ -217,7 +217,7 @@ expose = [
     "PACKAGE_FILE_NAME",
     "ROOT_MODULE_SENTINEL_TAG",
     "DEFAULT_EXCLUDE_PATHS",
-    "GAUGE_API_BASE_URL"
+    "GAUGE_API_BASE_URL",
 ]
 from = [
     "tach.constants",

--- a/tach.toml
+++ b/tach.toml
@@ -20,39 +20,39 @@ depends_on = []
 [[modules]]
 path = "tach.__main__"
 depends_on = [
-    { path = "tach.start" },
+    "tach.start",
 ]
 
 [[modules]]
 path = "tach.cache"
 depends_on = [
-    { path = "tach" },
-    { path = "tach.filesystem" },
+    "tach",
+    "tach.filesystem",
 ]
 
 [[modules]]
 path = "tach.check_external"
 depends_on = [
-    { path = "tach.extension" },
+    "tach.extension",
 ]
 
 [[modules]]
 path = "tach.cli"
 depends_on = [
-    { path = "tach" },
-    { path = "tach.cache" },
-    { path = "tach.check_external" },
-    { path = "tach.extension" },
-    { path = "tach.filesystem" },
-    { path = "tach.icons" },
-    { path = "tach.logging" },
-    { path = "tach.mod" },
-    { path = "tach.modularity" },
-    { path = "tach.parsing" },
-    { path = "tach.report" },
-    { path = "tach.show" },
-    { path = "tach.sync" },
-    { path = "tach.test" },
+    "tach",
+    "tach.cache",
+    "tach.check_external",
+    "tach.extension",
+    "tach.filesystem",
+    "tach.icons",
+    "tach.logging",
+    "tach.mod",
+    "tach.modularity",
+    "tach.parsing",
+    "tach.report",
+    "tach.show",
+    "tach.sync",
+    "tach.test",
 ]
 
 [[modules]]
@@ -77,7 +77,7 @@ depends_on = []
 [[modules]]
 path = "tach.filesystem"
 depends_on = [
-    { path = "tach.hooks" },
+    "tach.hooks",
 ]
 
 [[modules]]
@@ -95,75 +95,75 @@ depends_on = []
 [[modules]]
 path = "tach.interactive"
 depends_on = [
-    { path = "tach.filesystem" },
+    "tach.filesystem",
 ]
 
 [[modules]]
 path = "tach.logging"
 depends_on = [
-    { path = "tach" },
-    { path = "tach.cache" },
-    { path = "tach.parsing" },
+    "tach",
+    "tach.cache",
+    "tach.parsing",
 ]
 
 [[modules]]
 path = "tach.mod"
 depends_on = [
-    { path = "tach.filesystem" },
-    { path = "tach.interactive" },
-    { path = "tach.parsing" },
+    "tach.filesystem",
+    "tach.interactive",
+    "tach.parsing",
 ]
 
 [[modules]]
 path = "tach.modularity"
 depends_on = [
-    { path = "tach.extension" },
-    { path = "tach.filesystem" },
-    { path = "tach.filesystem.git_ops" },
-    { path = "tach.parsing" },
+    "tach.extension",
+    "tach.filesystem",
+    "tach.filesystem.git_ops",
+    "tach.parsing",
 ]
 
 [[modules]]
 path = "tach.parsing"
 depends_on = [
-    { path = "tach.extension" },
-    { path = "tach.filesystem" },
+    "tach.extension",
+    "tach.filesystem",
 ]
 
 [[modules]]
 path = "tach.pytest_plugin"
 depends_on = [
-    { path = "tach.extension" },
-    { path = "tach.filesystem" },
-    { path = "tach.filesystem.git_ops" },
-    { path = "tach.parsing" },
+    "tach.extension",
+    "tach.filesystem",
+    "tach.filesystem.git_ops",
+    "tach.parsing",
 ]
 
 [[modules]]
 path = "tach.report"
 depends_on = [
-    { path = "tach.extension" },
-    { path = "tach.filesystem" },
+    "tach.extension",
+    "tach.filesystem",
 ]
 
 [[modules]]
 path = "tach.show"
 depends_on = [
-    { path = "tach.extension" },
-    { path = "tach.filesystem" },
+    "tach.extension",
+    "tach.filesystem",
 ]
 
 [[modules]]
 path = "tach.start"
 depends_on = [
-    { path = "tach.cli" },
+    "tach.cli",
 ]
 
 [[modules]]
 path = "tach.sync"
 depends_on = [
-    { path = "tach.extension" },
-    { path = "tach.filesystem" },
+    "tach.extension",
+    "tach.filesystem",
 ]
 
 [[modules]]


### PR DESCRIPTION
Fixes: #483 

This allows two new forms in `tach.toml` configuration:

1. Shorthand for dependencies
  - `depends_on = [{ path = "module.a"}]` can now be written simply as `depends_on = ["module.a"]`
  - the object form is only necessary to specify `deprecated = true`
2. Shorthand for groups of modules with the same attributes
  - modules can now use `paths = ["module.a", "module.b"]` instead of a single `path = "module.a"`
  - this allows sharing the `depends_on`, `visibility`, `utility`, or `unchecked` fields across all specified module paths
  - it is equivalent to flattening the module definition, but it far more concise