### PR TITLE
Fix external exclude behavior

### DIFF
--- a/src/commands/check/checks.rs
+++ b/src/commands/check/checks.rs
@@ -230,10 +230,13 @@ pub(super) fn check_import_external(
     let default_distribution_names = vec![top_level_module_name.clone()];
     let distribution_names: Vec<String> = module_mappings
         .get(&top_level_module_name)
-        .unwrap_or(&default_distribution_names)
-        .iter()
-        .map(|dist_name| normalize_package_name(dist_name))
-        .collect();
+        .map(|dist_names| {
+            dist_names
+                .iter()
+                .map(|dist_name| normalize_package_name(dist_name))
+                .collect()
+        })
+        .unwrap_or(default_distribution_names);
 
     if distribution_names
         .iter()


### PR DESCRIPTION
Fixes: #580 

This issue is a regression due to a recent refactor of the check-external behavior. We check for excludes earlier (rather than after all diagnostics are produced) and this check did not handle the default case correctly. Instead of defaulting to the top level module name for the import, we first normalized this name as if it were a distribution name (e.g. `_typeshed` -> `typeshed`, `__future__` -> `future`).

This PR fixes the check so that the default case is the literal top level module name.