### PR TITLE
Fix `tach show` when Python files exist outside of source roots

### DIFF
--- a/python/tach/modularity.py
+++ b/python/tach/modularity.py
@@ -257,39 +257,42 @@ def build_usages(
         )
 
     usages: list[Usage] = []
-    for pyfile in fs.walk_pyfiles(
-        project_root,
-        project_root=project_root,
-        exclude_paths=project_config.exclude,
-        use_regex_matching=project_config.use_regex_matching,
-    ):
-        pyfile_mod_path = fs.file_to_module_path(
-            tuple(source_roots), project_root / pyfile
-        )
-        pyfile_containing_module = get_containing_module(pyfile_mod_path)
-        imports = get_project_imports(
+    for source_root in source_roots:
+        for pyfile in fs.walk_pyfiles(
+            source_root,
             project_root=project_root,
-            source_roots=source_roots,
-            file_path=pyfile,
-            project_config=project_config,
-        )
-        for project_import in imports:
-            import_containing_module = get_containing_module(project_import.module_path)
-            if (
-                import_containing_module is None
-                or import_containing_module == pyfile_containing_module
-            ):
-                continue
-
-            usages.append(
-                Usage(
-                    module_path=import_containing_module,
-                    full_path=project_import.module_path,
-                    filepath=str(pyfile),
-                    line=project_import.line_number,
-                    containing_module_path=pyfile_containing_module,
-                )
+            exclude_paths=project_config.exclude,
+            use_regex_matching=project_config.use_regex_matching,
+        ):
+            pyfile_mod_path = fs.file_to_module_path(
+                tuple(source_roots), source_root / pyfile
             )
+            pyfile_containing_module = get_containing_module(pyfile_mod_path)
+            imports = get_project_imports(
+                project_root=project_root,
+                source_roots=source_roots,
+                file_path=source_root / pyfile,
+                project_config=project_config,
+            )
+            for project_import in imports:
+                import_containing_module = get_containing_module(
+                    project_import.module_path
+                )
+                if (
+                    import_containing_module is None
+                    or import_containing_module == pyfile_containing_module
+                ):
+                    continue
+
+                usages.append(
+                    Usage(
+                        module_path=import_containing_module,
+                        full_path=project_import.module_path,
+                        filepath=str(pyfile),
+                        line=project_import.line_number,
+                        containing_module_path=pyfile_containing_module,
+                    )
+                )
 
     return usages
 

--- a/python/tests/test_show.py
+++ b/python/tests/test_show.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from tach.parsing.config import parse_project_config
+from tach.show import generate_show_report
+
+
+# right now this is just a smoke test
+# this example directory has Python files outside source roots, which has previously caused bugs
+def test_many_features_example_dir(example_dir, capfd):
+    project_root = example_dir / "many_features"
+    project_config = parse_project_config(root=project_root)
+    assert project_config is not None
+
+    report = generate_show_report(
+        project_root=project_root, project_config=project_config, included_paths=[]
+    )
+    assert report is not None


### PR DESCRIPTION
This PR fixes a bug which occurs when running `tach show` with Python files outside of a source root. The file traversal is naive, and tries to resolve the module path relative to source roots for every Python file within the project, and fails when this is not possible.

This PR changes the traversal to start from each source root, which guarantees module resolution will succeed.