### PR TITLE
Fix tach server startup by unifying ctrlc interrupts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,10 +300,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -315,6 +357,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -334,9 +382,13 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1081,10 +1133,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
 
 [[package]]
 name = "semver"
@@ -1142,6 +1209,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1228,6 +1320,7 @@ dependencies = [
  "ruff_source_file",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.7",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ debug = true
 
 [dev-dependencies]
 rstest = "0.24.0"
+serial_test = "3.2.0"

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,14 +1,60 @@
-use crossbeam_channel::{bounded, Receiver, Sender};
+use crossbeam_channel::{bounded, Receiver};
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 
 static INTERRUPT_SIGNAL: AtomicBool = AtomicBool::new(false);
-static INTERRUPT_CHANNEL: Lazy<(Sender<()>, Receiver<()>)> = Lazy::new(|| bounded(1));
+static INTERRUPT_NOTIFIER: Lazy<Arc<InterruptNotifier>> =
+    Lazy::new(|| Arc::new(InterruptNotifier::new()));
+
+struct InterruptNotifier {
+    condvar: Condvar,
+    mutex: Mutex<()>,
+}
+
+impl InterruptNotifier {
+    fn new() -> Self {
+        Self {
+            condvar: Condvar::new(),
+            mutex: Mutex::new(()),
+        }
+    }
+
+    fn create_channel(&self) -> Receiver<()> {
+        let (sender, receiver) = bounded(1);
+        let (ready_sender, ready_receiver) = bounded(0);
+        let notifier = Arc::clone(&INTERRUPT_NOTIFIER);
+
+        std::thread::spawn(move || {
+            let mut _guard = notifier.mutex.lock().unwrap();
+            // Send a ready signal AFTER acquiring the mutex
+            let _ = ready_sender.send(());
+            loop {
+                // Waiting on the condvar will block the thread AND release the mutex
+                // Then when the condvar is notified, it will re-acquire the mutex
+                // and continue the loop
+                _guard = notifier.condvar.wait(_guard).unwrap();
+                if INTERRUPT_SIGNAL.load(Ordering::SeqCst) {
+                    let _ = sender.send(());
+                    return;
+                }
+            }
+        });
+
+        // Wait for the thread to be ready (acquire the mutex)
+        let _ = ready_receiver.recv();
+        receiver
+    }
+}
 
 pub fn setup_interrupt_handler() {
     ctrlc::set_handler(move || {
         INTERRUPT_SIGNAL.store(true, Ordering::SeqCst);
-        let _ = INTERRUPT_CHANNEL.0.send(());
+        // Notify all waiting threads
+        // This acquires the mutex, which means any channels must be waiting on the condvar
+        // and will be notified
+        let _guard = INTERRUPT_NOTIFIER.mutex.lock().unwrap();
+        INTERRUPT_NOTIFIER.condvar.notify_all();
     })
     .expect("Error setting Ctrl-C handler");
 }
@@ -22,5 +68,65 @@ pub fn check_interrupt() -> Result<(), &'static str> {
 }
 
 pub fn get_interrupt_channel() -> Receiver<()> {
-    INTERRUPT_CHANNEL.1.clone()
+    INTERRUPT_NOTIFIER.create_channel()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_interrupt() {
+        assert!(check_interrupt().is_ok());
+
+        INTERRUPT_SIGNAL.store(true, Ordering::SeqCst);
+        assert_eq!(check_interrupt(), Err("Operation cancelled by user"));
+
+        // This must be reset for other tests
+        INTERRUPT_SIGNAL.store(false, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn test_interrupt_channel() {
+        let receiver = get_interrupt_channel();
+        // Initially should not receive anything
+        assert!(receiver.try_recv().is_err());
+
+        // Manually trigger interrupt
+        {
+            INTERRUPT_SIGNAL.store(true, Ordering::SeqCst);
+            let _guard = INTERRUPT_NOTIFIER.mutex.lock().unwrap();
+            INTERRUPT_NOTIFIER.condvar.notify_all();
+        }
+
+        // Should receive notification
+        assert!(receiver.recv().is_ok());
+
+        // Reset for other tests
+        INTERRUPT_SIGNAL.store(false, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn test_multiple_interrupt_channels() {
+        let receiver1 = get_interrupt_channel();
+        let receiver2 = get_interrupt_channel();
+        let receiver3 = get_interrupt_channel();
+        assert!(receiver1.try_recv().is_err());
+        assert!(receiver2.try_recv().is_err());
+        assert!(receiver3.try_recv().is_err());
+
+        {
+            INTERRUPT_SIGNAL.store(true, Ordering::SeqCst);
+            let _guard = INTERRUPT_NOTIFIER.mutex.lock().unwrap();
+            INTERRUPT_NOTIFIER.condvar.notify_all();
+        }
+
+        // All receivers should get the signal
+        assert!(receiver1.recv().is_ok());
+        assert!(receiver2.recv().is_ok());
+        assert!(receiver3.recv().is_ok());
+
+        // Reset for other tests
+        INTERRUPT_SIGNAL.store(false, Ordering::SeqCst);
+    }
 }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -76,20 +76,26 @@ pub fn get_interrupt_channel() -> Receiver<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::*;
+    use serial_test::serial;
 
-    #[test]
-    fn test_check_interrupt() {
+    #[fixture]
+    fn reset_interrupt_signal() {
+        INTERRUPT_SIGNAL.store(false, Ordering::SeqCst);
+    }
+
+    #[rstest]
+    #[serial]
+    fn test_check_interrupt(_reset_interrupt_signal: ()) {
         assert!(check_interrupt().is_ok());
 
         INTERRUPT_SIGNAL.store(true, Ordering::SeqCst);
         assert_eq!(check_interrupt(), Err("Operation cancelled by user"));
-
-        // This must be reset for other tests
-        INTERRUPT_SIGNAL.store(false, Ordering::SeqCst);
     }
 
-    #[test]
-    fn test_interrupt_channel() {
+    #[rstest]
+    #[serial]
+    fn test_interrupt_channel(_reset_interrupt_signal: ()) {
         let receiver = get_interrupt_channel();
         // Initially should not receive anything
         assert!(receiver.try_recv().is_err());
@@ -103,13 +109,11 @@ mod tests {
 
         // Should receive notification
         assert!(receiver.recv().is_ok());
-
-        // Reset for other tests
-        INTERRUPT_SIGNAL.store(false, Ordering::SeqCst);
     }
 
-    #[test]
-    fn test_multiple_interrupt_channels() {
+    #[rstest]
+    #[serial]
+    fn test_multiple_interrupt_channels(_reset_interrupt_signal: ()) {
         let receiver1 = get_interrupt_channel();
         let receiver2 = get_interrupt_channel();
         let receiver3 = get_interrupt_channel();

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -34,6 +34,8 @@ impl InterruptNotifier {
                 // Then when the condvar is notified, it will re-acquire the mutex
                 // and continue the loop
                 _guard = notifier.condvar.wait(_guard).unwrap();
+                // After waking, check if the interrupt signal is set
+                // Spurious wakeups are possible, so we must check the signal
                 if INTERRUPT_SIGNAL.load(Ordering::SeqCst) {
                     let _ = sender.send(());
                     return;


### PR DESCRIPTION
This PR fixes `tach server`, which started failing after fixing the Ctrl + C behavior in tach sync/check.

The failure happened because we initialized a new ctrlc handler on initialization of the extension module, and then tried to initialize another handler when running the LSP server. Only one is allowed.

This PR extends our 'interrupt' module to provide access to an interrupt channel, so that the LSP server can receive an interrupt from the same ctrlc handler, even when idle.