### PR TITLE
Generalize imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,6 +2183,8 @@ dependencies = [
  "ruff_linter",
  "ruff_python_ast",
  "ruff_python_parser",
+ "ruff_source_file",
+ "ruff_text_size",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ walkdir = "2.5.0"
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
 ruff_linter = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
 cached = { version = "0.54.0", features = ["disk_store"] }
 globset = "0.4.15"
 toml = "0.8.19"

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -1,17 +1,21 @@
 from pathlib import Path
 from typing import Literal
 
+class PythonImport:
+    module_path: str
+    line_number: int
+
 def get_project_imports(
     source_roots: list[str],
     file_path: str,
     ignore_type_checking_imports: bool,
     include_string_imports: bool,
-) -> list[tuple[str, int]]: ...
+) -> list[PythonImport]: ...
 def get_external_imports(
     source_roots: list[str],
     file_path: str,
     ignore_type_checking_imports: bool,
-) -> list[tuple[str, int]]: ...
+) -> list[PythonImport]: ...
 def set_excluded_paths(
     project_root: str, exclude_paths: list[str], use_regex_matching: bool
 ) -> None: ...

--- a/python/tach/modularity.py
+++ b/python/tach/modularity.py
@@ -258,8 +258,7 @@ def build_usages(
             include_string_imports=project_config.include_string_imports,
         )
         for project_import in imports:
-            import_mod_path, line = project_import
-            import_containing_module = get_containing_module(import_mod_path)
+            import_containing_module = get_containing_module(project_import.module_path)
             if (
                 import_containing_module is None
                 or import_containing_module == pyfile_containing_module
@@ -269,9 +268,9 @@ def build_usages(
             usages.append(
                 Usage(
                     module_path=import_containing_module,
-                    full_path=import_mod_path,
+                    full_path=project_import.module_path,
                     filepath=str(pyfile),
-                    line=line,
+                    line=project_import.line_number,
                     containing_module_path=pyfile_containing_module,
                 )
             )

--- a/python/tach/report.py
+++ b/python/tach/report.py
@@ -138,7 +138,7 @@ def get_external_dependencies(
     excluded_modules = excluded_modules or set()
     external_dependencies: list[ExternalDependency] = []
     for external_import in external_imports:
-        external_package = get_package_name(external_import[0])
+        external_package = get_package_name(external_import.module_path)
         if external_package in excluded_modules:
             continue
 
@@ -148,9 +148,9 @@ def get_external_dependencies(
         external_dependencies.append(
             ExternalDependency(
                 absolute_file_path=Path(file_path),
-                import_module_path=external_import[0],
-                import_line_number=external_import[1],
-                package_name=normalize_package_name(external_import[0]),
+                import_module_path=external_import.module_path,
+                import_line_number=external_import.line_number,
+                package_name=normalize_package_name(external_import.module_path),
             )
         )
     return external_dependencies

--- a/python/tests/test_imports.py
+++ b/python/tests/test_imports.py
@@ -10,6 +10,11 @@ from tach.constants import DEFAULT_EXCLUDE_PATHS
 from tach.extension import get_project_imports, set_excluded_paths
 
 
+def _get_project_imports(*args, **kwargs):
+    result = get_project_imports(*args, **kwargs)
+    return list(map(lambda x: (x.module_path, x.line_number), result))
+
+
 # Utility function to create temporary files with content
 def create_temp_file(directory, filename, content):
     filepath = os.path.join(directory, filename)
@@ -81,7 +86,7 @@ import file3
 
 
 def test_regular_imports(temp_project):
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "file1.py"),
         ignore_type_checking_imports=True,
@@ -92,7 +97,7 @@ def test_regular_imports(temp_project):
 
 
 def test_relative_imports(temp_project):
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "local/file2.py"),
         ignore_type_checking_imports=True,
@@ -103,7 +108,7 @@ def test_relative_imports(temp_project):
 
 
 def test_ignore_type_checking_imports(temp_project):
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "file3.py"),
         ignore_type_checking_imports=True,
@@ -114,7 +119,7 @@ def test_ignore_type_checking_imports(temp_project):
 
 
 def test_include_type_checking_imports(temp_project):
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "file3.py"),
         ignore_type_checking_imports=False,
@@ -132,7 +137,7 @@ if TYPE_CHECKING:
 from ..file1 import x
 """
     create_temp_file(temp_project, "local/file4.py", mixed_content)
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "local/file4.py"),
         ignore_type_checking_imports=True,
@@ -141,7 +146,7 @@ from ..file1 import x
     expected = [("file1.x", 5)]
     assert result == expected
 
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "local/file4.py"),
         ignore_type_checking_imports=False,
@@ -157,7 +162,7 @@ import os
 from external_module import something
 """
     create_temp_file(temp_project, "file5.py", external_content)
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "file5.py"),
         ignore_type_checking_imports=True,
@@ -174,7 +179,7 @@ from file1 import c
 from external_module import something
 """
     create_temp_file(temp_project, "file6.py", mixed_content)
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "file6.py"),
         ignore_type_checking_imports=True,
@@ -187,7 +192,7 @@ from external_module import something
 
 
 def test_ignored_imports(temp_project):
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "file4.py"),
         ignore_type_checking_imports=True,
@@ -211,7 +216,7 @@ from external_module import something
     path_outside_source_root = tmp_path / "outside_src_root.py"
     path_outside_source_root.write_text(mixed_content)
 
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(path_outside_source_root),
         ignore_type_checking_imports=True,
@@ -245,7 +250,7 @@ def child_function():
         temp_project / "parent" / "child", "child_module.py", child_file_content
     )
 
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "parent" / "child" / "child_module.py"),
         ignore_type_checking_imports=True,
@@ -269,7 +274,7 @@ from local.m.n import k, l
 """
     create_temp_file(temp_project, "ignore_test.py", content)
 
-    result = get_project_imports(
+    result = _get_project_imports(
         [str(temp_project)],
         str(temp_project / "ignore_test.py"),
         ignore_type_checking_imports=True,

--- a/src/checks/external_dependency.rs
+++ b/src/checks/external_dependency.rs
@@ -52,7 +52,7 @@ impl<'a> ExternalDependencyChecker<'a> {
         if !is_declared {
             Some(Diagnostic::new_located_error(
                 processed_file.relative_file_path().to_path_buf(),
-                import.import.import_line_no,
+                processed_file.line_number(import.import.import_offset),
                 DiagnosticDetails::Code(CodeDiagnostic::UndeclaredExternalDependency {
                     import_mod_path: import.import.top_level_module_name().to_string(),
                 }),

--- a/src/commands/check/check_external.rs
+++ b/src/commands/check/check_external.rs
@@ -142,11 +142,21 @@ pub fn check(
                                 return vec![];
                             }
 
-                            match pipeline.diagnostics(ProjectFile::new(
-                                project_root,
-                                source_root,
-                                &file_path,
-                            )) {
+                            let project_file =
+                                match ProjectFile::try_new(project_root, source_root, &file_path) {
+                                    Ok(project_file) => project_file,
+                                    Err(_) => {
+                                        return vec![Diagnostic::new_global_warning(
+                                            DiagnosticDetails::Configuration(
+                                                ConfigurationDiagnostic::SkippedFileIoError {
+                                                    file_path: file_path.display().to_string(),
+                                                },
+                                            ),
+                                        )]
+                                    }
+                                };
+
+                            match pipeline.diagnostics(project_file) {
                                 Ok(diagnostics) => diagnostics,
                                 Err(DiagnosticError::Io(_))
                                 | Err(DiagnosticError::Filesystem(_)) => {

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -191,8 +191,21 @@ pub fn check(
                     return vec![];
                 }
 
-                let internal_file = ProjectFile::new(&project_root, source_root, &file_path);
-                match pipeline.diagnostics(internal_file) {
+                let project_file =
+                    match ProjectFile::try_new(&project_root, source_root, &file_path) {
+                        Ok(project_file) => project_file,
+                        Err(_) => {
+                            return vec![Diagnostic::new_global_warning(
+                                DiagnosticDetails::Configuration(
+                                    ConfigurationDiagnostic::SkippedFileIoError {
+                                        file_path: file_path.display().to_string(),
+                                    },
+                                ),
+                            )]
+                        }
+                    };
+
+                match pipeline.diagnostics(project_file) {
                     Ok(diagnostics) => diagnostics,
                     Err(DiagnosticError::Io(_)) | Err(DiagnosticError::Filesystem(_)) => {
                         vec![Diagnostic::new_global_warning(

--- a/src/commands/helpers/import.rs
+++ b/src/commands/helpers/import.rs
@@ -1,16 +1,36 @@
 use std::path::{Path, PathBuf};
 
+use pyo3::prelude::*;
+use ruff_linter::Locator;
+
 use crate::filesystem;
 use crate::processors::ignore_directive::get_ignore_directives;
-use crate::processors::import::{get_normalized_imports, NormalizedImport, Result};
+use crate::processors::import::{get_normalized_imports, LocatedImport, Result};
 
-pub fn get_project_imports<P: AsRef<Path>>(
+#[pyclass(get_all)]
+pub struct PythonImport {
+    pub module_path: String,
+    pub line_number: usize,
+}
+
+impl IntoPy<PyObject> for LocatedImport {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        PythonImport {
+            module_path: self.import.module_path,
+            line_number: self.alias_line_number,
+        }
+        .into_py(py)
+    }
+}
+
+pub fn get_located_project_imports<P: AsRef<Path>>(
     source_roots: &[PathBuf],
     file_path: P,
     ignore_type_checking_imports: bool,
     include_string_imports: bool,
-) -> Result<Vec<NormalizedImport>> {
+) -> Result<Vec<LocatedImport>> {
     let file_contents = filesystem::read_file_content(file_path.as_ref())?;
+    let line_index = Locator::new(&file_contents).to_index().clone();
     let normalized_imports = get_normalized_imports(
         source_roots,
         file_path.as_ref(),
@@ -21,19 +41,27 @@ pub fn get_project_imports<P: AsRef<Path>>(
     let ignore_directives = get_ignore_directives(&file_contents);
     Ok(normalized_imports
         .into_iter()
+        .map(|import| {
+            LocatedImport::new(
+                line_index.line_index(import.import_offset).get(),
+                line_index.line_index(import.alias_offset).get(),
+                import,
+            )
+        })
         .filter(|import| {
             !ignore_directives.is_ignored(import)
-                && filesystem::is_project_import(source_roots, &import.module_path)
+                && filesystem::is_project_import(source_roots, import.module_path())
         })
         .collect())
 }
 
-pub fn get_external_imports<P: AsRef<Path>>(
+pub fn get_located_external_imports<P: AsRef<Path>>(
     source_roots: &[PathBuf],
     file_path: P,
     ignore_type_checking_imports: bool,
-) -> Result<Vec<NormalizedImport>> {
+) -> Result<Vec<LocatedImport>> {
     let file_contents = filesystem::read_file_content(file_path.as_ref())?;
+    let line_index = Locator::new(&file_contents).to_index().clone();
     let normalized_imports = get_normalized_imports(
         source_roots,
         file_path.as_ref(),
@@ -44,9 +72,16 @@ pub fn get_external_imports<P: AsRef<Path>>(
     let ignore_directives = get_ignore_directives(&file_contents);
     Ok(normalized_imports
         .into_iter()
+        .map(|import| {
+            LocatedImport::new(
+                line_index.line_index(import.import_offset).get(),
+                line_index.line_index(import.alias_offset).get(),
+                import,
+            )
+        })
         .filter(|import| {
             !ignore_directives.is_ignored(import)
-                && !filesystem::is_project_import(source_roots, &import.module_path)
+                && !filesystem::is_project_import(source_roots, import.module_path())
         })
         .collect())
 }

--- a/src/commands/helpers/mod.rs
+++ b/src/commands/helpers/mod.rs
@@ -1,3 +1,3 @@
 pub mod import;
 
-pub use import::{get_external_imports, get_project_imports};
+pub use import::{get_located_external_imports, get_located_project_imports};

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -9,7 +9,7 @@ use crate::config::{ModuleConfig, ProjectConfig};
 use crate::filesystem::{self as fs};
 use crate::modules::{build_module_tree, ModuleTree};
 
-use super::helpers::import::get_project_imports;
+use super::helpers::import::get_located_project_imports;
 
 #[derive(Error, Debug)]
 pub enum TestError {
@@ -88,11 +88,11 @@ impl TachPytestPluginHandler {
     pub fn should_remove_items(&self, file_path: PathBuf) -> bool {
         // TODO: Remove unwrap
         let project_imports =
-            get_project_imports(&self.source_roots, &file_path, true, false).unwrap();
+            get_located_project_imports(&self.source_roots, &file_path, true, false).unwrap();
         let mut should_remove = true;
 
         for import in project_imports {
-            if let Some(nearest_module) = self.module_tree.find_nearest(&import.module_path) {
+            if let Some(nearest_module) = self.module_tree.find_nearest(import.module_path()) {
                 if self.affected_modules.contains(&nearest_module.full_path) {
                     // If the module is affected, break early and don't remove the item
                     should_remove = false;

--- a/src/config/plugins/mod.rs
+++ b/src/config/plugins/mod.rs
@@ -1,4 +1,4 @@
 mod all;
-mod django;
+pub mod django;
 
 pub use all::PluginsConfig;

--- a/src/diagnostics/error.rs
+++ b/src/diagnostics/error.rs
@@ -4,18 +4,21 @@ use thiserror::Error;
 
 use crate::external;
 use crate::filesystem as fs;
-use crate::interfaces::error::InterfaceError;
+use crate::interfaces;
 use crate::modules;
 use crate::processors::import;
+use crate::python;
 
 #[derive(Error, Debug)]
 pub enum DiagnosticError {
     #[error("Module tree error: {0}")]
     ModuleTree(#[from] modules::error::ModuleTreeError),
     #[error("Interface error: {0}")]
-    Interface(#[from] InterfaceError),
+    Interface(#[from] interfaces::error::InterfaceError),
     #[error("Parsing error: {0}")]
-    Parse(#[from] external::ParsingError),
+    ExternalParse(#[from] external::ParsingError),
+    #[error("Python parsing error: {0}")]
+    PythonParse(#[from] python::error::ParsingError),
     #[error("Import parsing error: {0}")]
     ImportParse(#[from] import::ImportParseError),
     #[error("IO error: {0}")]

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -271,17 +271,24 @@ pub struct ProjectFile<'a> {
     pub source_root: &'a Path,
     pub file_path: PathBuf,
     pub relative_file_path: PathBuf,
+    pub contents: String,
 }
 
 impl<'a> ProjectFile<'a> {
-    pub fn new(project_root: &'a Path, source_root: &'a Path, file_path: &'a Path) -> Self {
+    pub fn try_new(
+        project_root: &'a Path,
+        source_root: &'a Path,
+        file_path: &'a Path,
+    ) -> Result<Self> {
         let absolute_file_path = source_root.join(file_path);
-        Self {
+        let contents = read_file_content(&absolute_file_path)?;
+        Ok(Self {
             project_root,
             source_root,
-            relative_file_path: relative_to(&absolute_file_path, project_root).unwrap(),
+            relative_file_path: relative_to(&absolute_file_path, project_root)?,
             file_path: absolute_file_path,
-        }
+            contents,
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ impl From<python::error::ParsingError> for PyErr {
             }
             python::error::ParsingError::Io(err) => PyOSError::new_err(err.to_string()),
             python::error::ParsingError::Filesystem(err) => PyOSError::new_err(err.to_string()),
+            python::error::ParsingError::InvalidSyntax => PySyntaxError::new_err(err.to_string()),
         }
     }
 }
@@ -174,10 +175,10 @@ fn get_project_imports(
     file_path: String,
     ignore_type_checking_imports: bool,
     include_string_imports: bool,
-) -> processors::import::Result<Vec<processors::import::NormalizedImport>> {
+) -> processors::import::Result<Vec<processors::import::LocatedImport>> {
     let source_roots: Vec<PathBuf> = source_roots.iter().map(PathBuf::from).collect();
     let file_path = PathBuf::from(file_path);
-    commands::helpers::import::get_project_imports(
+    commands::helpers::import::get_located_project_imports(
         &source_roots,
         &file_path,
         ignore_type_checking_imports,
@@ -192,10 +193,10 @@ fn get_external_imports(
     source_roots: Vec<String>,
     file_path: String,
     ignore_type_checking_imports: bool,
-) -> processors::import::Result<Vec<processors::import::NormalizedImport>> {
+) -> processors::import::Result<Vec<processors::import::LocatedImport>> {
     let source_roots: Vec<PathBuf> = source_roots.iter().map(PathBuf::from).collect();
     let file_path = PathBuf::from(file_path);
-    commands::helpers::import::get_external_imports(
+    commands::helpers::import::get_located_external_imports(
         &source_roots,
         &file_path,
         ignore_type_checking_imports,

--- a/src/processors/reference.rs
+++ b/src/processors/reference.rs
@@ -1,10 +1,16 @@
+use ruff_text_size::TextSize;
+
 #[derive(Debug)]
-pub struct SourceCodeReference<'a> {
-    pub content: &'a str,
+pub struct SourceCodeReference {
+    pub module_path: String,
+    pub offset: TextSize,
 }
 
-impl<'a> SourceCodeReference<'a> {
-    pub fn new(content: &'a str) -> Self {
-        Self { content }
+impl SourceCodeReference {
+    pub fn new(module_path: String, offset: TextSize) -> Self {
+        Self {
+            module_path,
+            offset,
+        }
     }
 }

--- a/src/python/error.rs
+++ b/src/python/error.rs
@@ -12,4 +12,6 @@ pub enum ParsingError {
     Io(#[from] io::Error),
     #[error("Filesystem error: {0}")]
     Filesystem(#[from] FileSystemError),
+    #[error("Invalid syntax")]
+    InvalidSyntax,
 }


### PR DESCRIPTION
This PR addresses two issues:
- Checks are done explicitly on Imports, rather than the more general Dependency (which can include string references)
- Locator is used inefficiently to compute the line number of every import

After this PR, checks operate on Dependency, and we build a single LineIndex per file to locate Dependencies and Imports only when necessary.