### PR TITLE
Django fkey detection

### DIFF
--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -205,7 +205,7 @@ def test_distributed_config_example_dir(example_dir, capfd):
 
     captured = capfd.readouterr()
     assert FAIL in captured.err or "FAIL" in captured.err
-    assert "Cannot import 'project.module_one.module_one'" in captured.err
+    assert "Cannot use 'project.module_one.module_one'" in captured.err
     assert (
         "Module 'project.top_level' cannot depend on 'project.module_one'"
         in captured.err

--- a/src/checks/external_dependency.rs
+++ b/src/checks/external_dependency.rs
@@ -54,7 +54,7 @@ impl<'a> ExternalDependencyChecker<'a> {
                 processed_file.relative_file_path().to_path_buf(),
                 processed_file.line_number(import.import.import_offset),
                 DiagnosticDetails::Code(CodeDiagnostic::UndeclaredExternalDependency {
-                    import_mod_path: import.import.top_level_module_name().to_string(),
+                    dependency: import.import.top_level_module_name().to_string(),
                 }),
             ))
         } else {

--- a/src/checks/interface.rs
+++ b/src/checks/interface.rs
@@ -112,8 +112,8 @@ impl<'a> InterfaceChecker<'a> {
                 InterfaceCheckResult::NotExposed => Ok(vec![Diagnostic::new_located_error(
                     file_module.relative_file_path().to_path_buf(),
                     file_module.line_number(dependency.offset()),
-                    DiagnosticDetails::Code(CodeDiagnostic::PrivateImport {
-                        import_mod_path: dependency.module_path().to_string(),
+                    DiagnosticDetails::Code(CodeDiagnostic::PrivateDependency {
+                        dependency: dependency.module_path().to_string(),
                         usage_module: file_module.module_config().path.to_string(),
                         definition_module: dependency_module_config.path.to_string(),
                     }),
@@ -124,7 +124,7 @@ impl<'a> InterfaceChecker<'a> {
                     file_module.relative_file_path().to_path_buf(),
                     file_module.line_number(dependency.offset()),
                     DiagnosticDetails::Code(CodeDiagnostic::InvalidDataTypeExport {
-                        import_mod_path: dependency.module_path().to_string(),
+                        dependency: dependency.module_path().to_string(),
                         usage_module: file_module.module_config().path.to_string(),
                         definition_module: dependency_module_config.path.to_string(),
                         expected_data_type: expected.to_string(),

--- a/src/checks/internal_dependency.rs
+++ b/src/checks/internal_dependency.rs
@@ -56,7 +56,7 @@ impl<'a> InternalDependencyChecker<'a> {
                                 relative_file_path.to_path_buf(),
                                 file_module.line_number(dependency.offset()),
                                 DiagnosticDetails::Code(CodeDiagnostic::LayerViolation {
-                                    import_mod_path: dependency.module_path().to_string(),
+                                    dependency: dependency.module_path().to_string(),
                                     usage_module: source_module_config.path.clone(),
                                     usage_layer: source_layer.clone(),
                                     definition_module: target_module_config.path.clone(),
@@ -140,8 +140,8 @@ impl<'a> InternalDependencyChecker<'a> {
             }) => Ok(vec![Diagnostic::new_located_warning(
                 relative_file_path.to_path_buf(),
                 file_module.line_number(dependency.offset()),
-                DiagnosticDetails::Code(CodeDiagnostic::DeprecatedImport {
-                    import_mod_path: dependency.module_path().to_string(),
+                DiagnosticDetails::Code(CodeDiagnostic::DeprecatedDependency {
+                    dependency: dependency.module_path().to_string(),
                     usage_module: file_nearest_module_path.to_string(),
                     definition_module: dependency_nearest_module_path.to_string(),
                 }),
@@ -150,8 +150,8 @@ impl<'a> InternalDependencyChecker<'a> {
             None => Ok(vec![Diagnostic::new_located_error(
                 relative_file_path.to_path_buf(),
                 file_module.line_number(dependency.offset()),
-                DiagnosticDetails::Code(CodeDiagnostic::InvalidImport {
-                    import_mod_path: dependency.module_path().to_string(),
+                DiagnosticDetails::Code(CodeDiagnostic::UndeclaredDependency {
+                    dependency: dependency.module_path().to_string(),
                     usage_module: file_nearest_module_path.to_string(),
                     definition_module: dependency_nearest_module_path.to_string(),
                 }),

--- a/src/commands/check/check_external.rs
+++ b/src/commands/check/check_external.rs
@@ -281,7 +281,7 @@ mod tests {
         assert_eq!(result.len(), 3);
         assert!(result.iter().any(|d| d.details()
             == &DiagnosticDetails::Code(CodeDiagnostic::UndeclaredExternalDependency {
-                import_mod_path: "git".to_string()
+                dependency: "git".to_string()
             })));
         assert!(result.iter().any(|d| d.details()
             == &DiagnosticDetails::Code(CodeDiagnostic::UnusedExternalDependency {

--- a/src/commands/check/format.rs
+++ b/src/commands/check/format.rs
@@ -21,14 +21,14 @@ impl From<&DiagnosticDetails> for DiagnosticGroupKind {
         match details {
             DiagnosticDetails::Configuration(..) => Self::Configuration,
             DiagnosticDetails::Code(code_diagnostic_details) => match code_diagnostic_details {
-                CodeDiagnostic::InvalidImport { .. } => Self::InternalDependency,
-                CodeDiagnostic::DeprecatedImport { .. } => Self::InternalDependency,
+                CodeDiagnostic::UndeclaredDependency { .. } => Self::InternalDependency,
+                CodeDiagnostic::DeprecatedDependency { .. } => Self::InternalDependency,
                 CodeDiagnostic::LayerViolation { .. } => Self::InternalDependency,
-                CodeDiagnostic::PrivateImport { .. } => Self::Interface,
+                CodeDiagnostic::PrivateDependency { .. } => Self::Interface,
                 CodeDiagnostic::InvalidDataTypeExport { .. } => Self::Interface,
                 CodeDiagnostic::UndeclaredExternalDependency { .. } => Self::ExternalDependency,
                 CodeDiagnostic::UnusedExternalDependency { .. } => Self::ExternalDependency,
-                CodeDiagnostic::UnnecessarilyIgnoredImport { .. } => Self::Other,
+                CodeDiagnostic::UnnecessarilyIgnoredDependency { .. } => Self::Other,
                 CodeDiagnostic::UnusedIgnoreDirective() => Self::Other,
                 CodeDiagnostic::MissingIgnoreDirectiveReason() => Self::Other,
             },

--- a/src/diagnostics/diagnostics.rs
+++ b/src/diagnostics/diagnostics.rs
@@ -68,46 +68,46 @@ pub enum ConfigurationDiagnostic {
 #[derive(Error, Debug, Clone, Serialize, PartialEq)]
 #[pyclass(module = "tach.extension")]
 pub enum CodeDiagnostic {
-    #[error("Module '{definition_module}' has a defined public interface. Only imports from the public interface of this module are allowed. The import '{import_mod_path}' (in module '{usage_module}') is not public.")]
-    PrivateImport {
-        import_mod_path: String,
+    #[error("Dependency '{dependency}' (in module '{usage_module}') is not public. Module '{definition_module}' has a defined public interface. Only dependencies on the public interface of this module are allowed.")]
+    PrivateDependency {
+        dependency: String,
         definition_module: String,
         usage_module: String,
     },
 
-    #[error("The import '{import_mod_path}' (from module '{definition_module}') matches an interface but does not match the expected data type ('{expected_data_type}').")]
+    #[error("The dependency '{dependency}' (from module '{definition_module}') matches an interface but does not match the expected data type ('{expected_data_type}').")]
     InvalidDataTypeExport {
-        import_mod_path: String,
+        dependency: String,
         definition_module: String,
         usage_module: String,
         expected_data_type: String,
     },
 
-    #[error("Cannot import '{import_mod_path}'. Module '{usage_module}' cannot depend on '{definition_module}'.")]
-    InvalidImport {
-        import_mod_path: String,
+    #[error("Cannot use '{dependency}'. Module '{usage_module}' cannot depend on '{definition_module}'.")]
+    UndeclaredDependency {
+        dependency: String,
         usage_module: String,
         definition_module: String,
     },
 
-    #[error("Import '{import_mod_path}' is deprecated. Module '{usage_module}' should not depend on '{definition_module}'.")]
-    DeprecatedImport {
-        import_mod_path: String,
+    #[error("Dependency '{dependency}' is deprecated. Module '{usage_module}' should not depend on '{definition_module}'.")]
+    DeprecatedDependency {
+        dependency: String,
         usage_module: String,
         definition_module: String,
     },
 
-    #[error("Cannot import '{import_mod_path}'. Layer '{usage_layer}' ('{usage_module}') is lower than layer '{definition_layer}' ('{definition_module}').")]
+    #[error("Cannot use '{dependency}'. Layer '{usage_layer}' ('{usage_module}') is lower than layer '{definition_layer}' ('{definition_module}').")]
     LayerViolation {
-        import_mod_path: String,
+        dependency: String,
         usage_module: String,
         usage_layer: String,
         definition_module: String,
         definition_layer: String,
     },
 
-    #[error("Import '{import_mod_path}' is unnecessarily ignored by a directive.")]
-    UnnecessarilyIgnoredImport { import_mod_path: String },
+    #[error("Dependency '{dependency}' is unnecessarily ignored by a directive.")]
+    UnnecessarilyIgnoredDependency { dependency: String },
 
     #[error("Ignore directive is unused.")]
     UnusedIgnoreDirective(),
@@ -115,47 +115,38 @@ pub enum CodeDiagnostic {
     #[error("Ignore directive is missing a reason.")]
     MissingIgnoreDirectiveReason(),
 
-    #[error("Import '{import_mod_path}' does not match any declared dependency.")]
-    UndeclaredExternalDependency { import_mod_path: String },
+    #[error("Dependency '{dependency}' is not declared in the project.")]
+    UndeclaredExternalDependency { dependency: String },
 
     #[error("External package '{package_module_name}' is not used.")]
     UnusedExternalDependency { package_module_name: String },
 }
 
 impl CodeDiagnostic {
-    pub fn import_mod_path(&self) -> Option<&str> {
+    pub fn dependency(&self) -> Option<&str> {
         match self {
-            CodeDiagnostic::PrivateImport {
-                import_mod_path, ..
-            }
-            | CodeDiagnostic::InvalidDataTypeExport {
-                import_mod_path, ..
-            }
-            | CodeDiagnostic::InvalidImport {
-                import_mod_path, ..
-            }
-            | CodeDiagnostic::DeprecatedImport {
-                import_mod_path, ..
-            }
-            | CodeDiagnostic::LayerViolation {
-                import_mod_path, ..
-            }
-            | CodeDiagnostic::UnnecessarilyIgnoredImport {
-                import_mod_path, ..
-            } => Some(import_mod_path),
+            CodeDiagnostic::PrivateDependency { dependency, .. }
+            | CodeDiagnostic::InvalidDataTypeExport { dependency, .. }
+            | CodeDiagnostic::UndeclaredDependency { dependency, .. }
+            | CodeDiagnostic::DeprecatedDependency { dependency, .. }
+            | CodeDiagnostic::LayerViolation { dependency, .. }
+            | CodeDiagnostic::UnnecessarilyIgnoredDependency { dependency, .. } => Some(dependency),
             CodeDiagnostic::UnusedIgnoreDirective() => None,
             CodeDiagnostic::MissingIgnoreDirectiveReason() => None,
-            CodeDiagnostic::UndeclaredExternalDependency { .. } => None,
-            CodeDiagnostic::UnusedExternalDependency { .. } => None,
+            CodeDiagnostic::UndeclaredExternalDependency { dependency, .. } => Some(dependency),
+            CodeDiagnostic::UnusedExternalDependency {
+                package_module_name,
+                ..
+            } => Some(package_module_name),
         }
     }
 
     pub fn usage_module(&self) -> Option<&str> {
         match self {
-            CodeDiagnostic::PrivateImport { usage_module, .. }
+            CodeDiagnostic::PrivateDependency { usage_module, .. }
             | CodeDiagnostic::InvalidDataTypeExport { usage_module, .. }
-            | CodeDiagnostic::InvalidImport { usage_module, .. }
-            | CodeDiagnostic::DeprecatedImport { usage_module, .. }
+            | CodeDiagnostic::UndeclaredDependency { usage_module, .. }
+            | CodeDiagnostic::DeprecatedDependency { usage_module, .. }
             | CodeDiagnostic::LayerViolation { usage_module, .. } => Some(usage_module),
             _ => None,
         }
@@ -163,16 +154,16 @@ impl CodeDiagnostic {
 
     pub fn definition_module(&self) -> Option<&str> {
         match self {
-            CodeDiagnostic::PrivateImport {
+            CodeDiagnostic::PrivateDependency {
                 definition_module, ..
             }
             | CodeDiagnostic::InvalidDataTypeExport {
                 definition_module, ..
             }
-            | CodeDiagnostic::InvalidImport {
+            | CodeDiagnostic::UndeclaredDependency {
                 definition_module, ..
             }
-            | CodeDiagnostic::DeprecatedImport {
+            | CodeDiagnostic::DeprecatedDependency {
                 definition_module, ..
             }
             | CodeDiagnostic::LayerViolation {
@@ -314,9 +305,9 @@ impl Diagnostic {
         }
     }
 
-    pub fn import_mod_path(&self) -> Option<&str> {
+    pub fn dependency(&self) -> Option<&str> {
         match self.details() {
-            DiagnosticDetails::Code(details) => details.import_mod_path(),
+            DiagnosticDetails::Code(details) => details.dependency(),
             _ => None,
         }
     }
@@ -349,8 +340,8 @@ impl Diagnostic {
     pub fn is_dependency_error(&self) -> bool {
         matches!(
             self.details(),
-            DiagnosticDetails::Code(CodeDiagnostic::InvalidImport { .. })
-                | DiagnosticDetails::Code(CodeDiagnostic::DeprecatedImport { .. })
+            DiagnosticDetails::Code(CodeDiagnostic::UndeclaredDependency { .. })
+                | DiagnosticDetails::Code(CodeDiagnostic::DeprecatedDependency { .. })
                 | DiagnosticDetails::Code(CodeDiagnostic::LayerViolation { .. })
         )
     }
@@ -358,7 +349,7 @@ impl Diagnostic {
     pub fn is_interface_error(&self) -> bool {
         matches!(
             self.details(),
-            DiagnosticDetails::Code(CodeDiagnostic::PrivateImport { .. })
+            DiagnosticDetails::Code(CodeDiagnostic::PrivateDependency { .. })
                 | DiagnosticDetails::Code(CodeDiagnostic::InvalidDataTypeExport { .. })
         )
     }
@@ -366,7 +357,7 @@ impl Diagnostic {
     pub fn is_deprecated(&self) -> bool {
         matches!(
             self.details(),
-            DiagnosticDetails::Code(CodeDiagnostic::DeprecatedImport { .. })
+            DiagnosticDetails::Code(CodeDiagnostic::DeprecatedDependency { .. })
         )
     }
 

--- a/src/diagnostics/diagnostics.rs
+++ b/src/diagnostics/diagnostics.rs
@@ -68,7 +68,9 @@ pub enum ConfigurationDiagnostic {
 #[derive(Error, Debug, Clone, Serialize, PartialEq)]
 #[pyclass(module = "tach.extension")]
 pub enum CodeDiagnostic {
-    #[error("Dependency '{dependency}' (in module '{usage_module}') is not public. Module '{definition_module}' has a defined public interface. Only dependencies on the public interface of this module are allowed.")]
+    #[error(
+        "The path '{dependency}' is not part of the public interface for '{definition_module}'."
+    )]
     PrivateDependency {
         dependency: String,
         definition_module: String,

--- a/src/modularity/diagnostics.rs
+++ b/src/modularity/diagnostics.rs
@@ -45,7 +45,7 @@ impl TryFrom<Diagnostic> for UsageError {
             value.is_dependency_error(),
             value.file_path(),
             value.line_number(),
-            value.import_mod_path(),
+            value.dependency(),
             value.usage_module(),
             value.definition_module(),
         ) {

--- a/src/processors/dependency.rs
+++ b/src/processors/dependency.rs
@@ -118,7 +118,7 @@ impl<'a> FileProcessor<'a, ProjectFile<'a>> for InternalDependencyExtractor<'a> 
         let mut dependencies: Vec<Dependency> = vec![];
         let file_ast = parse_python_source(file_module.contents())?;
 
-        let project_imports: Vec<Dependency> = get_normalized_imports_from_ast(
+        let project_imports = get_normalized_imports_from_ast(
             self.source_roots,
             file_module.file_path(),
             &file_ast,
@@ -136,8 +136,7 @@ impl<'a> FileProcessor<'a, ProjectFile<'a>> for InternalDependencyExtractor<'a> 
                     .remove_matching_directives(file_module.line_number(import.import_offset));
                 None
             }
-        })
-        .collect();
+        });
         dependencies.extend(project_imports);
 
         if self.django_metadata.is_some() {

--- a/src/processors/dependency.rs
+++ b/src/processors/dependency.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use ruff_text_size::TextSize;
 
+use crate::config::plugins::django::DjangoConfig;
 use crate::config::root_module::RootModuleTreatment;
 use crate::config::ProjectConfig;
 use crate::diagnostics::{FileProcessor, Result as DiagnosticResult};
@@ -11,6 +12,7 @@ use crate::modules::error::ModuleTreeError;
 use crate::modules::{ModuleNode, ModuleTree};
 use crate::python::parsing::parse_python_source;
 
+use super::django::fkey::{get_foreign_key_references, get_known_apps};
 use super::file_module::FileModule;
 use super::import::{get_normalized_imports, get_normalized_imports_from_ast, NormalizedImport};
 use super::reference::SourceCodeReference;
@@ -50,10 +52,27 @@ impl From<SourceCodeReference> for Dependency {
 }
 
 #[derive(Debug)]
+pub struct DjangoMetadata<'a> {
+    pub config: &'a DjangoConfig,
+    pub known_apps: Vec<String>,
+}
+
+impl<'a> DjangoMetadata<'a> {
+    pub fn new(source_roots: &[PathBuf], django_config: &'a DjangoConfig) -> Self {
+        let known_apps = get_known_apps(source_roots, django_config).unwrap_or_default();
+        Self {
+            config: django_config,
+            known_apps,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct InternalDependencyExtractor<'a> {
     module_tree: &'a ModuleTree,
     source_roots: &'a [PathBuf],
     project_config: &'a ProjectConfig,
+    django_metadata: Option<DjangoMetadata<'a>>,
 }
 
 impl<'a> InternalDependencyExtractor<'a> {
@@ -62,10 +81,17 @@ impl<'a> InternalDependencyExtractor<'a> {
         module_tree: &'a ModuleTree,
         project_config: &'a ProjectConfig,
     ) -> Self {
+        let django_metadata = project_config
+            .plugins
+            .django
+            .as_ref()
+            .map(|django_config| DjangoMetadata::new(source_roots, django_config));
+
         Self {
             source_roots,
             module_tree,
             project_config,
+            django_metadata,
         }
     }
 }
@@ -89,6 +115,7 @@ impl<'a> FileProcessor<'a, ProjectFile<'a>> for InternalDependencyExtractor<'a> 
         }
 
         let mut file_module = FileModule::new(file_path, module);
+        let mut dependencies: Vec<Dependency> = vec![];
         let file_ast = parse_python_source(file_module.contents())?;
 
         let project_imports: Vec<Dependency> = get_normalized_imports_from_ast(
@@ -111,8 +138,17 @@ impl<'a> FileProcessor<'a, ProjectFile<'a>> for InternalDependencyExtractor<'a> 
             }
         })
         .collect();
+        dependencies.extend(project_imports);
 
-        file_module.extend_dependencies(project_imports);
+        if self.django_metadata.is_some() {
+            dependencies.extend(
+                get_foreign_key_references(&file_ast)
+                    .into_iter()
+                    .map(Dependency::Reference),
+            );
+        }
+
+        file_module.extend_dependencies(dependencies);
         Ok(file_module)
     }
 }

--- a/src/processors/django/fkey.rs
+++ b/src/processors/django/fkey.rs
@@ -1,0 +1,155 @@
+use std::path::PathBuf;
+
+use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::Mod;
+use thiserror::Error;
+
+use crate::config::plugins::django::DjangoConfig;
+use crate::filesystem;
+use crate::processors::reference::SourceCodeReference;
+use crate::python::error::ParsingError;
+use crate::python::parsing::parse_python_source;
+
+#[derive(Error, Debug)]
+pub enum FKeyError {
+    #[error("Failed to parse Django foreign keys: {0}")]
+    Parsing(#[from] ParsingError),
+    #[error("Failed to read Django settings file: {0}")]
+    Filesystem(#[from] filesystem::FileSystemError),
+    #[error("Could not find Django settings file: {0}")]
+    SettingsFileNotFound(String),
+}
+
+pub type Result<T> = std::result::Result<T, FKeyError>;
+
+struct FKeyVisitor {
+    pub fkeys: Vec<SourceCodeReference>,
+}
+
+impl FKeyVisitor {
+    fn new() -> Self {
+        FKeyVisitor { fkeys: vec![] }
+    }
+}
+
+impl Visitor<'_> for FKeyVisitor {
+    fn visit_expr(&mut self, expr: &ruff_python_ast::Expr) {
+        if let ruff_python_ast::Expr::Call(call_expr) = expr {
+            let is_foreign_key = match &*call_expr.func {
+                // Match direct name (ForeignKey)
+                ruff_python_ast::Expr::Name(name) => name.id() == "ForeignKey",
+                // Match attribute access (models.ForeignKey, django.db.models.ForeignKey, etc.)
+                ruff_python_ast::Expr::Attribute(attr) => attr.attr.as_str() == "ForeignKey",
+                _ => false,
+            };
+
+            if !is_foreign_key {
+                return;
+            }
+
+            let target_model = if !call_expr.arguments.args.is_empty() {
+                // First positional argument
+                if let ruff_python_ast::Expr::StringLiteral(s) = &call_expr.arguments.args[0] {
+                    Some((s.value.to_string(), s.range.start()))
+                } else {
+                    None
+                }
+            } else {
+                // Look for "to" keyword argument
+                call_expr.arguments.keywords.iter().find_map(|kw| {
+                    if kw.arg.as_deref() == Some("to") {
+                        if let ruff_python_ast::Expr::StringLiteral(s) = &kw.value {
+                            Some((s.value.to_string(), s.range.start()))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                })
+            };
+
+            if let Some((model_path, string_start)) = target_model {
+                self.fkeys
+                    .push(SourceCodeReference::new(model_path, string_start));
+            }
+        }
+    }
+}
+
+struct InstalledAppVisitor {
+    pub installed_apps: Vec<String>,
+}
+
+impl InstalledAppVisitor {
+    fn new() -> Self {
+        InstalledAppVisitor {
+            installed_apps: vec![],
+        }
+    }
+}
+
+impl Visitor<'_> for InstalledAppVisitor {
+    fn visit_stmt(&mut self, stmt: &ruff_python_ast::Stmt) {
+        if let ruff_python_ast::Stmt::Assign(ref assign) = stmt {
+            if assign.targets.len() == 1 {
+                let target = &assign.targets[0];
+                if let ruff_python_ast::Expr::Name(name) = target {
+                    if name.id() == "INSTALLED_APPS" {
+                        if let ruff_python_ast::Expr::List(list) = assign.value.as_ref() {
+                            for item in &list.elts {
+                                if let ruff_python_ast::Expr::StringLiteral(string) = item {
+                                    self.installed_apps.push(string.value.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn filter_installed_apps(source_roots: &[PathBuf], installed_apps: Vec<String>) -> Vec<String> {
+    installed_apps
+        .into_iter()
+        .filter(|app| filesystem::module_to_file_path(source_roots, app, false).is_some())
+        .collect()
+}
+
+pub fn get_known_apps(
+    source_roots: &[PathBuf],
+    django_config: &DjangoConfig,
+) -> Result<Vec<String>> {
+    let settings_module_path = &django_config.settings_module;
+    let settings_module =
+        filesystem::module_to_file_path(source_roots, settings_module_path, false);
+    if let Some(settings_module) = settings_module {
+        let settings_file = filesystem::read_file_content(settings_module.file_path)?;
+        let settings_ast = parse_python_source(&settings_file)?;
+        let mut visitor = InstalledAppVisitor::new();
+
+        match settings_ast {
+            Mod::Module(ref module) => {
+                visitor.visit_body(&module.body);
+            }
+            Mod::Expression(_) => return Err(FKeyError::Parsing(ParsingError::InvalidSyntax)),
+        };
+
+        Ok(filter_installed_apps(source_roots, visitor.installed_apps))
+    } else {
+        Err(FKeyError::SettingsFileNotFound(
+            settings_module_path.to_string(),
+        ))
+    }
+}
+
+pub fn get_foreign_key_references(file_ast: &Mod) -> impl IntoIterator<Item = SourceCodeReference> {
+    let mut visitor = FKeyVisitor::new();
+
+    if let Mod::Module(module) = file_ast {
+        visitor.visit_body(&module.body);
+    }
+
+    visitor.fkeys
+}

--- a/src/processors/django/mod.rs
+++ b/src/processors/django/mod.rs
@@ -1,0 +1,1 @@
+pub mod fkey;

--- a/src/processors/ignore_directive.rs
+++ b/src/processors/ignore_directive.rs
@@ -30,7 +30,7 @@ impl IgnoreDirective {
         }
 
         // If applicable, check if the diagnostic has specified a matching module path
-        diagnostic.import_mod_path().is_none_or(|import_mod_path| {
+        diagnostic.dependency().is_none_or(|import_mod_path| {
             self.modules
                 .iter()
                 .any(|module| import_mod_path.ends_with(module))

--- a/src/processors/mod.rs
+++ b/src/processors/mod.rs
@@ -1,4 +1,5 @@
 pub mod dependency;
+pub mod django;
 pub mod file_module;
 pub mod ignore_directive;
 pub mod import;


### PR DESCRIPTION
This PR plugs into the 'processing' stage of the `tach check` pipeline.

In addition to extracting imports from the AST, this PR introduces a specialized visitor which finds `ForeignKey` calls, and extracts the `to` field when it is a string literal. This is useful because it may avoid a direct import, but still create a cross-module dependency.

To support this, there is also an AST visitor which runs once up-front to extract the `INSTALLED_APPS` from the configured Django settings module. This allows us to resolve the string literals used in `ForeignKey`, which are typically of the form `<app_label>.<model>`.