### PR TITLE
Support JSON output from `tach check`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ cython_debug/
 
 # Generated report files
 modularity_report.json
+
+# Profiling
+profile.json

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
@@ -150,7 +151,7 @@ def print_unused_dependencies(
 
 def print_no_config_found(output_format: str = "text") -> None:
     if output_format == "json":
-        print('{"error": "No config file found"}')
+        json.dump({"error": "No config file found"}, sys.stdout)
     else:
         print(
             f"{BCOLORS.FAIL} {CONFIG_FILE_NAME}.toml not found. Do you need to run {BCOLORS.ENDC}'tach mod'{BCOLORS.FAIL}?{BCOLORS.ENDC}",
@@ -200,10 +201,8 @@ def print_circular_dependency_error(
     module_paths: list[str], output_format: str = "text"
 ) -> None:
     if output_format == "json":
-        print(
-            '{"error": "Circular dependency", "dependencies": '
-            + str(module_paths)
-            + "}"
+        json.dump(
+            {"error": "Circular dependency", "dependencies": module_paths}, sys.stdout
         )
     else:
         print(
@@ -215,7 +214,8 @@ def print_circular_dependency_error(
             )
             + f"\n\n{BCOLORS.WARNING}Resolve circular dependencies.\n"
             f"Remove or unset 'forbid_circular_dependencies' from "
-            f"'{CONFIG_FILE_NAME}.toml' to allow circular dependencies.{BCOLORS.ENDC}"
+            f"'{CONFIG_FILE_NAME}.toml' to allow circular dependencies.{BCOLORS.ENDC}",
+            file=sys.stderr,
         )
 
 
@@ -223,10 +223,9 @@ def print_visibility_errors(
     visibility_errors: list[tuple[str, str, list[str]]], output_format: str = "text"
 ) -> None:
     if output_format == "json":
-        print(
-            '{"error": "Visibility error", "visibility_errors": '
-            + str(visibility_errors)
-            + "}"
+        json.dump(
+            {"error": "Visibility error", "visibility_errors": visibility_errors},
+            sys.stdout,
         )
     else:
         for dependent_module, dependency_module, visibility in visibility_errors:
@@ -234,7 +233,8 @@ def print_visibility_errors(
                 f"{icons.FAIL} {BCOLORS.FAIL}Module configuration error:{BCOLORS.ENDC} {BCOLORS.WARNING}'{dependent_module}' cannot depend on '{dependency_module}' because '{dependent_module}' does not match its visibility: {visibility}.{BCOLORS.ENDC}"
                 "\n"
                 f"{BCOLORS.WARNING}Adjust 'visibility' for '{dependency_module}' to include '{dependent_module}', or remove the dependency.{BCOLORS.ENDC}"
-                "\n"
+                "\n",
+                file=sys.stderr,
             )
 
 
@@ -250,7 +250,8 @@ def print_undeclared_dependencies(
                 print(f"\t{BCOLORS.FAIL}{dependency}{BCOLORS.ENDC}")
     print(
         f"{BCOLORS.WARNING}\nAdd the undeclared dependencies to the corresponding pyproject.toml file, "
-        f"or consider ignoring the dependencies by adding them to the 'external.exclude' list in {CONFIG_FILE_NAME}.toml.\n{BCOLORS.ENDC}"
+        f"or consider ignoring the dependencies by adding them to the 'external.exclude' list in {CONFIG_FILE_NAME}.toml.\n{BCOLORS.ENDC}",
+        file=sys.stderr,
     )
 
 
@@ -266,7 +267,8 @@ def print_unused_external_dependencies(
                 print(f"\t{BCOLORS.WARNING}{dependency}{BCOLORS.ENDC}")
     print(
         f"{BCOLORS.OKCYAN}\nRemove the unused dependencies from the corresponding pyproject.toml file, "
-        f"or consider ignoring the dependencies by adding them to the 'external.exclude' list in {CONFIG_FILE_NAME}.toml.\n{BCOLORS.ENDC}"
+        f"or consider ignoring the dependencies by adding them to the 'external.exclude' list in {CONFIG_FILE_NAME}.toml.\n{BCOLORS.ENDC}",
+        file=sys.stderr,
     )
 
 
@@ -630,7 +632,7 @@ def tach_check(
             try:
                 print(check_result.serialize_json(pretty_print=True))
             except ValueError as e:
-                print('{"error": "' + str(e) + '"}')
+                json.dump({"error": str(e)}, sys.stdout)
             sys.exit(1 if len(check_result.errors) > 0 else 0)
 
         if check_result.warnings:
@@ -667,7 +669,7 @@ def tach_check(
         sys.exit(1)
     except Exception as e:
         if output_format == "json":
-            print('{"error": "' + str(e) + '"}')
+            json.dump({"error": str(e)}, sys.stdout)
         else:
             print(str(e))
         sys.exit(1)
@@ -1011,7 +1013,7 @@ def tach_test(
 
     if pytest_args and pytest_args[0] != "--":
         print(
-            f"{BCOLORS.FAIL}Unknown arguments received. Use '--' to separate arguments for pytest. Ex: '{TOOL_NAME} test -- -v'{BCOLORS.ENDC}"
+            f"{BCOLORS.FAIL}Unknown arguments received. Use '--' to separate arguments for pytest. Ex: '{TOOL_NAME} test -- -v'"
         )
         sys.exit(1)
 

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -1013,7 +1013,7 @@ def tach_test(
 
     if pytest_args and pytest_args[0] != "--":
         print(
-            f"{BCOLORS.FAIL}Unknown arguments received. Use '--' to separate arguments for pytest. Ex: '{TOOL_NAME} test -- -v'"
+            f"{BCOLORS.FAIL}Unknown arguments received. Use '--' to separate arguments for pytest. Ex: '{TOOL_NAME} test -- -v'{BCOLORS.ENDC}"
         )
         sys.exit(1)
 

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -627,7 +627,10 @@ def tach_check(
         )
 
         if output_format == "json":
-            print(check_result.serialize_json(pretty_print=True))
+            try:
+                print(check_result.serialize_json(pretty_print=True))
+            except ValueError as e:
+                print('{"error": "' + str(e) + '"}')
             sys.exit(1 if len(check_result.errors) > 0 else 0)
 
         if check_result.warnings:

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -93,6 +93,8 @@ class CheckDiagnostics:
     deprecated_warnings: list[BoundaryError]
     warnings: list[str]
 
+    def serialize_json(self, pretty_print: bool = False) -> str: ...
+
 class DependencyConfig:
     path: str
     deprecated: bool

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import json
+from unittest.mock import NonCallableMagicMock
+
 import pytest
 
 from tach.cli import tach_check
+from tach.errors import TachCircularDependencyError, TachVisibilityError
+from tach.extension import CheckDiagnostics
 from tach.icons import SUCCESS, WARNING
 
 
@@ -12,8 +17,8 @@ def test_valid_example_dir(example_dir, capfd):
         tach_check(project_root=project_root)
     assert exc_info.value.code == 0
     captured = capfd.readouterr()
-    assert SUCCESS in captured.out  # success state
-    assert WARNING in captured.err  # deprecated warning
+    assert SUCCESS in captured.out
+    assert WARNING in captured.err
 
 
 def test_valid_example_dir_monorepo(example_dir):
@@ -21,3 +26,107 @@ def test_valid_example_dir_monorepo(example_dir):
     with pytest.raises(SystemExit) as exc_info:
         tach_check(project_root=project_root)
     assert exc_info.value.code == 0
+
+
+def test_check_json_output(example_dir, capfd, mocker):
+    project_root = example_dir / "valid"
+
+    mock_diagnostics = NonCallableMagicMock(spec=CheckDiagnostics)
+    mock_diagnostics.serialize_json.return_value = json.dumps(
+        {"errors": [], "warnings": []}
+    )
+    mocker.patch("tach.cli.check", return_value=mock_diagnostics)
+
+    with pytest.raises(SystemExit) as exc_info:
+        tach_check(project_root=project_root, output_format="json")
+    assert exc_info.value.code == 0
+
+    captured = capfd.readouterr()
+    assert json.loads(captured.out) == {"errors": [], "warnings": []}
+
+
+def test_check_json_with_errors(example_dir, capfd, mocker):
+    project_root = example_dir / "valid"
+
+    mock_diagnostics = NonCallableMagicMock(spec=CheckDiagnostics)
+    mock_diagnostics.serialize_json.return_value = json.dumps(
+        {"errors": ["error1", "error2"], "warnings": ["warning1"]}
+    )
+    mocker.patch("tach.cli.check", return_value=mock_diagnostics)
+
+    with pytest.raises(SystemExit):
+        tach_check(project_root=project_root, output_format="json")
+
+    captured = capfd.readouterr()
+    assert json.loads(captured.out) == {
+        "errors": ["error1", "error2"],
+        "warnings": ["warning1"],
+    }
+
+
+def test_check_circular_dependency_text(example_dir, capfd, mocker):
+    project_root = example_dir / "valid"
+
+    mocker.patch(
+        "tach.cli.check",
+        side_effect=TachCircularDependencyError(["mod1", "mod2", "mod1"]),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        tach_check(project_root=project_root)
+    assert exc_info.value.code == 1
+
+    captured = capfd.readouterr()
+    assert "Circular dependency detected" in captured.err
+    assert "'mod1'" in captured.err
+    assert "'mod2'" in captured.err
+
+
+def test_check_circular_dependency_json(example_dir, capfd, mocker):
+    project_root = example_dir / "valid"
+
+    mocker.patch(
+        "tach.cli.check",
+        side_effect=TachCircularDependencyError(["mod1", "mod2", "mod1"]),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        tach_check(project_root=project_root, output_format="json")
+    assert exc_info.value.code == 1
+
+    captured = capfd.readouterr()
+    result = json.loads(captured.out)
+    assert result["error"] == "Circular dependency"
+    assert result["dependencies"] == ["mod1", "mod2", "mod1"]
+
+
+def test_check_visibility_error_text(example_dir, capfd, mocker):
+    project_root = example_dir / "valid"
+
+    visibility_errors = [("mod1", "mod2", ["public"])]
+    mocker.patch("tach.cli.check", side_effect=TachVisibilityError(visibility_errors))
+
+    with pytest.raises(SystemExit) as exc_info:
+        tach_check(project_root=project_root)
+    assert exc_info.value.code == 1
+
+    captured = capfd.readouterr()
+    assert "Module configuration error" in captured.err
+    assert "'mod1' cannot depend on 'mod2'" in captured.err
+    assert "public" in captured.err
+
+
+def test_check_visibility_error_json(example_dir, capfd, mocker):
+    project_root = example_dir / "valid"
+
+    visibility_errors = [("mod1", "mod2", ["public"])]
+    mocker.patch("tach.cli.check", side_effect=TachVisibilityError(visibility_errors))
+
+    with pytest.raises(SystemExit) as exc_info:
+        tach_check(project_root=project_root, output_format="json")
+    assert exc_info.value.code == 1
+
+    captured = capfd.readouterr()
+    result = json.loads(captured.out)
+    assert result["error"] == "Visibility error"
+    assert result["visibility_errors"] == [["mod1", "mod2", ["public"]]]


### PR DESCRIPTION
Solves: #526 

This PR adds an `--output` flag to `tach check` to switch between the current human-readable text format and a machine-readable JSON format.

This format is NOT guaranteed to be stable at all right now.