### PR TITLE
Fix `unused_ignore_directives` rule when ignore directive does not apply to any import

### DIFF
--- a/src/commands/check_internal/checks.rs
+++ b/src/commands/check_internal/checks.rs
@@ -151,7 +151,7 @@ pub(super) fn check_unused_ignore_directive(
         interface_checker,
         check_dependencies,
     ) {
-        Ok(()) => Err(ImportCheckError::UnusedIgnoreDirective {
+        Ok(()) => Err(ImportCheckError::UnnecessarilyIgnoredImport {
             import_mod_path: directive_ignored_import.import.module_path.to_string(),
         }),
         Err(_) => Ok(()),

--- a/src/commands/check_internal/diagnostics.rs
+++ b/src/commands/check_internal/diagnostics.rs
@@ -122,7 +122,10 @@ pub enum ImportCheckError {
     },
 
     #[error("Import '{import_mod_path}' is unnecessarily ignored by a directive.")]
-    UnusedIgnoreDirective { import_mod_path: String },
+    UnnecessarilyIgnoredImport { import_mod_path: String },
+
+    #[error("Ignore directive is unused.")]
+    UnusedIgnoreDirective(),
 
     #[error("Import '{import_mod_path}' is ignored without providing a reason.")]
     MissingIgnoreDirectiveReason { import_mod_path: String },

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -199,8 +199,9 @@ impl IntoPy<PyObject> for NormalizedImport {
 
 #[derive(Debug)]
 pub struct IgnoreDirective {
-    modules: Vec<String>,
-    reason: String,
+    pub modules: Vec<String>,
+    pub reason: String,
+    pub line_no: usize,
 }
 
 #[derive(Debug)]
@@ -293,7 +294,11 @@ fn get_ignore_directives(file_content: &str) -> IgnoreDirectives {
                     .collect()
             };
 
-            let directive = IgnoreDirective { modules, reason };
+            let directive = IgnoreDirective {
+                modules,
+                reason,
+                line_no: normal_lineno,
+            };
 
             if line.trim_start().starts_with('#') {
                 ignores.insert(normal_lineno + 1, directive);
@@ -533,7 +538,6 @@ pub fn get_normalized_imports(
             source: err,
         })?;
     let is_package = file_path.ends_with("__init__.py");
-    let ignore_directives = get_ignore_directives(file_contents.as_str());
     let ignore_directives = get_ignore_directives(file_contents.as_str());
     let file_mod_path: Option<String> =
         filesystem::file_to_module_path(source_roots, file_path).ok();


### PR DESCRIPTION
Fixes: #519 

Before this PR, the check phase only had scope on ignore directives that had been applied to actual imports. After the recent refactor ( #548 ), it has scope on the ignore directives themselves, and can process directives which do not map to any detected imports.