### PR TITLE
fix macos nscharacterset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "tach"
-version = "0.19.6"
+version = "0.19.7"
 dependencies = [
  "cached",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tach"
-version = "0.19.6"
+version = "0.19.7"
 edition = "2021"
 
 [lib]

--- a/docs/usage/commands.mdx
+++ b/docs/usage/commands.mdx
@@ -255,7 +255,7 @@ If you use the [pre-commit framework](https://github.com/pre-commit/pre-commit),
 ```yaml
 repos:
   - repo: https://github.com/gauge-sh/tach-pre-commit
-    rev: v0.19.6 # change this to the latest tag!
+    rev: v0.19.7 # change this to the latest tag!
     hooks:
       - id: tach
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tach"
-version = "0.19.6"
+version = "0.19.7"
 authors = [
     { name = "Caelean Barnes", email = "caeleanb@gmail.com" },
     { name = "Evan Doyle", email = "evanmdoyle@gmail.com" },

--- a/python/tach/__init__.py
+++ b/python/tach/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-__version__: str = "0.19.6"
+__version__: str = "0.19.7"
 
 __all__ = ["__version__"]

--- a/python/tach/logging/logger.py
+++ b/python/tach/logging/logger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import multiprocessing
 import os
+import sys
 import threading
 import time
 from dataclasses import dataclass, field

--- a/python/tach/logging/logger.py
+++ b/python/tach/logging/logger.py
@@ -52,7 +52,7 @@ def handle_log_entry(record: logging.LogRecord, entry: str) -> None:
         def timeout_handler():
             nonlocal done
             if not done:
-                os._exit(1)
+                os._exit(1)  # pyright: ignore
 
         # Start timeout timer
         timer = threading.Timer(5.0, timeout_handler)
@@ -73,7 +73,7 @@ def spawn_log_entry(record: logging.LogRecord, entry: str) -> None:
         target=handle_log_entry, args=(record, entry), daemon=False
     )
     process.start()
-    os._exit(0)
+    os._exit(0)  # pyright: ignore
 
 
 class RemoteLoggingHandler(logging.Handler):


### PR DESCRIPTION
MacOS's object-C library's utilization of `NSCharacterSet` interferes with `os.fork()`, resulting in terminated child processes and garbage output. 

This PR removes `os.fork()` in exchange for `multiprocessing.set_start_method("spawn")` and `os._exit()` to effectively start nonblocking child processes.