### PR TITLE
Create 'tach init' for smoother initial setup

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -8,12 +8,11 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from rich.console import Console
-
 from tach import __version__, cache, icons
 from tach import filesystem as fs
 from tach.check_external import check_external
 from tach.colors import BCOLORS
+from tach.console import console, console_err
 from tach.constants import CONFIG_FILE_NAME, TOOL_NAME
 from tach.errors import (
     TachCircularDependencyError,
@@ -51,8 +50,16 @@ from tach.test import run_affected_tests
 if TYPE_CHECKING:
     from tach.extension import UnusedDependencies
 
-console = Console(highlight=False)
-console_err = Console(highlight=False, stderr=True)
+
+import signal
+
+
+def handle_sigint(_signum: int, _frame: Any) -> None:
+    print("Exiting...")
+    sys.exit(1)
+
+
+signal.signal(signal.SIGINT, handle_sigint)
 
 
 def print_unused_dependencies(

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -898,12 +898,12 @@ def tach_test(
         if cached_output.exists:
             # Early exit, cached terminal output was found
             console.print(
-                f"{BCOLORS.OKGREEN}============ Cached results found!  ============{BCOLORS.ENDC}",
+                "============ Cached results found!  ============",
                 style="green",
             )
             cached_output.replay()
             console.print(
-                f"{BCOLORS.OKGREEN}============ END Cached results  ============{BCOLORS.ENDC}",
+                "============ END Cached results  ============",
                 style="green",
             )
             sys.exit(cached_output.exit_code)

--- a/python/tach/console.py
+++ b/python/tach/console.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from rich.console import Console
+
+console = Console(highlight=False)
+console_err = Console(highlight=False, stderr=True)

--- a/python/tach/errors/__init__.py
+++ b/python/tach/errors/__init__.py
@@ -23,3 +23,6 @@ class TachVisibilityError(TachError):
     def __init__(self, visibility_errors: list[tuple[str, str, list[str]]]):
         self.visibility_errors = visibility_errors
         super().__init__("Visibility error")
+
+
+class TachInitCancelledError(TachError): ...

--- a/python/tach/init.py
+++ b/python/tach/init.py
@@ -71,7 +71,7 @@ def show_project(project_config: ProjectConfig):
         show_url = generate_show_url(project_config)
         if show_url:
             console.print(
-                "[green]View your dependency graph here:[/]\n"
+                "\n[cyan]View your dependency graph here:[/]\n"
                 f"[blue underline]{show_url}[/]"
             )
         else:
@@ -144,12 +144,13 @@ def init_project(project_root: Path, force: bool = False):
     try:
         project_config = setup_modules(project_root, project_config)
     except errors.TachInitCancelledError:
+        console.print("[yellow]Initialization cancelled.[/]")
         return
 
     show_project(project_config)
 
     console.print(
-        "[yellow]Tach is now configured for this project!"
-        " You can run [cyan]'tach check'[/] to validate your configuration.[/]\n"
-        "[yellow]Documentation is available at [blue underline]https://docs.gauge.sh[/]"
+        "\n[green]Tach is now configured for this project!"
+        " Run [cyan]'tach check'[/] to validate your configuration.[/]\n\n"
+        "[green]Full documentation is available at [blue underline]https://docs.gauge.sh[/]"
     )

--- a/python/tach/init.py
+++ b/python/tach/init.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tach import errors
+from tach import filesystem as fs
+from tach.constants import CONFIG_FILE_NAME, TOOL_NAME
+from tach.extension import ProjectConfig, parse_project_config, sync_project
+from tach.mod import mod_edit_interactive
+from tach.show import generate_show_url
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def mark_modules(project_root: Path, project_config: ProjectConfig) -> ProjectConfig:
+    saved, _ = mod_edit_interactive(
+        project_root=project_root,
+        project_config=project_config,
+        exclude_paths=project_config.exclude,
+    )
+    if not saved:
+        raise errors.TachInitCancelledError()
+
+    project_config_path = fs.build_project_config_path(project_root)
+    project_config, _ = parse_project_config(project_config_path)
+    return project_config
+
+
+def sync_modules(project_root: Path, project_config: ProjectConfig) -> ProjectConfig:
+    sync_project(project_root, project_config)
+
+    project_config_path = fs.build_project_config_path(project_root)
+    project_config, _ = parse_project_config(project_config_path)
+    return project_config
+
+
+def prompt_to_re_select_modules() -> bool:
+    print(
+        "No dependencies found between the selected modules."
+        + " This might mean that your source root is not set correctly,"
+        + " or you did not select modules which depend on each other."
+    )
+    return input("Would you like to re-select modules?" + "\n  (y/n):  ").lower() == "y"
+
+
+def setup_modules(project_root: Path, project_config: ProjectConfig) -> ProjectConfig:
+    project_config = mark_modules(project_root, project_config)
+    project_config = sync_modules(project_root, project_config)
+
+    while project_config.has_no_dependencies():
+        wants_to_re_select = prompt_to_re_select_modules()
+        if wants_to_re_select:
+            project_config = mark_modules(project_root, project_config)
+            project_config = sync_modules(project_root, project_config)
+        else:
+            print("Continuing with selected modules.")
+            break
+    return project_config
+
+
+def prompt_to_show_project() -> bool:
+    return (
+        input(
+            "Would you like to visualize your dependency graph?"
+            + f"\nThis will upload your module configuration from '{CONFIG_FILE_NAME}.toml' to Gauge [https://app.gauge.sh/show]."
+            + "\n  (y/n):  "
+        ).lower()
+        == "y"
+    )
+
+
+def show_project(project_config: ProjectConfig):
+    if prompt_to_show_project():
+        show_url = generate_show_url(project_config)
+        if show_url:
+            print("View your dependency graph here:")
+            print(show_url)
+        else:
+            print("Failed to generate show URL. Please try again later.")
+
+
+def print_intro():
+    print(
+        "Tach is now configured for this project."
+        + " You can now run `tach check` to validate your configuration."
+    )
+
+
+def prompt_to_reinitialize_project() -> bool:
+    return (
+        input(
+            "Project already initialized. Would you like to reinitialize?"
+            + " This will overwrite the current configuration."
+            + "\n  (y/n):  "
+        ).lower()
+        == "y"
+    )
+
+
+def init_project(project_root: Path, force: bool = False):
+    current_config_path = fs.get_project_config_path(project_root)
+    if current_config_path:
+        if not force:
+            raise errors.TachError(
+                f"Project already initialized. Use `{TOOL_NAME} init --force` to reinitialize."
+            )
+        else:
+            if prompt_to_reinitialize_project():
+                try:
+                    current_config_path.unlink()
+                    for domain_file in project_root.rglob("tach.domain.toml"):
+                        domain_file.unlink()
+                except OSError:
+                    raise errors.TachError("Failed to remove configuration file.")
+            else:
+                raise errors.TachError(
+                    "Refusing to overwrite existing project configuration."
+                )
+
+    project_config = ProjectConfig()
+
+    try:
+        project_config = setup_modules(project_root, project_config)
+    except errors.TachInitCancelledError:
+        return
+    show_project(project_config)
+    print_intro()

--- a/python/tach/show.py
+++ b/python/tach/show.py
@@ -18,8 +18,9 @@ if TYPE_CHECKING:
 
 def generate_show_url(
     project_config: ProjectConfig,
-    included_paths: list[Path],
+    included_paths: list[Path] | None = None,
 ) -> str | None:
+    included_paths = included_paths or []
     modules = project_config.filtered_modules(included_paths)
     for module in modules:
         if module.depends_on is None:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,7 @@ fn detect_unused_dependencies(
 }
 
 #[pyfunction]
+#[pyo3(signature = (project_root, project_config, add = false))]
 pub fn sync_project(
     project_root: PathBuf,
     project_config: config::ProjectConfig,

--- a/tach.toml
+++ b/tach.toml
@@ -34,6 +34,11 @@ depends_on = ["tach.show", "tach.mod"]
 layer = "commands"
 
 [[modules]]
+path = "tach.console"
+depends_on = []
+utility = true
+
+[[modules]]
 path = "tach.cache"
 depends_on = [
     "tach",

--- a/tach.toml
+++ b/tach.toml
@@ -29,6 +29,11 @@ depends_on = [
 layer = "ui"
 
 [[modules]]
+path = "tach.init"
+depends_on = ["tach.show", "tach.mod"]
+layer = "commands"
+
+[[modules]]
 path = "tach.cache"
 depends_on = [
     "tach",


### PR DESCRIPTION
This PR introduces `tach init`, which wraps the `tach mod`, `tach sync` and `tach show` commands. It provides guidance and guardrails for the most common case of a new user onboarding to Tach.