### PR TITLE
Fix early exit with Ctrl + C in `tach check` and `tach sync`

### DIFF
--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -8,7 +8,7 @@ Aside from running `tach mod` and `tach sync`, you can configure Tach by creatin
 
 This is the project-level configuration file which should be in the root of your project.
 
-`modules` defines the modules in your project - [see detais](#modules).
+`modules` defines the modules in your project - [see details](#modules).
 
 `interfaces` defines the interfaces of modules in your project - [see details](#interfaces).
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,0 +1,18 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub static INTERRUPT_SIGNAL: AtomicBool = AtomicBool::new(false);
+
+pub fn setup_interrupt_handler() {
+    ctrlc::set_handler(move || {
+        INTERRUPT_SIGNAL.store(true, Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl-C handler");
+}
+
+pub fn check_interrupt() -> Result<(), &'static str> {
+    if INTERRUPT_SIGNAL.load(Ordering::SeqCst) {
+        Err("Operation cancelled by user")
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes: #521 

The issue is that Python has explicit handling set up for KeyboardInterrupt, but our Rust extension doesn't respect this, so potentially long-running commands cannot be interrupted.

This introduces a module in our Rust extension called `interrupt` which lets us setup a ctrlc handler and atomically read the interrupt flag. I added reads (and early exits) to a couple places within the check/sync control flow. Specifically right before the module tree build, and before each file is visited during `check` (which is also the hot path of `sync`).