### PR TITLE
Layers

### DIFF
--- a/src/commands/check_internal.rs
+++ b/src/commands/check_internal.rs
@@ -338,8 +338,11 @@ fn check_layers(
 ) -> bool {
     match (&source_module_config.layer, &target_module_config.layer) {
         (Some(source_layer), Some(target_layer)) => {
+            // If the 'source' layer comes before the 'target' layer,
+            // this means a higher layer is importing a lower layer.
+            // This direction is allowed.
             layers.iter().position(|layer| layer == source_layer)
-                >= layers.iter().position(|layer| layer == target_layer)
+                <= layers.iter().position(|layer| layer == target_layer)
         }
         _ => true,
     }

--- a/src/commands/check_internal.rs
+++ b/src/commands/check_internal.rs
@@ -138,7 +138,7 @@ pub enum ImportCheckError {
         invalid_module: String,
     },
 
-    #[error("Cannot import '{import_mod_path}'. Module '{source_module}' is in layer '{source_layer}', while module '{invalid_module}' is in layer '{invalid_layer}'.")]
+    #[error("Cannot import '{import_mod_path}'. Layer '{source_layer}' ('{source_module}') is lower than layer '{invalid_layer}' ('{invalid_module}').")]
     LayerViolation {
         import_mod_path: String,
         source_module: String,

--- a/src/commands/check_internal.rs
+++ b/src/commands/check_internal.rs
@@ -338,11 +338,17 @@ fn check_layers(
 ) -> bool {
     match (&source_module_config.layer, &target_module_config.layer) {
         (Some(source_layer), Some(target_layer)) => {
-            // If the 'source' layer comes before the 'target' layer,
-            // this means a higher layer is importing a lower layer.
-            // This direction is allowed.
-            layers.iter().position(|layer| layer == source_layer)
-                <= layers.iter().position(|layer| layer == target_layer)
+            let source_index = layers.iter().position(|layer| layer == source_layer);
+            let target_index = layers.iter().position(|layer| layer == target_layer);
+
+            match (source_index, target_index) {
+                // If the 'source' layer comes before the 'target' layer,
+                // this means a higher layer is importing a lower layer.
+                // This direction is allowed.
+                (Some(source_index), Some(target_index)) => source_index <= target_index,
+                // If either index is not found, the layer is unknown -- ignore for now
+                _ => true,
+            }
         }
         _ => true,
     }

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -163,6 +163,21 @@ impl Default for ModuleConfig {
     }
 }
 
+impl ModuleConfig {
+    pub fn new_with_layer(path: &str, layer: &str) -> Self {
+        Self {
+            path: path.to_string(),
+            depends_on: vec![],
+            layer: Some(layer.to_string()),
+            visibility: default_visibility(),
+            utility: false,
+            strict: false,
+            unchecked: false,
+            group_id: None,
+        }
+    }
+}
+
 #[pymethods]
 impl ModuleConfig {
     #[new]

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -110,6 +110,14 @@ impl<'de> Deserialize<'de> for DependencyConfig {
     }
 }
 
+pub fn default_visibility() -> Vec<String> {
+    global_visibility()
+}
+
+pub fn is_default_visibility(value: &Vec<String>) -> bool {
+    value == &default_visibility()
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[pyclass(get_all, eq, module = "tach.extension")]
 pub struct ModuleConfig {

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -30,6 +30,8 @@ pub struct ProjectConfig {
     pub modules: Vec<ModuleConfig>,
     #[serde(default)]
     pub interfaces: Vec<InterfaceConfig>,
+    #[serde(default, skip_serializing_if = "is_empty")]
+    pub layers: Vec<String>,
     #[serde(default, skip_serializing_if = "CacheConfig::is_default")]
     pub cache: CacheConfig,
     #[serde(default, skip_serializing_if = "ExternalDependencyConfig::is_default")]
@@ -58,11 +60,25 @@ pub struct ProjectConfig {
     pub rules: RulesConfig,
 }
 
+pub fn default_source_roots() -> Vec<PathBuf> {
+    vec![PathBuf::from(".")]
+}
+
+pub const DEFAULT_EXCLUDE_PATHS: [&str; 4] = ["tests", "docs", ".*__pycache__", ".*egg-info"];
+
+pub fn default_excludes() -> Vec<String> {
+    DEFAULT_EXCLUDE_PATHS
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
 impl Default for ProjectConfig {
     fn default() -> Self {
         Self {
             modules: Default::default(),
             interfaces: Default::default(),
+            layers: Default::default(),
             cache: Default::default(),
             external: Default::default(),
             exclude: default_excludes(),
@@ -134,6 +150,7 @@ impl ProjectConfig {
         Self {
             modules,
             interfaces: self.interfaces.clone(),
+            layers: self.layers.clone(),
             cache: self.cache.clone(),
             external: self.external.clone(),
             exclude: self.exclude.clone(),

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -1,32 +1,10 @@
-use std::path::PathBuf;
-
-pub const DEFAULT_EXCLUDE_PATHS: [&str; 4] = ["tests", "docs", ".*__pycache__", ".*egg-info"];
-
 // for serde
 pub fn default_true() -> bool {
     true
 }
-pub fn default_source_roots() -> Vec<PathBuf> {
-    vec![PathBuf::from(".")]
-}
-
-pub fn default_excludes() -> Vec<String> {
-    DEFAULT_EXCLUDE_PATHS
-        .iter()
-        .map(|s| s.to_string())
-        .collect()
-}
 
 pub fn global_visibility() -> Vec<String> {
     vec!["*".to_string()]
-}
-
-pub fn default_visibility() -> Vec<String> {
-    global_visibility()
-}
-
-pub fn is_default_visibility(value: &Vec<String>) -> bool {
-    value == &default_visibility()
 }
 
 pub fn is_true(value: &bool) -> bool {
@@ -35,4 +13,8 @@ pub fn is_true(value: &bool) -> bool {
 
 pub fn is_false(value: &bool) -> bool {
     !*value
+}
+
+pub fn is_empty<T>(value: &[T]) -> bool {
+    value.is_empty()
 }

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -84,8 +84,8 @@ mod tests {
 
     use super::*;
     use crate::{
+        config::project::DEFAULT_EXCLUDE_PATHS,
         config::root_module::ROOT_MODULE_SENTINEL_TAG,
-        config::utils::DEFAULT_EXCLUDE_PATHS,
         config::{DependencyConfig, ModuleConfig},
         tests::fixtures::example_dir,
     };
@@ -126,6 +126,7 @@ mod tests {
                     }
                 ],
                 interfaces: Default::default(),
+                layers: Default::default(),
                 cache: Default::default(),
                 exclude: DEFAULT_EXCLUDE_PATHS
                     .into_iter()

--- a/src/tests/check_internal.rs
+++ b/src/tests/check_internal.rs
@@ -16,6 +16,15 @@ pub mod fixtures {
     }
 
     #[fixture]
+    pub fn layers() -> Vec<String> {
+        vec![
+            "top".to_string(),
+            "middle".to_string(),
+            "bottom".to_string(),
+        ]
+    }
+
+    #[fixture]
     pub fn module_tree() -> ModuleTree {
         ModuleTree {
             root: Arc::new(ModuleNode {
@@ -35,6 +44,7 @@ pub mod fixtures {
                                     DependencyConfig::from_path("domain_three"),
                                 ],
                                 strict: false,
+                                layer: Some("top".to_string()),
                                 ..Default::default()
                             }),
                             children: HashMap::from([(
@@ -42,7 +52,10 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "domain_one.subdomain".to_string(),
-                                    config: Some(ModuleConfig::new("domain_one.subdomain", false)),
+                                    config: Some(ModuleConfig::new_with_layer(
+                                        "domain_one.subdomain",
+                                        "middle",
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             )]),
@@ -57,6 +70,7 @@ pub mod fixtures {
                                 path: "domain_two".to_string(),
                                 depends_on: vec![DependencyConfig::from_path("domain_one")],
                                 strict: false,
+                                layer: Some("top".to_string()),
                                 ..Default::default()
                             }),
                             children: HashMap::from([(
@@ -68,6 +82,7 @@ pub mod fixtures {
                                         path: "domain_two".to_string(),
                                         depends_on: vec![DependencyConfig::from_path("domain_one")],
                                         strict: false,
+                                        layer: Some("top".to_string()),
                                         ..Default::default()
                                     }),
                                     children: HashMap::new(),
@@ -80,7 +95,7 @@ pub mod fixtures {
                         Arc::new(ModuleNode {
                             is_end_of_path: true,
                             full_path: "domain_three".to_string(),
-                            config: Some(ModuleConfig::new("domain_three", false)),
+                            config: Some(ModuleConfig::new_with_layer("domain_three", "bottom")),
                             children: HashMap::new(),
                         }),
                     ),
@@ -99,16 +114,18 @@ pub mod fixtures {
                     DependencyConfig::from_path("domain_three"),
                 ],
                 strict: false,
+                layer: Some("top".to_string()),
                 ..Default::default()
             },
-            ModuleConfig::new("domain_one.subdomain", false),
+            ModuleConfig::new_with_layer("domain_one.subdomain", "middle"),
             ModuleConfig {
                 path: "domain_two".to_string(),
                 depends_on: vec![DependencyConfig::from_path("domain_one")],
                 strict: false,
+                layer: Some("top".to_string()),
                 ..Default::default()
             },
-            ModuleConfig::new("domain_three", false),
+            ModuleConfig::new_with_layer("domain_three", "bottom"),
         ]
     }
 

--- a/tach.toml
+++ b/tach.toml
@@ -1,3 +1,8 @@
+layers = [
+    "ui",
+    "commands",
+    "core",
+]
 exclude = [
     "**/__pycache__",
     "**/tests",
@@ -12,12 +17,6 @@ source_roots = [
 exact = true
 forbid_circular_dependencies = true
 use_regex_matching = false
-
-layers = [
-    "ui",
-    "commands",
-    "core"
-]
 
 [[modules]]
 path = "tach"
@@ -68,20 +67,20 @@ layer = "ui"
 [[modules]]
 path = "tach.colors"
 depends_on = []
-utility = true
 layer = "core"
+utility = true
 
 [[modules]]
 path = "tach.constants"
 depends_on = []
-utility = true
 layer = "core"
+utility = true
 
 [[modules]]
 path = "tach.errors"
 depends_on = []
-utility = true
 layer = "core"
+utility = true
 
 [[modules]]
 path = "tach.extension"
@@ -202,8 +201,8 @@ layer = "commands"
 [[modules]]
 path = "tach.utils"
 depends_on = []
-utility = true
 layer = "core"
+utility = true
 
 [[interfaces]]
 expose = [

--- a/tach.toml
+++ b/tach.toml
@@ -13,6 +13,12 @@ exact = true
 forbid_circular_dependencies = true
 use_regex_matching = false
 
+layers = [
+    "ui",
+    "commands",
+    "core"
+]
+
 [[modules]]
 path = "tach"
 depends_on = []
@@ -22,6 +28,7 @@ path = "tach.__main__"
 depends_on = [
     "tach.start",
 ]
+layer = "ui"
 
 [[modules]]
 path = "tach.cache"
@@ -29,12 +36,14 @@ depends_on = [
     "tach",
     "tach.filesystem",
 ]
+layer = "core"
 
 [[modules]]
 path = "tach.check_external"
 depends_on = [
     "tach.extension",
 ]
+layer = "commands"
 
 [[modules]]
 path = "tach.cli"
@@ -54,49 +63,59 @@ depends_on = [
     "tach.sync",
     "tach.test",
 ]
+layer = "ui"
 
 [[modules]]
 path = "tach.colors"
 depends_on = []
 utility = true
+layer = "core"
 
 [[modules]]
 path = "tach.constants"
 depends_on = []
 utility = true
+layer = "core"
 
 [[modules]]
 path = "tach.errors"
 depends_on = []
 utility = true
+layer = "core"
 
 [[modules]]
 path = "tach.extension"
 depends_on = []
+layer = "core"
 
 [[modules]]
 path = "tach.filesystem"
 depends_on = [
     "tach.hooks",
 ]
+layer = "core"
 
 [[modules]]
 path = "tach.filesystem.git_ops"
 depends_on = []
+layer = "core"
 
 [[modules]]
 path = "tach.hooks"
 depends_on = []
+layer = "core"
 
 [[modules]]
 path = "tach.icons"
 depends_on = []
+layer = "core"
 
 [[modules]]
 path = "tach.interactive"
 depends_on = [
     "tach.filesystem",
 ]
+layer = "core"
 
 [[modules]]
 path = "tach.logging"
@@ -105,6 +124,7 @@ depends_on = [
     "tach.cache",
     "tach.parsing",
 ]
+layer = "core"
 
 [[modules]]
 path = "tach.mod"
@@ -113,6 +133,7 @@ depends_on = [
     "tach.interactive",
     "tach.parsing",
 ]
+layer = "commands"
 
 [[modules]]
 path = "tach.modularity"
@@ -122,6 +143,7 @@ depends_on = [
     "tach.filesystem.git_ops",
     "tach.parsing",
 ]
+layer = "commands"
 
 [[modules]]
 path = "tach.parsing"
@@ -129,6 +151,7 @@ depends_on = [
     "tach.extension",
     "tach.filesystem",
 ]
+layer = "core"
 
 [[modules]]
 path = "tach.pytest_plugin"
@@ -138,6 +161,7 @@ depends_on = [
     "tach.filesystem.git_ops",
     "tach.parsing",
 ]
+layer = "core"
 
 [[modules]]
 path = "tach.report"
@@ -145,6 +169,7 @@ depends_on = [
     "tach.extension",
     "tach.filesystem",
 ]
+layer = "commands"
 
 [[modules]]
 path = "tach.show"
@@ -152,12 +177,14 @@ depends_on = [
     "tach.extension",
     "tach.filesystem",
 ]
+layer = "commands"
 
 [[modules]]
 path = "tach.start"
 depends_on = [
     "tach.cli",
 ]
+layer = "ui"
 
 [[modules]]
 path = "tach.sync"
@@ -165,15 +192,18 @@ depends_on = [
     "tach.extension",
     "tach.filesystem",
 ]
+layer = "commands"
 
 [[modules]]
 path = "tach.test"
 depends_on = []
+layer = "commands"
 
 [[modules]]
 path = "tach.utils"
 depends_on = []
 utility = true
+layer = "core"
 
 [[interfaces]]
 expose = [


### PR DESCRIPTION
This PR gives Tach the ability to enforce **Layers** in your dependency graph. Layers are defined in a stack, such that higher layers can depend on lower layers, but not vice versa.

Example:
```toml
layers = [
    "ui",
    "commands",
    "core",
]


[[modules]]
path = "tach.__main__"
depends_on = [
    "tach.start",
]
layer = "ui"

[[modules]]
path = "tach.cache"
depends_on = [
    "tach",
    "tach.filesystem",
]
layer = "core"

[[modules]]
path = "tach.check_external"
depends_on = [
    "tach.extension",
]
layer = "commands"
```