### PR TITLE
Migrate check external interface fully to Rust

### DIFF
--- a/python/tach/check_external.py
+++ b/python/tach/check_external.py
@@ -1,48 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from tach.errors import TachError
-from tach.extension import (
-    Diagnostic,
-    check_external_dependencies,
-)
-from tach.utils.external import (
-    get_module_mappings,
-    get_stdlib_modules,
-)
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from tach.extension import ProjectConfig
-
-
-def extract_module_mappings(rename: list[str]) -> dict[str, list[str]]:
-    try:
-        return {
-            module: [name] for module, name in [module.split(":") for module in rename]
-        }
-    except ValueError as e:
-        raise TachError(
-            "Invalid rename format: expected format is a list of 'module:name' pairs, e.g. ['PIL:pillow']"
-        ) from e
-
-
-def check_external(
-    project_root: Path, project_config: ProjectConfig
-) -> list[Diagnostic]:
-    metadata_module_mappings = get_module_mappings()
-    if project_config.external.rename:
-        metadata_module_mappings.update(
-            extract_module_mappings(project_config.external.rename)
-        )
-    return check_external_dependencies(
-        project_root=project_root,
-        project_config=project_config,
-        module_mappings=metadata_module_mappings,
-        stdlib_modules=get_stdlib_modules(),
-    )
-
+from tach.extension import check_external_dependencies as check_external
 
 __all__ = ["check_external"]

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -53,8 +53,6 @@ def check(
 def check_external_dependencies(
     project_root: Path,
     project_config: ProjectConfig,
-    module_mappings: dict[str, list[str]],
-    stdlib_modules: list[str],
 ) -> list[Diagnostic]: ...
 def format_diagnostics(
     project_root: Path,

--- a/src/commands/check/error.rs
+++ b/src/commands/check/error.rs
@@ -24,4 +24,6 @@ pub enum CheckError {
     Interrupt,
     #[error("Diagnostic error: {0}")]
     Diagnostic(#[from] DiagnosticError),
+    #[error("Config error: {0}")]
+    ConfigError(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,15 +19,14 @@ pub mod pattern;
 pub mod processors;
 pub mod python;
 pub mod tests;
-
 use commands::{check, report, server, sync, test};
 use diagnostics::serialize_diagnostics_json;
 use modularity::into_usage_errors;
+use pyo3::prelude::*;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 use pyo3::exceptions::{PyKeyboardInterrupt, PyOSError, PySyntaxError, PyValueError};
-use pyo3::prelude::*;
 
 mod errors {
     pyo3::import_exception!(tach.errors, TachCircularDependencyError);
@@ -199,19 +198,58 @@ fn get_external_imports(
     )
 }
 
+struct CheckExternalMetadata {
+    module_mappings: HashMap<String, Vec<String>>,
+    stdlib_modules: Vec<String>,
+}
+
+/// Get metadata for checking external dependencies.
+fn get_check_external_metadata(project_config: &config::ProjectConfig) -> CheckExternalMetadata {
+    Python::with_gil(|py| {
+        let external_utils = PyModule::import_bound(py, "tach.utils.external")
+            .expect("Failed to import tach.utils.external");
+        let mut module_mappings: HashMap<String, Vec<String>> = external_utils
+            .getattr("get_module_mappings")
+            .expect("Failed to get module_mappings")
+            .call0()
+            .expect("Failed to call get_module_mappings")
+            .extract()
+            .expect("Failed to extract module_mappings");
+        let stdlib_modules: Vec<String> = external_utils
+            .getattr("get_stdlib_modules")
+            .expect("Failed to get stdlib_modules")
+            .call0()
+            .expect("Failed to call get_stdlib_modules")
+            .extract()
+            .expect("Failed to extract stdlib_modules");
+
+        if !project_config.external.rename.is_empty() {
+            for rename_pair in project_config.external.rename.iter() {
+                if let Some((module, name)) = rename_pair.split_once(':') {
+                    module_mappings.insert(module.to_string(), vec![name.to_string()]);
+                }
+            }
+        }
+
+        CheckExternalMetadata {
+            module_mappings,
+            stdlib_modules,
+        }
+    })
+}
+
 /// Validate external dependency imports against pyproject.toml dependencies
 #[pyfunction]
 fn check_external_dependencies(
     project_root: PathBuf,
     project_config: config::ProjectConfig,
-    module_mappings: HashMap<String, Vec<String>>,
-    stdlib_modules: Vec<String>,
 ) -> check::check_external::Result<Vec<diagnostics::Diagnostic>> {
+    let metadata = get_check_external_metadata(&project_config);
     check::check_external::check(
         &project_root,
         &project_config,
-        &module_mappings,
-        &stdlib_modules,
+        &metadata.module_mappings,
+        &metadata.stdlib_modules,
     )
 }
 


### PR DESCRIPTION
This PR migrates `check_external` fully to Rust, in particular the pulling in of relevant metadata so that we can easily fix https://github.com/gauge-sh/tach-vscode/issues/17.