### PR TITLE
Fix relative imports missing from `usages` during modularity report generation

### DIFF
--- a/python/tach/modularity.py
+++ b/python/tach/modularity.py
@@ -253,7 +253,7 @@ def build_usages(
         pyfile_containing_module = get_containing_module(pyfile_mod_path)
         imports = get_project_imports(
             source_roots=list(map(str, source_roots)),
-            file_path=str(pyfile),
+            file_path=str(project_root / pyfile),
             ignore_type_checking_imports=project_config.ignore_type_checking_imports,
             include_string_imports=project_config.include_string_imports,
         )


### PR DESCRIPTION
Modularity report generation still has significant components written in Python, including the population of the `usages` field, containing all cross-module usages.

When calling the `get_project_imports` function directly (the only remaining callsite in Python), the `file_path` was being given relative to the project root. This caused a failure to resolve the module path for the file, which silently resulted in the failure to resolve relative imports. This is because the function can technically operate on file paths outside any source root, in which case a relative import path is assumed to also be outside any source root.