### PR TITLE
Support glob paths for modules

### DIFF
--- a/python/tests/example/many_features/other_src_root/module4/service.py
+++ b/python/tests/example/many_features/other_src_root/module4/service.py
@@ -14,3 +14,5 @@ from module1 import (
     i,
     j,
 )
+
+from globbed.other.module import something

--- a/python/tests/example/many_features/real_src/globbed/module.py
+++ b/python/tests/example/many_features/real_src/globbed/module.py
@@ -1,0 +1,4 @@
+# tach-ignore(ok)
+from module2 import something
+
+from module4 import something_else

--- a/python/tests/example/many_features/real_src/globbed/other/module.py
+++ b/python/tests/example/many_features/real_src/globbed/other/module.py
@@ -1,0 +1,1 @@
+from module2 import something

--- a/python/tests/example/many_features/real_src/module3/__init__.py
+++ b/python/tests/example/many_features/real_src/module3/__init__.py
@@ -1,3 +1,5 @@
 import module1
 
 from .submodule1.api import Api
+
+from globbed.other.module import something

--- a/python/tests/example/many_features/tach.toml
+++ b/python/tests/example/many_features/tach.toml
@@ -29,6 +29,11 @@ layer = "high"
 path = "outer_module"
 unchecked = true
 
+[[modules]]
+path = "globbed.**"
+depends_on = ["module4"]
+layer = "hightest"
+
 [rules]
 unused_ignore_directives = "error"
 require_ignore_directive_reasons = "warn"

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -335,6 +335,19 @@ def test_many_features_example_dir(example_dir, capfd):
     expected_dependencies = [
         ("[FAIL]", "real_src/module2/service.py", "outer_module", "module2"),
         ("[FAIL]", "real_src/module3/__init__.py", "'low'", "lower than", "'mid'"),
+        (
+            "[FAIL]",
+            "real_src/globbed/other/module.py",
+            "'hightest'",
+            "lower than",
+            "'high'",
+        ),
+        (
+            "[FAIL]",
+            "other_src_root/module4/service.py",
+            "cannot depend on",
+            "globbed.other.module.something",
+        ),
     ]
 
     _check_expected_messages_unordered(general_section, expected_general)

--- a/src/checks/internal_dependency.rs
+++ b/src/checks/internal_dependency.rs
@@ -137,6 +137,8 @@ impl<'a> InternalDependencyChecker<'a> {
 
         match file_module_config
             .dependencies_iter()
+            // this is where we match depends_on to the module boundary path
+            // DependencyConfig should build a matcher up-front for any glob patterns
             .find(|dep| &dep.path == dependency_nearest_module_path)
         {
             Some(DependencyConfig {

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -131,7 +131,7 @@ pub fn check(
         ));
     }
 
-    let mut warnings = Vec::new();
+    let mut diagnostics = Vec::new();
     let found_imports = AtomicBool::new(false);
     let source_roots: Vec<PathBuf> = project_config.prepend_roots(&project_root);
     let (valid_modules, invalid_modules) = fs::validate_project_modules(
@@ -140,7 +140,7 @@ pub fn check(
     );
 
     for module in &invalid_modules {
-        warnings.push(Diagnostic::new_global_warning(
+        diagnostics.push(Diagnostic::new_global_warning(
             DiagnosticDetails::Configuration(ConfigurationDiagnostic::ModuleNotFound {
                 file_mod_path: module.path.to_string(),
             }),
@@ -148,8 +148,14 @@ pub fn check(
     }
 
     check_interrupt().map_err(|_| CheckError::Interrupt)?;
+    let exclusions = PathExclusions::new(
+        &project_root,
+        &project_config.exclude,
+        project_config.use_regex_matching,
+    )?;
     let module_tree = build_module_tree(
         &source_roots,
+        &exclusions,
         &valid_modules,
         project_config.forbid_circular_dependencies,
         project_config.root_module.clone(),
@@ -169,11 +175,6 @@ pub fn check(
         None
     };
 
-    let exclusions = PathExclusions::new(
-        &project_root,
-        &project_config.exclude,
-        project_config.use_regex_matching,
-    )?;
     let pipeline = CheckInternalPipeline::new(
         project_config,
         &source_roots,
@@ -184,7 +185,7 @@ pub fn check(
     .with_dependency_checker(dependency_checker)
     .with_interface_checker(interface_checker);
 
-    let diagnostics = source_roots.par_iter().flat_map(|source_root| {
+    diagnostics.par_extend(source_roots.par_iter().flat_map(|source_root| {
         fs::walk_pyfiles(&source_root.display().to_string(), &exclusions)
             .par_bridge()
             .flat_map(|file_path| {
@@ -238,18 +239,17 @@ pub fn check(
                     )],
                 }
             })
-    });
+    }));
 
     if check_interrupt().is_err() {
         return Err(CheckError::Interrupt);
     }
 
-    let mut final_diagnostics: Vec<Diagnostic> = diagnostics.collect();
     if !found_imports.load(Ordering::Relaxed) {
-        final_diagnostics.push(Diagnostic::new_global_warning(
+        diagnostics.push(Diagnostic::new_global_warning(
             DiagnosticDetails::Configuration(ConfigurationDiagnostic::NoFirstPartyImportsFound()),
         ));
     }
 
-    Ok(final_diagnostics)
+    Ok(diagnostics)
 }

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -14,11 +14,9 @@ use crate::config::root_module::RootModuleTreatment;
 use crate::config::ProjectConfig;
 use crate::dependencies::LocatedImport;
 use crate::exclusion::{PathExclusionError, PathExclusions};
-use crate::filesystem::{
-    file_to_module_path, validate_project_modules, walk_pyfiles, FileSystemError,
-};
+use crate::filesystem::{file_to_module_path, walk_pyfiles, FileSystemError};
 use crate::interrupt::check_interrupt;
-use crate::modules::{build_module_tree, error::ModuleTreeError};
+use crate::modules::{ModuleTreeBuilder, ModuleTreeError};
 use crate::processors::import::ImportParseError;
 
 use super::helpers::import::get_located_project_imports;
@@ -227,25 +225,22 @@ pub fn create_dependency_report(
     }
 
     let source_roots = project_config.prepend_roots(project_root);
-    let (valid_modules, _) = validate_project_modules(
-        &source_roots,
-        project_config.all_modules().cloned().collect(),
-    );
-
-    check_interrupt().map_err(|_| ReportCreationError::Interrupted)?;
-
     let exclusions = PathExclusions::new(
         project_root,
         &project_config.exclude,
         project_config.use_regex_matching,
     )?;
-    let module_tree = build_module_tree(
+    let module_tree_builder = ModuleTreeBuilder::new(
         &source_roots,
         &exclusions,
-        &valid_modules,
         false,                      // skip circular dependency check in report
         RootModuleTreatment::Allow, // skip root module check in report
-    )?;
+    );
+    let (valid_modules, _) = module_tree_builder.resolve_modules(project_config.all_modules());
+
+    check_interrupt().map_err(|_| ReportCreationError::Interrupted)?;
+
+    let module_tree = module_tree_builder.build(valid_modules)?;
 
     let absolute_path = project_root.join(path);
     let module_path = file_to_module_path(&source_roots, &absolute_path)?;

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -234,8 +234,14 @@ pub fn create_dependency_report(
 
     check_interrupt().map_err(|_| ReportCreationError::Interrupted)?;
 
+    let exclusions = PathExclusions::new(
+        project_root,
+        &project_config.exclude,
+        project_config.use_regex_matching,
+    )?;
     let module_tree = build_module_tree(
         &source_roots,
+        &exclusions,
         &valid_modules,
         false,                      // skip circular dependency check in report
         RootModuleTreatment::Allow, // skip root module check in report
@@ -248,12 +254,6 @@ pub fn create_dependency_report(
     })?;
 
     let mut report = DependencyReport::new(path.display().to_string());
-
-    let exclusions = PathExclusions::new(
-        project_root,
-        &project_config.exclude,
-        project_config.use_regex_matching,
-    )?;
 
     for source_root in &source_roots {
         check_interrupt().map_err(|_| ReportCreationError::Interrupted)?;

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -6,6 +6,7 @@ use pyo3::{pyclass, pymethods};
 use thiserror::Error;
 
 use crate::config::{ModuleConfig, ProjectConfig};
+use crate::exclusion::PathExclusions;
 use crate::filesystem::{self as fs};
 use crate::modules::{build_module_tree, ModuleTree};
 
@@ -60,8 +61,15 @@ impl TachPytestPluginHandler {
         }
 
         // TODO: Remove unwraps
+        let exclusions = PathExclusions::new(
+            &project_root,
+            &project_config.exclude,
+            project_config.use_regex_matching,
+        )
+        .unwrap();
         let module_tree = build_module_tree(
             &source_roots,
+            &exclusions,
             &valid_modules,
             project_config.forbid_circular_dependencies,
             project_config.root_module.clone(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,4 +20,5 @@ pub use interfaces::{InterfaceConfig, InterfaceDataTypes};
 pub use modules::{serialize_modules_json, DependencyConfig, ModuleConfig};
 pub use plugins::PluginsConfig;
 pub use project::ProjectConfig;
+pub use root_module::RootModuleTreatment;
 pub use rules::{RuleSetting, RulesConfig};

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -223,6 +223,16 @@ impl ModuleConfig {
         }
     }
 
+    pub fn clone_with_path(&self, path: &str) -> Self {
+        let mut new_config = self.clone();
+        if path == self.path {
+            return new_config;
+        }
+
+        new_config.path = path.to_string();
+        new_config
+    }
+
     pub fn new_root_config() -> Self {
         Self::new(ROOT_MODULE_SENTINEL_TAG, false)
     }

--- a/src/config/root_module.rs
+++ b/src/config/root_module.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub const ROOT_MODULE_SENTINEL_TAG: &str = "<root>";
 
-#[derive(Debug, Serialize, Default, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Default, Deserialize, Copy, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum RootModuleTreatment {
     Allow,

--- a/src/interfaces/data_types.rs
+++ b/src/interfaces/data_types.rs
@@ -1,6 +1,6 @@
 use super::compiled::{CompiledInterface, CompiledInterfaces};
 use super::error::InterfaceError;
-use crate::config::{InterfaceDataTypes, ModuleConfig};
+use crate::config::InterfaceDataTypes;
 use crate::filesystem::module_to_file_path;
 use crate::python::parsing::parse_python_source;
 use std::collections::HashMap;
@@ -23,14 +23,14 @@ pub struct TypeCheckCache {
 impl TypeCheckCache {
     pub fn build(
         compiled_interfaces: &CompiledInterfaces,
-        modules: &[ModuleConfig],
+        module_paths: &[String],
         source_roots: &[PathBuf],
     ) -> Result<Self, InterfaceError> {
-        let module_paths: Vec<&str> = modules
+        let filtered_module_paths: Vec<&str> = module_paths
             .iter()
-            .filter_map(|module| {
-                if compiled_interfaces.should_type_check(module.path.as_str()) {
-                    Some(module.path.as_str())
+            .filter_map(|path| {
+                if compiled_interfaces.should_type_check(path.as_str()) {
+                    Some(path.as_str())
                 } else {
                     None
                 }
@@ -40,7 +40,7 @@ impl TypeCheckCache {
         Ok(Self {
             type_check_cache: type_check_all_interface_members(
                 source_roots,
-                &module_paths,
+                &filtered_module_paths,
                 compiled_interfaces,
             )?,
         })
@@ -420,7 +420,7 @@ def custom_func(a: CustomType) -> CustomType:
 
         let source_roots = setup_test_files(&temp_dir, &source_files);
         let interfaces = CompiledInterfaces::build(&[basic_interface]);
-        let modules = vec![ModuleConfig::new("my_module", false)];
+        let modules = vec!["my_module".to_string()];
 
         let cache = TypeCheckCache::build(&interfaces, &modules, &source_roots).unwrap();
 

--- a/src/modules/error.rs
+++ b/src/modules/error.rs
@@ -1,7 +1,8 @@
-use globset::Error as GlobError;
 use thiserror::Error;
 
 use crate::python::error::ParsingError;
+
+use super::resolve::ModuleResolverError;
 
 #[derive(Debug, Clone)]
 pub struct VisibilityErrorInfo {
@@ -28,6 +29,6 @@ pub enum ModuleTreeError {
     InsertNodeError,
     #[error("Module not found: {0}")]
     ModuleNotFound(String),
-    #[error("Glob error: {0}")]
-    GlobError(#[from] GlobError),
+    #[error("Module resolution error: {0}")]
+    ModuleResolutionError(#[from] ModuleResolverError),
 }

--- a/src/modules/error.rs
+++ b/src/modules/error.rs
@@ -1,3 +1,4 @@
+use globset::Error as GlobError;
 use thiserror::Error;
 
 use crate::python::error::ParsingError;
@@ -27,4 +28,6 @@ pub enum ModuleTreeError {
     InsertNodeError,
     #[error("Module not found: {0}")]
     ModuleNotFound(String),
+    #[error("Glob error: {0}")]
+    GlobError(#[from] GlobError),
 }

--- a/src/modules/glob.rs
+++ b/src/modules/glob.rs
@@ -1,0 +1,103 @@
+use globset::{Error as GlobError, GlobBuilder, GlobMatcher};
+use std::path::{Path, PathBuf};
+
+use crate::{exclusion::PathExclusions, filesystem};
+
+#[derive(Debug)]
+enum ModuleGlobSegment {
+    Literal(String),
+    Wildcard,
+    DoubleWildcard,
+}
+
+#[derive(Debug)]
+struct ModuleGlob {
+    segments: Vec<ModuleGlobSegment>,
+}
+
+impl ModuleGlob {
+    pub fn parse(pattern: &str) -> Option<Self> {
+        if !pattern.contains('*') {
+            // No wildcards, not a glob
+            return None;
+        }
+
+        let segments = pattern
+            .split('.')
+            .map(|s| match s {
+                "*" => ModuleGlobSegment::Wildcard,
+                "**" => ModuleGlobSegment::DoubleWildcard,
+                _ => ModuleGlobSegment::Literal(s.to_string()),
+            })
+            .collect();
+        Some(Self { segments })
+    }
+
+    pub fn into_matcher(self) -> Result<GlobMatcher, GlobError> {
+        let pattern = self
+            .segments
+            .iter()
+            .map(|s| match s {
+                ModuleGlobSegment::Literal(s) => globset::escape(s),
+                ModuleGlobSegment::Wildcard => "*".to_string(),
+                ModuleGlobSegment::DoubleWildcard => "**".to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("/");
+        let mut glob_builder = GlobBuilder::new(&pattern);
+        Ok(glob_builder
+            .literal_separator(true)
+            .build()?
+            .compile_matcher())
+    }
+}
+
+#[derive(Debug)]
+pub struct ModuleGlobResolver {
+    modules: Vec<PathBuf>,
+}
+
+impl ModuleGlobResolver {
+    fn collect_modules<P: AsRef<Path>>(
+        source_roots: &[P],
+        exclusions: &PathExclusions,
+    ) -> Vec<PathBuf> {
+        let mut modules = Vec::new();
+        for root in source_roots {
+            modules.extend(filesystem::walk_pymodules(
+                root.as_ref().to_str().unwrap(),
+                exclusions,
+            ));
+        }
+        modules
+    }
+
+    pub fn new<P: AsRef<Path>>(source_roots: &[P], exclusions: &PathExclusions) -> Self {
+        Self {
+            modules: Self::collect_modules(source_roots, exclusions),
+        }
+    }
+
+    pub fn resolve_module_path(&self, path: &str) -> Result<Vec<String>, GlobError> {
+        let glob = match ModuleGlob::parse(path) {
+            Some(glob) => glob,
+            // If not a glob, return the path as is
+            None => return Ok(vec![path.to_string()]),
+        };
+
+        let matcher = glob.into_matcher()?;
+        let res = Ok(self
+            .modules
+            .iter()
+            .filter(|m| matcher.is_match(m))
+            .map(|m| {
+                m.with_extension("")
+                    .display()
+                    .to_string()
+                    .replace(std::path::MAIN_SEPARATOR, ".")
+            })
+            .collect());
+        eprintln!("Resolved glob for: {} to {:?}", path, res);
+        res
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,8 +1,10 @@
+pub mod build;
 pub mod error;
-pub mod glob;
-pub mod parsing;
+pub mod resolve;
 pub mod tree;
+pub mod validation;
 
-pub use glob::ModuleGlobResolver;
-pub use parsing::build_module_tree;
+pub use build::ModuleTreeBuilder;
+pub use error::ModuleTreeError;
+pub use resolve::{ModuleResolver, ModuleResolverError};
 pub use tree::{ModuleNode, ModuleTree};

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,6 +1,8 @@
 pub mod error;
+pub mod glob;
 pub mod parsing;
 pub mod tree;
 
+pub use glob::ModuleGlobResolver;
 pub use parsing::build_module_tree;
 pub use tree::{ModuleNode, ModuleTree};

--- a/src/modules/tree.rs
+++ b/src/modules/tree.rs
@@ -150,6 +150,10 @@ impl ModuleTree {
     pub fn iter(&self) -> ModuleTreeIterator {
         ModuleTreeIterator::new(self)
     }
+
+    pub fn module_paths(&self) -> Vec<String> {
+        self.iter().map(|node| node.full_path.clone()).collect()
+    }
 }
 
 pub struct ModuleTreeIterator {


### PR DESCRIPTION
This PR allows a 'module glob' syntax for the `path` or `paths` fields on modules.

For example:
```toml
[[modules]]
path = "tach.filesystem.**"
layer = "core"
```

This will create modules for all Python files and packages whose module paths start with `tach.filesystem`, and add them to the `core` layer.

More specifically, Tach will allow module paths which use a single wildcard `*` or double wildcard `**` as path segments. All other segments will be treated as literals. A single wildcard will match exactly one segment with any name, while the double wildcard will match zero or more segments with any name.

In a follow-on to this PR, globs in the same form will also be allowed in `depends_on`.