### PR TITLE
Make `depends_on` optional

### DIFF
--- a/src/commands/check_internal/checks.rs
+++ b/src/commands/check_internal/checks.rs
@@ -372,4 +372,41 @@ mod tests {
         let result = check_layers(&layers, &source_config, &target_config);
         assert!(matches!(result, LayerCheckResult::LayerNotSpecified));
     }
+
+    #[rstest]
+    #[case("unrestricted", "domain_one", false)] // middle->top denied due to layer check
+    #[case("unrestricted", "service_one", true)] // same layer allowed
+    #[case("unrestricted", "data_one", true)] // middle->bottom allowed
+    fn test_check_import_unrestricted_dependencies(
+        module_tree: ModuleTree,
+        module_config: Vec<ModuleConfig>,
+        interface_config: Vec<InterfaceConfig>,
+        layers: Vec<String>,
+        #[case] file_mod_path: &str,
+        #[case] import_mod_path: &str,
+        #[case] expected_result: bool,
+    ) {
+        let file_module = module_tree.find_nearest(file_mod_path).unwrap();
+        let interface_checker = Some(
+            InterfaceChecker::new(&interface_config)
+                .with_type_check_cache(&module_config, &[PathBuf::from(".")])
+                .unwrap(),
+        );
+
+        let check_error = check_import(
+            import_mod_path,
+            &module_tree,
+            file_module.clone(),
+            &layers,
+            RootModuleTreatment::Allow,
+            &interface_checker,
+            true,
+        );
+        let result = check_error.is_ok();
+        assert_eq!(
+            result, expected_result,
+            "Expected import from '{}' to '{}' to be {}, but got {}",
+            file_mod_path, import_mod_path, expected_result, result
+        );
+    }
 }

--- a/src/commands/check_internal/checks.rs
+++ b/src/commands/check_internal/checks.rs
@@ -23,15 +23,19 @@ fn check_dependencies(
         LayerCheckResult::LayerViolation(e) | LayerCheckResult::UnknownLayer(e) => return Err(e),
     };
 
+    if file_module_config.depends_on.is_none() {
+        return Ok(());
+    }
+
     if import_module_config.utility {
         return Ok(());
     }
+
     let file_nearest_module_path = &file_module_config.path;
     let import_nearest_module_path = &import_module_config.path;
 
     match file_module_config
-        .depends_on
-        .iter()
+        .dependencies_iter()
         .find(|dep| &dep.path == import_nearest_module_path)
     {
         Some(DependencyConfig {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -88,7 +88,7 @@ pub fn sync_dependency_constraints(
                 new_modules.push(module.with_no_dependencies());
             }
             // Track deprecations for each module
-            for dependency in module.depends_on.iter() {
+            for dependency in module.dependencies_iter() {
                 if dependency.deprecated {
                     deprecation_map
                         .entry(module.path.clone())

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -104,7 +104,7 @@ impl TachPytestPluginHandler {
 fn build_module_consumer_map(modules: &Vec<ModuleConfig>) -> HashMap<&String, Vec<String>> {
     let mut consumer_map: HashMap<&String, Vec<String>> = HashMap::new();
     for module in modules {
-        for dependency in &module.depends_on {
+        for dependency in module.dependencies_iter() {
             consumer_map
                 .entry(&dependency.path)
                 .or_default()
@@ -154,7 +154,7 @@ fn find_affected_modules(
 }
 
 pub fn get_affected_modules(
-    project_root: &PathBuf,
+    project_root: &Path,
     project_config: &ProjectConfig,
     changed_files: Vec<PathBuf>,
     module_tree: &ModuleTree,

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -152,7 +152,7 @@ impl Default for ModuleConfig {
     fn default() -> Self {
         Self {
             path: Default::default(),
-            depends_on: Default::default(),
+            depends_on: Some(vec![]),
             layer: Default::default(),
             visibility: default_visibility(),
             utility: Default::default(),
@@ -192,7 +192,7 @@ impl ModuleConfig {
     pub fn new(path: &str, strict: bool) -> Self {
         Self {
             path: path.to_string(),
-            depends_on: None,
+            depends_on: Some(vec![]),
             layer: None,
             visibility: default_visibility(),
             utility: false,

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -29,7 +29,9 @@ pub fn dump_project_config_to_toml(
     });
 
     for module in &mut config.modules {
-        module.depends_on.sort_by(|a, b| a.path.cmp(&b.path));
+        if let Some(depends_on) = &mut module.depends_on {
+            depends_on.sort_by(|a, b| a.path.cmp(&b.path));
+        }
     }
 
     config.exclude.sort();
@@ -102,25 +104,27 @@ mod tests {
                 modules: vec![
                     ModuleConfig {
                         path: "domain_one".to_string(),
-                        depends_on: vec![DependencyConfig::from_deprecated_path("domain_two")],
+                        depends_on: Some(vec![DependencyConfig::from_deprecated_path(
+                            "domain_two"
+                        )]),
                         strict: false,
                         ..Default::default()
                     },
                     ModuleConfig {
                         path: "domain_three".to_string(),
-                        depends_on: vec![],
+                        depends_on: Some(vec![]),
                         strict: false,
                         ..Default::default()
                     },
                     ModuleConfig {
                         path: "domain_two".to_string(),
-                        depends_on: vec![DependencyConfig::from_path("domain_three")],
+                        depends_on: Some(vec![DependencyConfig::from_path("domain_three")]),
                         strict: false,
                         ..Default::default()
                     },
                     ModuleConfig {
                         path: ROOT_MODULE_SENTINEL_TAG.to_string(),
-                        depends_on: vec![DependencyConfig::from_path("domain_one")],
+                        depends_on: Some(vec![DependencyConfig::from_path("domain_one")]),
                         strict: false,
                         ..Default::default()
                     }

--- a/src/tests/check_internal.rs
+++ b/src/tests/check_internal.rs
@@ -107,6 +107,21 @@ pub mod fixtures {
                             children: HashMap::new(),
                         }),
                     ),
+                    (
+                        "unrestricted".to_string(),
+                        Arc::new(ModuleNode {
+                            is_end_of_path: true,
+                            full_path: "unrestricted".to_string(),
+                            config: Some(ModuleConfig {
+                                path: "unrestricted".to_string(),
+                                depends_on: None,
+                                strict: false,
+                                layer: Some("middle".to_string()),
+                                ..Default::default()
+                            }),
+                            children: HashMap::new(),
+                        }),
+                    ),
                 ]),
             }),
         }
@@ -158,6 +173,13 @@ pub mod fixtures {
                 depends_on: Some(vec![]),
                 strict: false,
                 layer: Some("bottom".to_string()),
+                ..Default::default()
+            },
+            ModuleConfig {
+                path: "unrestricted".to_string(),
+                depends_on: None,
+                strict: false,
+                layer: Some("middle".to_string()),
                 ..Default::default()
             },
         ]

--- a/src/tests/check_internal.rs
+++ b/src/tests/check_internal.rs
@@ -39,10 +39,10 @@ pub mod fixtures {
                             full_path: "domain_one".to_string(),
                             config: Some(ModuleConfig {
                                 path: "domain_one".to_string(),
-                                depends_on: vec![
+                                depends_on: Some(vec![
                                     DependencyConfig::from_path("domain_two"),
                                     DependencyConfig::from_deprecated_path("domain_one.subdomain"),
-                                ],
+                                ]),
                                 strict: false,
                                 layer: Some("top".to_string()),
                                 ..Default::default()
@@ -77,9 +77,9 @@ pub mod fixtures {
                             full_path: "service_one".to_string(),
                             config: Some(ModuleConfig {
                                 path: "service_one".to_string(),
-                                depends_on: vec![DependencyConfig::from_path(
+                                depends_on: Some(vec![DependencyConfig::from_path(
                                     "service_one.internal",
-                                )],
+                                )]),
                                 strict: false,
                                 layer: Some("middle".to_string()),
                                 ..Default::default()
@@ -117,45 +117,45 @@ pub mod fixtures {
         vec![
             ModuleConfig {
                 path: "domain_one".to_string(),
-                depends_on: vec![
+                depends_on: Some(vec![
                     DependencyConfig::from_path("domain_two"),
                     DependencyConfig::from_deprecated_path("domain_one.subdomain"),
-                ],
+                ]),
                 strict: false,
                 layer: Some("top".to_string()),
                 ..Default::default()
             },
             ModuleConfig {
                 path: "domain_one.subdomain".to_string(),
-                depends_on: vec![],
+                depends_on: Some(vec![]),
                 strict: false,
                 layer: Some("top".to_string()),
                 ..Default::default()
             },
             ModuleConfig {
                 path: "domain_two".to_string(),
-                depends_on: vec![],
+                depends_on: Some(vec![]),
                 strict: false,
                 layer: Some("top".to_string()),
                 ..Default::default()
             },
             ModuleConfig {
                 path: "service_one".to_string(),
-                depends_on: vec![DependencyConfig::from_path("service_one.internal")],
+                depends_on: Some(vec![DependencyConfig::from_path("service_one.internal")]),
                 strict: false,
                 layer: Some("middle".to_string()),
                 ..Default::default()
             },
             ModuleConfig {
                 path: "service_one.internal".to_string(),
-                depends_on: vec![],
+                depends_on: Some(vec![]),
                 strict: false,
                 layer: Some("middle".to_string()),
                 ..Default::default()
             },
             ModuleConfig {
                 path: "data_one".to_string(),
-                depends_on: vec![],
+                depends_on: Some(vec![]),
                 strict: false,
                 layer: Some("bottom".to_string()),
                 ..Default::default()

--- a/src/tests/test.rs
+++ b/src/tests/test.rs
@@ -12,47 +12,53 @@ pub mod fixtures {
             ModuleConfig::new("tach", true),
             ModuleConfig {
                 path: "tach.__main__".to_string(),
-                depends_on: vec![DependencyConfig::from_path("tach.start")],
+                depends_on: Some(vec![DependencyConfig::from_path("tach.start")]),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.cache".to_string(),
-                depends_on: ["tach", "tach.filesystem"]
-                    .map(DependencyConfig::from_path)
-                    .into(),
+                depends_on: Some(
+                    ["tach", "tach.filesystem"]
+                        .map(DependencyConfig::from_path)
+                        .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.check".to_string(),
-                depends_on: ["tach.errors", "tach.filesystem", "tach.parsing"]
-                    .map(DependencyConfig::from_path)
-                    .into(),
+                depends_on: Some(
+                    ["tach.errors", "tach.filesystem", "tach.parsing"]
+                        .map(DependencyConfig::from_path)
+                        .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.cli".to_string(),
-                depends_on: [
-                    "tach",
-                    "tach.cache",
-                    "tach.check",
-                    "tach.colors",
-                    "tach.constants",
-                    "tach.core",
-                    "tach.errors",
-                    "tach.filesystem",
-                    "tach.logging",
-                    "tach.mod",
-                    "tach.parsing",
-                    "tach.report",
-                    "tach.show",
-                    "tach.sync",
-                    "tach.test",
-                ]
-                .map(DependencyConfig::from_path)
-                .into(),
+                depends_on: Some(
+                    [
+                        "tach",
+                        "tach.cache",
+                        "tach.check",
+                        "tach.colors",
+                        "tach.constants",
+                        "tach.core",
+                        "tach.errors",
+                        "tach.filesystem",
+                        "tach.logging",
+                        "tach.mod",
+                        "tach.parsing",
+                        "tach.report",
+                        "tach.show",
+                        "tach.sync",
+                        "tach.test",
+                    ]
+                    .map(DependencyConfig::from_path)
+                    .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
@@ -60,112 +66,126 @@ pub mod fixtures {
             ModuleConfig::new("tach.constants", true),
             ModuleConfig {
                 path: "tach.core".to_string(),
-                depends_on: vec![DependencyConfig::from_path("tach.constants")],
+                depends_on: Some(vec![DependencyConfig::from_path("tach.constants")]),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig::new("tach.errors", true),
             ModuleConfig {
                 path: "tach.filesystem".to_string(),
-                depends_on: [
-                    "tach.colors",
-                    "tach.constants",
-                    "tach.core",
-                    "tach.errors",
-                    "tach.hooks",
-                ]
-                .map(DependencyConfig::from_path)
-                .into(),
+                depends_on: Some(
+                    [
+                        "tach.colors",
+                        "tach.constants",
+                        "tach.core",
+                        "tach.errors",
+                        "tach.hooks",
+                    ]
+                    .map(DependencyConfig::from_path)
+                    .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.filesystem.git_ops".to_string(),
-                depends_on: vec![DependencyConfig::from_path("tach.errors")],
+                depends_on: Some(vec![DependencyConfig::from_path("tach.errors")]),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.hooks".to_string(),
-                depends_on: vec![DependencyConfig::from_path("tach.constants")],
+                depends_on: Some(vec![DependencyConfig::from_path("tach.constants")]),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.interactive".to_string(),
-                depends_on: ["tach.errors", "tach.filesystem"]
-                    .map(DependencyConfig::from_path)
-                    .into(),
+                depends_on: Some(
+                    ["tach.errors", "tach.filesystem"]
+                        .map(DependencyConfig::from_path)
+                        .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.logging".to_string(),
-                depends_on: ["tach", "tach.cache", "tach.parsing"]
-                    .map(DependencyConfig::from_path)
-                    .into(),
+                depends_on: Some(
+                    ["tach", "tach.cache", "tach.parsing"]
+                        .map(DependencyConfig::from_path)
+                        .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.mod".to_string(),
-                depends_on: [
-                    "tach.colors",
-                    "tach.constants",
-                    "tach.errors",
-                    "tach.filesystem",
-                    "tach.interactive",
-                    "tach.parsing",
-                ]
-                .map(DependencyConfig::from_path)
-                .into(),
+                depends_on: Some(
+                    [
+                        "tach.colors",
+                        "tach.constants",
+                        "tach.errors",
+                        "tach.filesystem",
+                        "tach.interactive",
+                        "tach.parsing",
+                    ]
+                    .map(DependencyConfig::from_path)
+                    .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.parsing".to_string(),
-                depends_on: ["tach.constants", "tach.core", "tach.filesystem"]
-                    .map(DependencyConfig::from_path)
-                    .into(),
+                depends_on: Some(
+                    ["tach.constants", "tach.core", "tach.filesystem"]
+                        .map(DependencyConfig::from_path)
+                        .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.report".to_string(),
-                depends_on: vec![DependencyConfig::from_path("tach.errors")],
+                depends_on: Some(vec![DependencyConfig::from_path("tach.errors")]),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig::new("tach.show", true),
             ModuleConfig {
                 path: "tach.start".to_string(),
-                depends_on: vec![DependencyConfig::from_path("tach.cli")],
+                depends_on: Some(vec![DependencyConfig::from_path("tach.cli")]),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.sync".to_string(),
-                depends_on: [
-                    "tach.check",
-                    "tach.errors",
-                    "tach.filesystem",
-                    "tach.parsing",
-                ]
-                .map(DependencyConfig::from_path)
-                .into(),
+                depends_on: Some(
+                    [
+                        "tach.check",
+                        "tach.errors",
+                        "tach.filesystem",
+                        "tach.parsing",
+                    ]
+                    .map(DependencyConfig::from_path)
+                    .into(),
+                ),
                 strict: true,
                 ..Default::default()
             },
             ModuleConfig {
                 path: "tach.test".to_string(),
-                depends_on: [
-                    "tach.errors",
-                    "tach.filesystem",
-                    "tach.filesystem.git_ops",
-                    "tach.parsing",
-                ]
-                .map(DependencyConfig::from_path)
-                .into(),
+                depends_on: Some(
+                    [
+                        "tach.errors",
+                        "tach.filesystem",
+                        "tach.filesystem.git_ops",
+                        "tach.parsing",
+                    ]
+                    .map(DependencyConfig::from_path)
+                    .into(),
+                ),
                 strict: false,
                 ..Default::default()
             },
@@ -193,7 +213,9 @@ pub mod fixtures {
                                     full_path: "tach.__main__".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.__main__".to_string(),
-                                        depends_on: vec![DependencyConfig::from_path("tach.start")],
+                                        depends_on: Some(vec![DependencyConfig::from_path(
+                                            "tach.start",
+                                        )]),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -207,9 +229,11 @@ pub mod fixtures {
                                     full_path: "tach.cache".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.cache".to_string(),
-                                        depends_on: ["tach", "tach.filesystem"]
-                                            .map(DependencyConfig::from_path)
-                                            .into(),
+                                        depends_on: Some(
+                                            ["tach", "tach.filesystem"]
+                                                .map(DependencyConfig::from_path)
+                                                .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -223,13 +247,11 @@ pub mod fixtures {
                                     full_path: "tach.check".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.check".to_string(),
-                                        depends_on: [
-                                            "tach.errors",
-                                            "tach.filesystem",
-                                            "tach.parsing",
-                                        ]
-                                        .map(DependencyConfig::from_path)
-                                        .into(),
+                                        depends_on: Some(
+                                            ["tach.errors", "tach.filesystem", "tach.parsing"]
+                                                .map(DependencyConfig::from_path)
+                                                .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -243,25 +265,27 @@ pub mod fixtures {
                                     full_path: "tach.cli".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.cli".to_string(),
-                                        depends_on: [
-                                            "tach",
-                                            "tach.cache",
-                                            "tach.check",
-                                            "tach.colors",
-                                            "tach.constants",
-                                            "tach.core",
-                                            "tach.errors",
-                                            "tach.filesystem",
-                                            "tach.logging",
-                                            "tach.mod",
-                                            "tach.parsing",
-                                            "tach.report",
-                                            "tach.show",
-                                            "tach.sync",
-                                            "tach.test",
-                                        ]
-                                        .map(DependencyConfig::from_path)
-                                        .into(),
+                                        depends_on: Some(
+                                            [
+                                                "tach",
+                                                "tach.cache",
+                                                "tach.check",
+                                                "tach.colors",
+                                                "tach.constants",
+                                                "tach.core",
+                                                "tach.errors",
+                                                "tach.filesystem",
+                                                "tach.logging",
+                                                "tach.mod",
+                                                "tach.parsing",
+                                                "tach.report",
+                                                "tach.show",
+                                                "tach.sync",
+                                                "tach.test",
+                                            ]
+                                            .map(DependencyConfig::from_path)
+                                            .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -293,9 +317,9 @@ pub mod fixtures {
                                     full_path: "tach.core".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.core".to_string(),
-                                        depends_on: vec![DependencyConfig::from_path(
+                                        depends_on: Some(vec![DependencyConfig::from_path(
                                             "tach.constants",
-                                        )],
+                                        )]),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -318,15 +342,17 @@ pub mod fixtures {
                                     full_path: "tach.filesystem".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.filesystem".to_string(),
-                                        depends_on: [
-                                            "tach.colors",
-                                            "tach.constants",
-                                            "tach.core",
-                                            "tach.errors",
-                                            "tach.hooks",
-                                        ]
-                                        .map(DependencyConfig::from_path)
-                                        .into(),
+                                        depends_on: Some(
+                                            [
+                                                "tach.colors",
+                                                "tach.constants",
+                                                "tach.core",
+                                                "tach.errors",
+                                                "tach.hooks",
+                                            ]
+                                            .map(DependencyConfig::from_path)
+                                            .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -337,9 +363,9 @@ pub mod fixtures {
                                             full_path: "tach.filesystem.git_ops".to_string(),
                                             config: Some(ModuleConfig {
                                                 path: "tach.filesystem.git_ops".to_string(),
-                                                depends_on: vec![DependencyConfig::from_path(
-                                                    "tach.errors",
-                                                )],
+                                                depends_on: Some(vec![
+                                                    DependencyConfig::from_path("tach.errors"),
+                                                ]),
                                                 strict: true,
                                                 ..Default::default()
                                             }),
@@ -355,9 +381,9 @@ pub mod fixtures {
                                     full_path: "tach.hooks".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.hooks".to_string(),
-                                        depends_on: vec![DependencyConfig::from_path(
+                                        depends_on: Some(vec![DependencyConfig::from_path(
                                             "tach.constants",
-                                        )],
+                                        )]),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -371,9 +397,11 @@ pub mod fixtures {
                                     full_path: "tach.interactive".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.interactive".to_string(),
-                                        depends_on: ["tach.errors", "tach.filesystem"]
-                                            .map(DependencyConfig::from_path)
-                                            .into(),
+                                        depends_on: Some(
+                                            ["tach.errors", "tach.filesystem"]
+                                                .map(DependencyConfig::from_path)
+                                                .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -387,9 +415,11 @@ pub mod fixtures {
                                     full_path: "tach.logging".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.logging".to_string(),
-                                        depends_on: ["tach", "tach.cache", "tach.parsing"]
-                                            .map(DependencyConfig::from_path)
-                                            .into(),
+                                        depends_on: Some(
+                                            ["tach", "tach.cache", "tach.parsing"]
+                                                .map(DependencyConfig::from_path)
+                                                .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -403,16 +433,18 @@ pub mod fixtures {
                                     full_path: "tach.mod".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.mod".to_string(),
-                                        depends_on: [
-                                            "tach.colors",
-                                            "tach.constants",
-                                            "tach.errors",
-                                            "tach.filesystem",
-                                            "tach.interactive",
-                                            "tach.parsing",
-                                        ]
-                                        .map(DependencyConfig::from_path)
-                                        .into(),
+                                        depends_on: Some(
+                                            [
+                                                "tach.colors",
+                                                "tach.constants",
+                                                "tach.errors",
+                                                "tach.filesystem",
+                                                "tach.interactive",
+                                                "tach.parsing",
+                                            ]
+                                            .map(DependencyConfig::from_path)
+                                            .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -426,13 +458,11 @@ pub mod fixtures {
                                     full_path: "tach.parsing".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.parsing".to_string(),
-                                        depends_on: [
-                                            "tach.constants",
-                                            "tach.core",
-                                            "tach.filesystem",
-                                        ]
-                                        .map(DependencyConfig::from_path)
-                                        .into(),
+                                        depends_on: Some(
+                                            ["tach.constants", "tach.core", "tach.filesystem"]
+                                                .map(DependencyConfig::from_path)
+                                                .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -446,9 +476,9 @@ pub mod fixtures {
                                     full_path: "tach.report".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.report".to_string(),
-                                        depends_on: vec![DependencyConfig::from_path(
+                                        depends_on: Some(vec![DependencyConfig::from_path(
                                             "tach.errors",
-                                        )],
+                                        )]),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -471,7 +501,9 @@ pub mod fixtures {
                                     full_path: "tach.start".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.start".to_string(),
-                                        depends_on: vec![DependencyConfig::from_path("tach.cli")],
+                                        depends_on: Some(vec![DependencyConfig::from_path(
+                                            "tach.cli",
+                                        )]),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -485,14 +517,16 @@ pub mod fixtures {
                                     full_path: "tach.sync".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.sync".to_string(),
-                                        depends_on: [
-                                            "tach.check",
-                                            "tach.errors",
-                                            "tach.filesystem",
-                                            "tach.parsing",
-                                        ]
-                                        .map(DependencyConfig::from_path)
-                                        .into(),
+                                        depends_on: Some(
+                                            [
+                                                "tach.check",
+                                                "tach.errors",
+                                                "tach.filesystem",
+                                                "tach.parsing",
+                                            ]
+                                            .map(DependencyConfig::from_path)
+                                            .into(),
+                                        ),
                                         strict: true,
                                         ..Default::default()
                                     }),
@@ -506,14 +540,16 @@ pub mod fixtures {
                                     full_path: "tach.test".to_string(),
                                     config: Some(ModuleConfig {
                                         path: "tach.test".to_string(),
-                                        depends_on: [
-                                            "tach.errors",
-                                            "tach.filesystem",
-                                            "tach.filesystem.git_ops",
-                                            "tach.parsing",
-                                        ]
-                                        .map(DependencyConfig::from_path)
-                                        .into(),
+                                        depends_on: Some(
+                                            [
+                                                "tach.errors",
+                                                "tach.filesystem",
+                                                "tach.filesystem.git_ops",
+                                                "tach.parsing",
+                                            ]
+                                            .map(DependencyConfig::from_path)
+                                            .into(),
+                                        ),
                                         strict: false,
                                         ..Default::default()
                                     }),

--- a/tach.toml
+++ b/tach.toml
@@ -121,10 +121,10 @@ layer = "commands"
 
 [[modules]]
 path = "tach.parsing"
-# depends_on = [
-#     # "tach.extension",
-#     "tach.filesystem",
-# ]
+depends_on = [
+    "tach.extension",
+    "tach.filesystem",
+]
 layer = "core"
 
 [[modules]]

--- a/tach.toml
+++ b/tach.toml
@@ -121,10 +121,10 @@ layer = "commands"
 
 [[modules]]
 path = "tach.parsing"
-depends_on = [
-    "tach.extension",
-    "tach.filesystem",
-]
+# depends_on = [
+#     # "tach.extension",
+#     "tach.filesystem",
+# ]
 layer = "core"
 
 [[modules]]


### PR DESCRIPTION
This PR is a follow-on for #545 

Before this PR, the `depends_on` key was strictly required for any module definition, with the only opt-out being [unchecked(https://docs.gauge.sh/usage/unchecked-modules#unchecked-modules).

After this PR, omitting the `depends_on` key will mean that any module dependency is allowed. However, if a `layer` is also specified, dependencies on higher layers will still cause errors.

Example:
```toml
[[modules]]
path = "parsing"
layer = "core"
```
This is now a valid module definition, and parsing would be allowed to depend on any module in `core` or below.

The net result of these two PRs is that you can use `layer` as an alternative to the more granular `depends_on` field, which can make adoption easier in a pre-existing, large codebase.

A natural progression could be:
- enable coarse layers
- resolve any violations, cycles between these layers
- begin tracking `depends_on` within each layer (can be done one module at-a-time)
- resolve any violations, cycles within layers.