### PR TITLE
Higher layers auto-allow dependencies on lower layers

### DIFF
--- a/src/commands/check_internal/checks.rs
+++ b/src/commands/check_internal/checks.rs
@@ -18,7 +18,7 @@ fn check_dependencies(
 ) -> Result<(), ImportCheckError> {
     // Layer check should take precedence over other dependency checks
     match check_layers(layers, file_module_config, import_module_config) {
-        LayerCheckResult::Ok => return Ok(()),
+        LayerCheckResult::Ok => return Ok(()), // Higher layers can unconditionally import lower layers
         LayerCheckResult::SameLayer | LayerCheckResult::LayerNotSpecified => (), // We need to do further processing to determine if the dependency is allowed
         LayerCheckResult::LayerViolation(e) | LayerCheckResult::UnknownLayer(e) => return Err(e),
     };

--- a/src/commands/check_internal/diagnostics.rs
+++ b/src/commands/check_internal/diagnostics.rs
@@ -121,6 +121,9 @@ pub enum ImportCheckError {
         invalid_layer: String,
     },
 
+    #[error("Layer '{layer}' is not defined in the project.")]
+    UnknownLayer { layer: String },
+
     #[error("Import '{import_mod_path}' is unnecessarily ignored by a directive.")]
     UnusedIgnoreDirective { import_mod_path: String },
 

--- a/src/tests/check_internal.rs
+++ b/src/tests/check_internal.rs
@@ -40,8 +40,8 @@ pub mod fixtures {
                             config: Some(ModuleConfig {
                                 path: "domain_one".to_string(),
                                 depends_on: vec![
+                                    DependencyConfig::from_path("domain_two"),
                                     DependencyConfig::from_deprecated_path("domain_one.subdomain"),
-                                    DependencyConfig::from_path("domain_three"),
                                 ],
                                 strict: false,
                                 layer: Some("top".to_string()),
@@ -54,7 +54,7 @@ pub mod fixtures {
                                     full_path: "domain_one.subdomain".to_string(),
                                     config: Some(ModuleConfig::new_with_layer(
                                         "domain_one.subdomain",
-                                        "middle",
+                                        "top",
                                     )),
                                     children: HashMap::new(),
                                 }),
@@ -66,36 +66,44 @@ pub mod fixtures {
                         Arc::new(ModuleNode {
                             is_end_of_path: true,
                             full_path: "domain_two".to_string(),
+                            config: Some(ModuleConfig::new_with_layer("domain_two", "top")),
+                            children: HashMap::new(),
+                        }),
+                    ),
+                    (
+                        "service_one".to_string(),
+                        Arc::new(ModuleNode {
+                            is_end_of_path: true,
+                            full_path: "service_one".to_string(),
                             config: Some(ModuleConfig {
-                                path: "domain_two".to_string(),
-                                depends_on: vec![DependencyConfig::from_path("domain_one")],
+                                path: "service_one".to_string(),
+                                depends_on: vec![DependencyConfig::from_path(
+                                    "service_one.internal",
+                                )],
                                 strict: false,
-                                layer: Some("top".to_string()),
+                                layer: Some("middle".to_string()),
                                 ..Default::default()
                             }),
                             children: HashMap::from([(
-                                "subdomain".to_string(),
+                                "internal".to_string(),
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
-                                    full_path: "domain_two.subdomain".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "domain_two".to_string(),
-                                        depends_on: vec![DependencyConfig::from_path("domain_one")],
-                                        strict: false,
-                                        layer: Some("top".to_string()),
-                                        ..Default::default()
-                                    }),
+                                    full_path: "service_one.internal".to_string(),
+                                    config: Some(ModuleConfig::new_with_layer(
+                                        "service_one.internal",
+                                        "middle",
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             )]),
                         }),
                     ),
                     (
-                        "domain_three".to_string(),
+                        "data_one".to_string(),
                         Arc::new(ModuleNode {
                             is_end_of_path: true,
-                            full_path: "domain_three".to_string(),
-                            config: Some(ModuleConfig::new_with_layer("domain_three", "bottom")),
+                            full_path: "data_one".to_string(),
+                            config: Some(ModuleConfig::new_with_layer("data_one", "bottom")),
                             children: HashMap::new(),
                         }),
                     ),
@@ -110,22 +118,48 @@ pub mod fixtures {
             ModuleConfig {
                 path: "domain_one".to_string(),
                 depends_on: vec![
+                    DependencyConfig::from_path("domain_two"),
                     DependencyConfig::from_deprecated_path("domain_one.subdomain"),
-                    DependencyConfig::from_path("domain_three"),
                 ],
                 strict: false,
                 layer: Some("top".to_string()),
                 ..Default::default()
             },
-            ModuleConfig::new_with_layer("domain_one.subdomain", "middle"),
             ModuleConfig {
-                path: "domain_two".to_string(),
-                depends_on: vec![DependencyConfig::from_path("domain_one")],
+                path: "domain_one.subdomain".to_string(),
+                depends_on: vec![],
                 strict: false,
                 layer: Some("top".to_string()),
                 ..Default::default()
             },
-            ModuleConfig::new_with_layer("domain_three", "bottom"),
+            ModuleConfig {
+                path: "domain_two".to_string(),
+                depends_on: vec![],
+                strict: false,
+                layer: Some("top".to_string()),
+                ..Default::default()
+            },
+            ModuleConfig {
+                path: "service_one".to_string(),
+                depends_on: vec![DependencyConfig::from_path("service_one.internal")],
+                strict: false,
+                layer: Some("middle".to_string()),
+                ..Default::default()
+            },
+            ModuleConfig {
+                path: "service_one.internal".to_string(),
+                depends_on: vec![],
+                strict: false,
+                layer: Some("middle".to_string()),
+                ..Default::default()
+            },
+            ModuleConfig {
+                path: "data_one".to_string(),
+                depends_on: vec![],
+                strict: false,
+                layer: Some("bottom".to_string()),
+                ..Default::default()
+            },
         ]
     }
 

--- a/tach.toml
+++ b/tach.toml
@@ -39,28 +39,13 @@ layer = "core"
 
 [[modules]]
 path = "tach.check_external"
-depends_on = [
-    "tach.extension",
-]
+depends_on = []
 layer = "commands"
 
 [[modules]]
 path = "tach.cli"
 depends_on = [
     "tach",
-    "tach.cache",
-    "tach.check_external",
-    "tach.extension",
-    "tach.filesystem",
-    "tach.icons",
-    "tach.logging",
-    "tach.mod",
-    "tach.modularity",
-    "tach.parsing",
-    "tach.report",
-    "tach.show",
-    "tach.sync",
-    "tach.test",
 ]
 layer = "ui"
 
@@ -126,21 +111,12 @@ layer = "core"
 
 [[modules]]
 path = "tach.mod"
-depends_on = [
-    "tach.filesystem",
-    "tach.interactive",
-    "tach.parsing",
-]
+depends_on = []
 layer = "commands"
 
 [[modules]]
 path = "tach.modularity"
-depends_on = [
-    "tach.extension",
-    "tach.filesystem",
-    "tach.filesystem.git_ops",
-    "tach.parsing",
-]
+depends_on = []
 layer = "commands"
 
 [[modules]]
@@ -163,18 +139,12 @@ layer = "core"
 
 [[modules]]
 path = "tach.report"
-depends_on = [
-    "tach.extension",
-    "tach.filesystem",
-]
+depends_on = []
 layer = "commands"
 
 [[modules]]
 path = "tach.show"
-depends_on = [
-    "tach.extension",
-    "tach.filesystem",
-]
+depends_on = []
 layer = "commands"
 
 [[modules]]
@@ -186,10 +156,7 @@ layer = "ui"
 
 [[modules]]
 path = "tach.sync"
-depends_on = [
-    "tach.extension",
-    "tach.filesystem",
-]
+depends_on = []
 layer = "commands"
 
 [[modules]]


### PR DESCRIPTION
This PR makes layer checking more significant, by automatically allowing dependencies from higher layers on lower layers, without declaring them in `tach.toml`.  In other words, a 'high-level' module can depend on a 'low-level' module without declaring this dependency in its `depends_on` list.

Example:
```toml
layers = ["product", "services", "platform"]

[[modules]]
path = "my.product"
depends_on = ["other.product"]
layer = "product"


[[modules]]
path = "platform.module"
depends_on = ["other.library"]
layer = "platform"
```

After this PR, dependencies in `my.product` on `platform.module` will be _allowed_ with the configuration shown above, even though this dependency is not explicitly listed in `depends_on`.

After this change, layers can be a standalone alternative to `depends_on`, rather than a preliminary check before the standard dependency checks. To complete this work, there will be a follow-on PR which allows omitting the `depends_on` key entirely.