### PR TITLE
Fix `tach sync` with `<root>` dependencies

### DIFF
--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -185,6 +185,10 @@ impl ProjectConfig {
         self.domains.push(domain);
     }
 
+    pub fn add_root_module(&mut self) {
+        self.modules.push(ModuleConfig::new_root_config());
+    }
+
     pub fn all_modules(&self) -> impl Iterator<Item = &ModuleConfig> {
         self.modules
             .iter()


### PR DESCRIPTION
This PR fixes a bug introduced with the new `tach sync` changes. Specifically, `tach sync` would not automatically create the `<root>` module, even when it detected dependencies, because this module is not marked during `tach mod` and therefore did not appear in `module_paths()` on a fresh ProjectConfig.

This handles this special case explicitly. In all other cases, detected dependencies will always refer to modules  already existing in module paths.