### PR TITLE
Fix `unused_ignore_directives` on redundant `tach-ignore`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ fmt-python: ## Format Python code
 
 
 fmt-rust: ## Format Rust code
-	cargo fmt --all
 	cargo clippy --fix --allow-dirty --allow-staged
+	cargo fmt --all
 
 
 lint-python: ## Lint Python code

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -100,16 +100,18 @@ impl<State> NormalizedImports<State> {
     }
 
     pub fn directive_ignored_imports(&self) -> impl Iterator<Item = DirectiveIgnoredImport> {
-        self.imports.iter().filter(|&import| self.ignore_directives
-                .is_ignored(import)).map(|import| DirectiveIgnoredImport {
-                    import,
-                    reason: self
-                        .ignore_directives
-                        .get(&import.import_line_no)
-                        .unwrap()
-                        .reason
-                        .clone(),
-                })
+        self.imports
+            .iter()
+            .filter(|&import| self.ignore_directives.is_ignored(import))
+            .map(|import| DirectiveIgnoredImport {
+                import,
+                reason: self
+                    .ignore_directives
+                    .get(&import.import_line_no)
+                    .unwrap()
+                    .reason
+                    .clone(),
+            })
     }
 
     pub fn unused_ignore_directives(&self) -> impl Iterator<Item = &IgnoreDirective> {


### PR DESCRIPTION
Fixes: #520 

This PR lets us detect when there is a `tach-ignore` comment being applied to a line that is already ignored (see below).

```python
# tach-ignore(this ignores the next line)
from module import service  # tach-ignore(this one is redundant)
```