### PR TITLE
Allow specific modules to overwrite glob modules

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -55,14 +55,13 @@ def print_unused_dependencies(
     all_unused_dependencies: list[UnusedDependencies],
 ) -> None:
     constraint_messages = "\n".join(
-        f"\t'{unused_dependencies.path}' does not depend on: {[dependency.path for dependency in unused_dependencies.dependencies]}"
+        f"{icons.FAIL} [bold]'{unused_dependencies.path}'[/] does not depend on: [bold]{[dependency.path for dependency in unused_dependencies.dependencies]}[/]"
         for unused_dependencies in all_unused_dependencies
     )
-    console.print(
-        f"{icons.FAIL}: [red]Found unused dependencies:[/]\n"
-        + f"[yellow]{constraint_messages}[/]"
+    console_err.print(
+        "[red bold]Unused Dependencies[/]\n" + f"[yellow]{constraint_messages}[/]"
     )
-    console.print(
+    console_err.print(
         f"\n[yellow]Remove the unused dependencies from {CONFIG_FILE_NAME}.toml, "
         f"or consider running '{TOOL_NAME} sync' to update module configuration and "
         f"remove all unused dependencies.[/]\n"

--- a/python/tach/filesystem/tach.domain.toml
+++ b/python/tach/filesystem/tach.domain.toml
@@ -1,6 +1,11 @@
 [root]
 layer = "core"
-depends_on = ["service", "install"]
+depends_on = ["service", "install", "project"]
+
+[[modules]]
+path = "*"
+depends_on = []
+layer = "core"
 
 [[modules]]
 paths = ["git_ops", "service"]

--- a/python/tests/example/many_features/real_src/module1/tach.domain.toml
+++ b/python/tests/example/many_features/real_src/module1/tach.domain.toml
@@ -3,6 +3,11 @@ depends_on = ["api", "//module5"]
 layer = "mid"
 
 [[modules]]
+path = "*"
+depends_on = []
+layer = "hightest"
+
+[[modules]]
 path = "api"
 depends_on = ["**"]
 layer = "mid"

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -5,6 +5,7 @@ from unittest.mock import NonCallableMagicMock
 
 import pytest
 
+from tach import icons
 from tach.cli import tach_check, tach_check_external
 from tach.errors import TachCircularDependencyError, TachVisibilityError
 from tach.extension import Diagnostic
@@ -208,29 +209,6 @@ def test_distributed_config_example_dir(example_dir, capfd):
     assert "project/top_level.py" in captured.err
 
 
-def _check_expected_messages(section_text: str, expected_messages: list[tuple]) -> None:
-    """Helper to verify all expected messages appear in a section of output text, in the given order.
-
-    Args:
-        section_text: The text section to check
-        expected_messages: List of tuples containing substrings that should appear together in a line
-    """
-    lines = iter(section_text.split("\n"))
-    substrs = iter(expected_messages)
-    current_substrs = next(substrs, None)
-
-    for line in lines:
-        if not current_substrs:
-            break
-
-        if all(substr.lower() in line.lower() for substr in current_substrs):
-            current_substrs = next(substrs, None)
-
-    assert current_substrs is None, (
-        f"Not all expected messages were found: {list(substrs)} in section: {section_text}"
-    )
-
-
 def _check_expected_messages_unordered(
     section_text: str, expected_messages: list[tuple]
 ) -> None:
@@ -243,7 +221,12 @@ def _check_expected_messages_unordered(
     lines = iter(section_text.split("\n"))
     substr_tuples = set(expected_messages)
     for line in lines:
-        if "[WARN]" in line or "[FAIL]" in line:
+        if (
+            "[WARN]" in line
+            or "[FAIL]" in line
+            or icons.FAIL in line
+            or icons.WARNING in line
+        ):
             matched = False
             for substr_tuple in substr_tuples:
                 if all(substr.lower() in line.lower() for substr in substr_tuple):
@@ -274,10 +257,12 @@ def test_many_features_example_dir(example_dir, capfd):
     general_header = captured.err.index("General\n")
     interfaces_header = captured.err.index("Interfaces\n")
     dependencies_header = captured.err.index("Internal Dependencies\n")
+    unused_header = captured.err.index("Unused Dependencies\n")
 
     general_section = captured.err[general_header:interfaces_header]
     interfaces_section = captured.err[interfaces_header:dependencies_header]
-    dependencies_section = captured.err[dependencies_header:]
+    dependencies_section = captured.err[dependencies_header:unused_header]
+    unused_section = captured.err[unused_header:]
 
     expected_general = [
         (
@@ -348,11 +333,42 @@ def test_many_features_example_dir(example_dir, capfd):
             "cannot depend on",
             "globbed.other.module.something",
         ),
+        (
+            "[FAIL]",
+            "real_src/module1/controller.py",
+            "'hightest'",
+            "lower than",
+            "'mid'",
+            "module5",
+        ),
+        (
+            "[FAIL]",
+            "real_src/module1/controller.py",
+            "L5",
+            "'hightest'",
+            "lower than",
+            "'low'",
+            "module3",
+        ),
+        (
+            "[FAIL]",
+            "real_src/module1/controller.py",
+            "L6",
+            "'hightest'",
+            "lower than",
+            "'low'",
+            "module3",
+        ),
+    ]
+
+    expected_unused = [
+        ("module1", "module5"),
     ]
 
     _check_expected_messages_unordered(general_section, expected_general)
     _check_expected_messages_unordered(interfaces_section, expected_interfaces)
     _check_expected_messages_unordered(dependencies_section, expected_dependencies)
+    _check_expected_messages_unordered(unused_section, expected_unused)
 
 
 def test_many_features_example_dir__external(example_dir, capfd):

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -257,7 +257,7 @@ def test_many_features_example_dir(example_dir, capfd):
     general_header = captured.err.index("General\n")
     interfaces_header = captured.err.index("Interfaces\n")
     dependencies_header = captured.err.index("Internal Dependencies\n")
-    unused_header = captured.err.index("Unused Dependencies\n")
+    unused_header = captured.err.index("Unused Dependencies")
 
     general_section = captured.err[general_header:interfaces_header]
     interfaces_section = captured.err[interfaces_header:dependencies_header]

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -91,7 +91,12 @@ pub fn detect_unused_dependencies(
     let detected_dependencies = detect_dependencies(&check_result);
 
     let mut unused_dependencies: Vec<UnusedDependencies> = vec![];
-    for module_path in project_config.module_paths() {
+    for module_path in project_config
+        .module_paths()
+        .into_iter()
+        // This is a hack to avoid checking globbed modules for unused dependencies
+        .filter(|path| !path.contains("*"))
+    {
         let module_detected_dependencies =
             detected_dependencies
                 .get(&module_path)
@@ -156,7 +161,12 @@ fn sync_dependency_constraints(
     }
 
     // Now diff with project config and apply edits
-    for module_path in project_config.module_paths() {
+    for module_path in project_config
+        .module_paths()
+        .into_iter()
+        // This is a hack to avoid attempting to sync globbed modules
+        .filter(|path| !path.contains("*"))
+    {
         let module_detected_dependencies =
             detected_dependencies
                 .get(&module_path)

--- a/src/config/domain.rs
+++ b/src/config/domain.rs
@@ -131,32 +131,29 @@ impl Resolvable<Vec<DependencyConfig>> for Vec<DependencyConfig> {
 
 impl Resolvable<ModuleConfig> for DomainRootConfig {
     fn resolve(&self, location: &ConfigLocation) -> ModuleConfig {
-        ModuleConfig {
+        ModuleConfig::new(
             // Root modules represent the domain itself
-            path: location.mod_path.clone(),
-            depends_on: self.depends_on.clone().map(|deps| deps.resolve(location)),
-            layer: self.layer.clone(),
-            visibility: self.visibility.clone(),
-            utility: self.utility,
-            strict: false,
-            unchecked: self.unchecked,
-            group_id: None,
-        }
+            &location.mod_path,
+            self.depends_on.clone().map(|deps| deps.resolve(location)),
+            self.layer.clone(),
+            self.visibility.clone(),
+            self.utility,
+            self.unchecked,
+        )
     }
 }
 
 impl Resolvable<ModuleConfig> for ModuleConfig {
     fn resolve(&self, location: &ConfigLocation) -> ModuleConfig {
-        ModuleConfig {
-            path: format!("{}.{}", location.mod_path, self.path),
-            depends_on: self.depends_on.clone().map(|deps| deps.resolve(location)),
-            layer: self.layer.clone(),
-            visibility: self.visibility.clone(),
-            utility: self.utility,
-            strict: false,
-            unchecked: self.unchecked,
-            group_id: None,
-        }
+        ModuleConfig::new(
+            &format!("{}.{}", location.mod_path, self.path),
+            self.depends_on.clone().map(|deps| deps.resolve(location)),
+            self.layer.clone(),
+            self.visibility.clone(),
+            self.utility,
+            self.unchecked,
+        )
+        .with_copied_origin(self)
     }
 }
 

--- a/src/config/domain.rs
+++ b/src/config/domain.rs
@@ -74,13 +74,12 @@ impl DomainConfig {
     }
 
     pub fn with_location(self, location: ConfigLocation) -> LocatedDomainConfig {
-        let resolved_modules = self
-            .modules
-            .iter()
-            .map(|module| Some(module.resolve(&location)))
-            .chain(iter::once(
-                self.root.as_ref().map(|root| root.resolve(&location)),
-            ))
+        let resolved_modules = iter::once(self.root.as_ref().map(|root| root.resolve(&location)))
+            .chain(
+                self.modules
+                    .iter()
+                    .map(|module| Some(module.resolve(&location))),
+            )
             .flatten()
             .collect();
         let resolved_interfaces = self

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -267,6 +267,31 @@ impl ModuleConfig {
         }
     }
 
+    pub fn can_merge_with(&self, other: &Self) -> bool {
+        self.path == other.path && self.origin != other.origin
+    }
+
+    pub fn merge(mut self, other: Self) -> Result<Self, String> {
+        if !self.can_merge_with(&other) {
+            return Err(format!(
+                "Cannot merge modules: ({}, {:?}) and ({}, {:?})",
+                self.path, self.origin, other.path, other.origin
+            ));
+        }
+
+        // TODO: also handle layer, visibility, utility, strict, unchecked
+        // Also: this logic is wrong if both are None
+        self.depends_on = Some(
+            self.depends_on
+                .unwrap_or_default()
+                .into_iter()
+                .chain(other.depends_on.unwrap_or_default().into_iter())
+                .collect(),
+        );
+
+        Ok(self)
+    }
+
     pub fn new_with_layer(path: &str, layer: &str) -> Self {
         // shorthand for test fixtures
         Self {

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -267,29 +267,15 @@ impl ModuleConfig {
         }
     }
 
-    pub fn can_merge_with(&self, other: &Self) -> bool {
-        self.path == other.path && self.origin != other.origin
-    }
-
-    pub fn merge(mut self, other: Self) -> Result<Self, String> {
-        if !self.can_merge_with(&other) {
-            return Err(format!(
-                "Cannot merge modules: ({}, {:?}) and ({}, {:?})",
-                self.path, self.origin, other.path, other.origin
-            ));
-        }
-
-        // TODO: also handle layer, visibility, utility, strict, unchecked
-        // Also: this logic is wrong if both are None
-        self.depends_on = Some(
-            self.depends_on
-                .unwrap_or_default()
-                .into_iter()
-                .chain(other.depends_on.unwrap_or_default().into_iter())
-                .collect(),
-        );
-
-        Ok(self)
+    pub fn overwriteable_by(&self, other: &Self) -> bool {
+        // a module is overwriteable by another if
+        // - they have the same path
+        // - this module's origin is a glob and is not the same as the other module's origin
+        self.path == other.path
+            && self
+                .origin
+                .as_ref()
+                .is_some_and(|origin| Some(origin) != other.origin.as_ref())
     }
 
     pub fn new_with_layer(path: &str, layer: &str) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ impl From<parsing::error::ParsingError> for PyErr {
             parsing::error::ParsingError::TomlParse(err) => PyValueError::new_err(err.to_string()),
             parsing::error::ParsingError::MissingField(err) => PyValueError::new_err(err),
             parsing::error::ParsingError::ModulePath(err) => PyValueError::new_err(err),
+            parsing::error::ParsingError::PathExclusion(err) => err.into(),
         }
     }
 }

--- a/src/modules/build.rs
+++ b/src/modules/build.rs
@@ -13,16 +13,16 @@ use super::{
     ModuleResolver, ModuleTree, ModuleTreeError,
 };
 
-pub struct ModuleTreeBuilder {
-    resolver: ModuleResolver,
+pub struct ModuleTreeBuilder<'a> {
+    resolver: ModuleResolver<'a>,
     forbid_circular_dependencies: bool,
     root_module_treatment: RootModuleTreatment,
 }
 
-impl ModuleTreeBuilder {
+impl<'a> ModuleTreeBuilder<'a> {
     pub fn new(
-        source_roots: &[PathBuf],
-        exclusions: &PathExclusions,
+        source_roots: &'a [PathBuf],
+        exclusions: &'a PathExclusions,
         forbid_circular_dependencies: bool,
         root_module_treatment: RootModuleTreatment,
     ) -> Self {
@@ -33,7 +33,7 @@ impl ModuleTreeBuilder {
         }
     }
 
-    pub fn resolve_modules<'a, T: IntoIterator<Item = &'a ModuleConfig>>(
+    pub fn resolve_modules<'b, T: IntoIterator<Item = &'b ModuleConfig>>(
         &self,
         modules: T,
     ) -> (Vec<ModuleConfig>, Vec<ModuleConfig>) {

--- a/src/modules/build.rs
+++ b/src/modules/build.rs
@@ -41,12 +41,15 @@ impl ModuleTreeBuilder {
         let mut unresolved_modules = Vec::new();
 
         for module in modules {
-            if let Ok(resolved_paths) = self.resolver.resolve_module_path(&module.mod_path()) {
-                resolved_modules.extend(
-                    resolved_paths
-                        .into_iter()
-                        .map(|path| module.clone_with_path(&path)),
-                );
+            let mod_path = module.mod_path();
+            if let Ok(resolved_paths) = self.resolver.resolve_module_path(&mod_path) {
+                resolved_modules.extend(resolved_paths.into_iter().map(|path| {
+                    if self.resolver.is_module_path_glob(&mod_path) {
+                        module.clone_with_path(&path).with_glob_origin(&mod_path)
+                    } else {
+                        module.clone_with_path(&path)
+                    }
+                }));
             } else {
                 unresolved_modules.push(module.clone());
             }

--- a/src/modules/resolve.rs
+++ b/src/modules/resolve.rs
@@ -1,5 +1,6 @@
 use globset::{Error as GlobError, GlobBuilder, GlobMatcher};
-use std::path::{Path, PathBuf};
+use rayon::prelude::*;
+use std::path::PathBuf;
 
 use crate::{config::root_module::ROOT_MODULE_SENTINEL_TAG, exclusion::PathExclusions, filesystem};
 
@@ -53,17 +54,21 @@ impl ModuleGlob {
             })
             .collect::<Vec<_>>()
             .join("/");
+
         if pattern.ends_with("/**") {
             // We want this to match both the module itself and any submodules,
             //   which means we need to make the trailing slash optional.
             pattern = pattern[..pattern.len() - 3].to_string();
-            // NOTE: Using 'pattern{,/**}' does not work due to a bug in globset
-            //   so we instead use '{pattern,pattern/**}'
-            pattern = format!("{{{},{}/**}}", &pattern, &pattern);
+            pattern = format!("{}{{,/**}}", &pattern);
         }
+
+        // Add allowed file extensions to the pattern
+        pattern = format!("{}{{,.py,.pyi}}", pattern);
+
         let mut glob_builder = GlobBuilder::new(&pattern);
         let matcher = glob_builder
             .literal_separator(true)
+            .empty_alternates(true)
             .build()?
             .compile_matcher();
         Ok(matcher)
@@ -79,43 +84,25 @@ pub enum ModuleResolverError {
 }
 
 #[derive(Debug)]
-pub struct ModuleResolver {
-    modules: Vec<PathBuf>,
+pub struct ModuleResolver<'a> {
+    source_roots: &'a [PathBuf],
+    exclusions: &'a PathExclusions,
 }
 
-impl ModuleResolver {
-    fn collect_modules<P: AsRef<Path>>(
-        source_roots: &[P],
-        exclusions: &PathExclusions,
-    ) -> Vec<PathBuf> {
-        let mut modules = Vec::new();
-        for root in source_roots {
-            modules.extend(filesystem::walk_pymodules(
-                root.as_ref().to_str().unwrap(),
-                exclusions,
-            ));
-        }
-        modules
-    }
-
-    pub fn new<P: AsRef<Path>>(source_roots: &[P], exclusions: &PathExclusions) -> Self {
+impl<'a> ModuleResolver<'a> {
+    pub fn new(source_roots: &'a [PathBuf], exclusions: &'a PathExclusions) -> Self {
         Self {
-            modules: Self::collect_modules(source_roots, exclusions),
+            source_roots,
+            exclusions,
         }
-    }
-
-    pub fn validate_module_path_literal(&self, path: &str) -> bool {
-        self.modules.iter().any(|m| {
-            m.with_extension("")
-                .display()
-                .to_string()
-                .replace(std::path::MAIN_SEPARATOR, ".")
-                == path
-        })
     }
 
     pub fn is_module_path_glob(&self, path: &str) -> bool {
         ModuleGlob::parse(path).is_some()
+    }
+
+    fn validate_module_path_literal(&self, path: &str) -> bool {
+        filesystem::module_to_pyfile_or_dir_path(self.source_roots, path).is_some()
     }
 
     pub fn resolve_module_path(&self, path: &str) -> Result<Vec<String>, ModuleResolverError> {
@@ -139,14 +126,18 @@ impl ModuleResolver {
 
         let matcher = glob.into_matcher()?;
         Ok(self
-            .modules
-            .iter()
-            .map(|m| m.with_extension(""))
-            .filter(|m| matcher.is_match(m))
-            .map(|m| {
-                m.display()
-                    .to_string()
-                    .replace(std::path::MAIN_SEPARATOR, ".")
+            .source_roots
+            .par_iter()
+            .flat_map(|root| {
+                filesystem::walk_pymodules(root.as_os_str().to_str().unwrap(), self.exclusions)
+                    .par_bridge()
+                    .filter(|m| matcher.is_match(m))
+                    .map(|m| {
+                        m.with_extension("")
+                            .display()
+                            .to_string()
+                            .replace(std::path::MAIN_SEPARATOR, ".")
+                    })
             })
             .collect())
     }

--- a/src/modules/tree.rs
+++ b/src/modules/tree.rs
@@ -52,7 +52,11 @@ impl ModuleNode {
 
     pub fn fill(&mut self, config: ModuleConfig, full_path: String) {
         self.is_end_of_path = true;
-        self.config = Some(config);
+        if let Some(existing_config) = self.config.take() {
+            self.config = existing_config.merge(config).ok();
+        } else {
+            self.config = Some(config);
+        }
         self.full_path = full_path;
     }
 }

--- a/src/modules/tree.rs
+++ b/src/modules/tree.rs
@@ -193,7 +193,7 @@ mod tests {
 
     #[fixture]
     fn test_config() -> ModuleConfig {
-        ModuleConfig::new("test", false)
+        ModuleConfig::from_path("test")
     }
 
     #[rstest]

--- a/src/modules/tree.rs
+++ b/src/modules/tree.rs
@@ -50,14 +50,12 @@ impl ModuleNode {
         self.config.as_ref().is_some_and(|c| c.unchecked)
     }
 
-    pub fn fill(&mut self, config: ModuleConfig, full_path: String) {
+    pub fn fill(&mut self, config: ModuleConfig, full_path: String) -> bool {
+        let did_overwrite = self.is_end_of_path;
         self.is_end_of_path = true;
-        if let Some(existing_config) = self.config.take() {
-            self.config = existing_config.merge(config).ok();
-        } else {
-            self.config = Some(config);
-        }
+        self.config = Some(config);
         self.full_path = full_path;
+        did_overwrite
     }
 }
 
@@ -110,7 +108,7 @@ impl ModuleTree {
         }
     }
 
-    pub fn insert(&mut self, config: ModuleConfig, path: String) -> Result<(), ModuleTreeError> {
+    pub fn insert(&mut self, config: ModuleConfig, path: String) -> Result<bool, ModuleTreeError> {
         if path.is_empty() {
             return Err(ModuleTreeError::InsertNodeError);
         }
@@ -125,8 +123,8 @@ impl ModuleTree {
             .unwrap();
         }
 
-        node.fill(config, path);
-        Ok(())
+        let did_overwrite = node.fill(config, path);
+        Ok(did_overwrite)
     }
 
     pub fn find_nearest(&self, path: &str) -> Option<Arc<ModuleNode>> {

--- a/src/modules/validation.rs
+++ b/src/modules/validation.rs
@@ -15,7 +15,7 @@ pub fn find_duplicate_modules(modules: &[ModuleConfig]) -> Vec<&String> {
     for module in modules {
         match seen.get(module.path.as_str()) {
             Some(other_module) => {
-                if !module.can_merge_with(&other_module) {
+                if !other_module.overwriteable_by(module) {
                     duplicate_module_paths.push(&module.path);
                 }
             }

--- a/src/modules/validation.rs
+++ b/src/modules/validation.rs
@@ -10,13 +10,18 @@ use super::error::{ModuleTreeError, VisibilityErrorInfo};
 
 pub fn find_duplicate_modules(modules: &[ModuleConfig]) -> Vec<&String> {
     let mut duplicate_module_paths = Vec::new();
-    let mut seen = HashSet::new();
+    let mut seen: HashMap<&str, &ModuleConfig> = HashMap::new();
 
     for module in modules {
-        if seen.contains(&module.path) {
-            duplicate_module_paths.push(&module.path);
-        } else {
-            seen.insert(&module.path);
+        match seen.get(module.path.as_str()) {
+            Some(other_module) => {
+                if !module.can_merge_with(&other_module) {
+                    duplicate_module_paths.push(&module.path);
+                }
+            }
+            None => {
+                seen.insert(module.path.as_str(), module);
+            }
         }
     }
 

--- a/src/parsing/error.rs
+++ b/src/parsing/error.rs
@@ -1,6 +1,7 @@
 use std::io;
 use thiserror::Error;
 
+use crate::exclusion::PathExclusionError;
 use crate::filesystem::FileSystemError;
 
 #[derive(Error, Debug)]
@@ -15,4 +16,6 @@ pub enum ParsingError {
     MissingField(String),
     #[error("Module path error: {0}")]
     ModulePath(String),
+    #[error("Path exclusion error: {0}")]
+    PathExclusion(#[from] PathExclusionError),
 }

--- a/src/tests/module.rs
+++ b/src/tests/module.rs
@@ -18,13 +18,13 @@ pub mod fixtures {
                         Arc::new(ModuleNode {
                             is_end_of_path: true,
                             full_path: "domain_one".to_string(),
-                            config: Some(ModuleConfig::new("test", false)),
+                            config: Some(ModuleConfig::from_path("test")),
                             children: HashMap::from([(
                                 "subdomain".to_string(),
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "domain_one.subdomain".to_string(),
-                                    config: Some(ModuleConfig::new("test", false)),
+                                    config: Some(ModuleConfig::from_path("test")),
                                     children: HashMap::new(),
                                 }),
                             )]),
@@ -35,13 +35,13 @@ pub mod fixtures {
                         Arc::new(ModuleNode {
                             is_end_of_path: true,
                             full_path: "domain_two".to_string(),
-                            config: Some(ModuleConfig::new("test", false)),
+                            config: Some(ModuleConfig::from_path("test")),
                             children: HashMap::from([(
                                 "subdomain".to_string(),
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "domain_two.subdomain".to_string(),
-                                    config: Some(ModuleConfig::new("test", false)),
+                                    config: Some(ModuleConfig::from_path("test")),
                                     children: HashMap::new(),
                                 }),
                             )]),
@@ -52,7 +52,7 @@ pub mod fixtures {
                         Arc::new(ModuleNode {
                             is_end_of_path: true,
                             full_path: "domain_three".to_string(),
-                            config: Some(ModuleConfig::new("test", false)),
+                            config: Some(ModuleConfig::from_path("test")),
                             children: HashMap::new(),
                         }),
                     ),

--- a/src/tests/test.rs
+++ b/src/tests/test.rs
@@ -9,36 +9,30 @@ pub mod fixtures {
     #[fixture]
     pub fn modules() -> Vec<ModuleConfig> {
         vec![
-            ModuleConfig::new("tach", true),
-            ModuleConfig {
-                path: "tach.__main__".to_string(),
-                depends_on: Some(vec![DependencyConfig::from_path("tach.start")]),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.cache".to_string(),
-                depends_on: Some(
+            ModuleConfig::from_path("tach"),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.__main__",
+                Some(vec![DependencyConfig::from_path("tach.start")]),
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.cache",
+                Some(
                     ["tach", "tach.filesystem"]
                         .map(DependencyConfig::from_path)
                         .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.check".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.check",
+                Some(
                     ["tach.errors", "tach.filesystem", "tach.parsing"]
                         .map(DependencyConfig::from_path)
                         .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.cli".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.cli",
+                Some(
                     [
                         "tach",
                         "tach.cache",
@@ -59,21 +53,17 @@ pub mod fixtures {
                     .map(DependencyConfig::from_path)
                     .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig::new("tach.colors", true),
-            ModuleConfig::new("tach.constants", true),
-            ModuleConfig {
-                path: "tach.core".to_string(),
-                depends_on: Some(vec![DependencyConfig::from_path("tach.constants")]),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig::new("tach.errors", true),
-            ModuleConfig {
-                path: "tach.filesystem".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path("tach.colors"),
+            ModuleConfig::from_path("tach.constants"),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.core",
+                Some(vec![DependencyConfig::from_path("tach.constants")]),
+            ),
+            ModuleConfig::from_path("tach.errors"),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.filesystem",
+                Some(
                     [
                         "tach.colors",
                         "tach.constants",
@@ -84,44 +74,34 @@ pub mod fixtures {
                     .map(DependencyConfig::from_path)
                     .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.filesystem.git_ops".to_string(),
-                depends_on: Some(vec![DependencyConfig::from_path("tach.errors")]),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.hooks".to_string(),
-                depends_on: Some(vec![DependencyConfig::from_path("tach.constants")]),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.interactive".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.filesystem.git_ops",
+                Some(vec![DependencyConfig::from_path("tach.errors")]),
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.hooks",
+                Some(vec![DependencyConfig::from_path("tach.constants")]),
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.interactive",
+                Some(
                     ["tach.errors", "tach.filesystem"]
                         .map(DependencyConfig::from_path)
                         .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.logging".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.logging",
+                Some(
                     ["tach", "tach.cache", "tach.parsing"]
                         .map(DependencyConfig::from_path)
                         .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.mod".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.mod",
+                Some(
                     [
                         "tach.colors",
                         "tach.constants",
@@ -133,35 +113,27 @@ pub mod fixtures {
                     .map(DependencyConfig::from_path)
                     .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.parsing".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.parsing",
+                Some(
                     ["tach.constants", "tach.core", "tach.filesystem"]
                         .map(DependencyConfig::from_path)
                         .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.report".to_string(),
-                depends_on: Some(vec![DependencyConfig::from_path("tach.errors")]),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig::new("tach.show", true),
-            ModuleConfig {
-                path: "tach.start".to_string(),
-                depends_on: Some(vec![DependencyConfig::from_path("tach.cli")]),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.sync".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.report",
+                Some(vec![DependencyConfig::from_path("tach.errors")]),
+            ),
+            ModuleConfig::from_path("tach.show"),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.start",
+                Some(vec![DependencyConfig::from_path("tach.cli")]),
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.sync",
+                Some(
                     [
                         "tach.check",
                         "tach.errors",
@@ -171,12 +143,10 @@ pub mod fixtures {
                     .map(DependencyConfig::from_path)
                     .into(),
                 ),
-                strict: true,
-                ..Default::default()
-            },
-            ModuleConfig {
-                path: "tach.test".to_string(),
-                depends_on: Some(
+            ),
+            ModuleConfig::from_path_and_dependencies(
+                "tach.test",
+                Some(
                     [
                         "tach.errors",
                         "tach.filesystem",
@@ -186,9 +156,7 @@ pub mod fixtures {
                     .map(DependencyConfig::from_path)
                     .into(),
                 ),
-                strict: false,
-                ..Default::default()
-            },
+            ),
         ]
     }
 
@@ -204,21 +172,17 @@ pub mod fixtures {
                     Arc::new(ModuleNode {
                         is_end_of_path: true,
                         full_path: "tach".to_string(),
-                        config: Some(ModuleConfig::new("tach", true)),
+                        config: Some(ModuleConfig::from_path("tach")),
                         children: HashMap::from([
                             (
                                 "__main__".to_string(),
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.__main__".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.__main__".to_string(),
-                                        depends_on: Some(vec![DependencyConfig::from_path(
-                                            "tach.start",
-                                        )]),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.__main__",
+                                        Some(vec![DependencyConfig::from_path("tach.start")]),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -227,16 +191,14 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.cache".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.cache".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.cache",
+                                        Some(
                                             ["tach", "tach.filesystem"]
                                                 .map(DependencyConfig::from_path)
                                                 .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -245,16 +207,14 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.check".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.check".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.check",
+                                        Some(
                                             ["tach.errors", "tach.filesystem", "tach.parsing"]
                                                 .map(DependencyConfig::from_path)
                                                 .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -263,9 +223,9 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.cli".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.cli".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.cli",
+                                        Some(
                                             [
                                                 "tach",
                                                 "tach.cache",
@@ -286,9 +246,7 @@ pub mod fixtures {
                                             .map(DependencyConfig::from_path)
                                             .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -297,7 +255,7 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.colors".to_string(),
-                                    config: Some(ModuleConfig::new("tach.colors", true)),
+                                    config: Some(ModuleConfig::from_path("tach.colors")),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -306,7 +264,7 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.constants".to_string(),
-                                    config: Some(ModuleConfig::new("tach.constants", true)),
+                                    config: Some(ModuleConfig::from_path("tach.constants")),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -315,14 +273,10 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.core".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.core".to_string(),
-                                        depends_on: Some(vec![DependencyConfig::from_path(
-                                            "tach.constants",
-                                        )]),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.core",
+                                        Some(vec![DependencyConfig::from_path("tach.constants")]),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -331,7 +285,7 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.errors".to_string(),
-                                    config: Some(ModuleConfig::new("tach.errors", true)),
+                                    config: Some(ModuleConfig::from_path("tach.errors")),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -340,9 +294,9 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.filesystem".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.filesystem".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.filesystem",
+                                        Some(
                                             [
                                                 "tach.colors",
                                                 "tach.constants",
@@ -353,22 +307,18 @@ pub mod fixtures {
                                             .map(DependencyConfig::from_path)
                                             .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::from([(
                                         "git_ops".to_string(),
                                         Arc::new(ModuleNode {
                                             is_end_of_path: true,
                                             full_path: "tach.filesystem.git_ops".to_string(),
-                                            config: Some(ModuleConfig {
-                                                path: "tach.filesystem.git_ops".to_string(),
-                                                depends_on: Some(vec![
-                                                    DependencyConfig::from_path("tach.errors"),
-                                                ]),
-                                                strict: true,
-                                                ..Default::default()
-                                            }),
+                                            config: Some(ModuleConfig::from_path_and_dependencies(
+                                                "tach.filesystem.git_ops",
+                                                Some(vec![DependencyConfig::from_path(
+                                                    "tach.errors",
+                                                )]),
+                                            )),
                                             children: HashMap::new(),
                                         }),
                                     )]),
@@ -379,14 +329,10 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.hooks".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.hooks".to_string(),
-                                        depends_on: Some(vec![DependencyConfig::from_path(
-                                            "tach.constants",
-                                        )]),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.hooks",
+                                        Some(vec![DependencyConfig::from_path("tach.constants")]),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -395,16 +341,14 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.interactive".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.interactive".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.interactive",
+                                        Some(
                                             ["tach.errors", "tach.filesystem"]
                                                 .map(DependencyConfig::from_path)
                                                 .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -413,16 +357,14 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.logging".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.logging".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.logging",
+                                        Some(
                                             ["tach", "tach.cache", "tach.parsing"]
                                                 .map(DependencyConfig::from_path)
                                                 .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -431,9 +373,9 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.mod".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.mod".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.mod",
+                                        Some(
                                             [
                                                 "tach.colors",
                                                 "tach.constants",
@@ -445,9 +387,7 @@ pub mod fixtures {
                                             .map(DependencyConfig::from_path)
                                             .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -456,16 +396,14 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.parsing".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.parsing".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.parsing",
+                                        Some(
                                             ["tach.constants", "tach.core", "tach.filesystem"]
                                                 .map(DependencyConfig::from_path)
                                                 .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -474,14 +412,10 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.report".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.report".to_string(),
-                                        depends_on: Some(vec![DependencyConfig::from_path(
-                                            "tach.errors",
-                                        )]),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.report",
+                                        Some(vec![DependencyConfig::from_path("tach.errors")]),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -490,7 +424,7 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.show".to_string(),
-                                    config: Some(ModuleConfig::new("tach.show", true)),
+                                    config: Some(ModuleConfig::from_path("tach.show")),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -499,14 +433,10 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.start".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.start".to_string(),
-                                        depends_on: Some(vec![DependencyConfig::from_path(
-                                            "tach.cli",
-                                        )]),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.start",
+                                        Some(vec![DependencyConfig::from_path("tach.cli")]),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -515,9 +445,9 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.sync".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.sync".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.sync",
+                                        Some(
                                             [
                                                 "tach.check",
                                                 "tach.errors",
@@ -527,9 +457,7 @@ pub mod fixtures {
                                             .map(DependencyConfig::from_path)
                                             .into(),
                                         ),
-                                        strict: true,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),
@@ -538,9 +466,9 @@ pub mod fixtures {
                                 Arc::new(ModuleNode {
                                     is_end_of_path: true,
                                     full_path: "tach.test".to_string(),
-                                    config: Some(ModuleConfig {
-                                        path: "tach.test".to_string(),
-                                        depends_on: Some(
+                                    config: Some(ModuleConfig::from_path_and_dependencies(
+                                        "tach.test",
+                                        Some(
                                             [
                                                 "tach.errors",
                                                 "tach.filesystem",
@@ -550,9 +478,7 @@ pub mod fixtures {
                                             .map(DependencyConfig::from_path)
                                             .into(),
                                         ),
-                                        strict: false,
-                                        ..Default::default()
-                                    }),
+                                    )),
                                     children: HashMap::new(),
                                 }),
                             ),

--- a/tach.toml
+++ b/tach.toml
@@ -129,10 +129,6 @@ depends_on = [
 layer = "core"
 
 [[modules]]
-path = "tach.filesystem.**"
-depends_on = ["tach.filesystem.project"]
-
-[[modules]]
 path = "tach.start"
 depends_on = [
     "tach.cli",

--- a/tach.toml
+++ b/tach.toml
@@ -11,9 +11,7 @@ exclude = [
     "docs",
     "tach.egg-info",
 ]
-source_roots = [
-    "python",
-]
+source_roots = ["python"]
 exact = true
 forbid_circular_dependencies = true
 

--- a/tach.toml
+++ b/tach.toml
@@ -129,6 +129,10 @@ depends_on = [
 layer = "core"
 
 [[modules]]
+path = "tach.filesystem.**"
+depends_on = ["tach.filesystem.project"]
+
+[[modules]]
 path = "tach.start"
 depends_on = [
     "tach.cli",


### PR DESCRIPTION
This PR allows modules which were matched by a glob path to be overwritten by more specific configuration.

```toml
[[modules]]
path = "**"
depends_on = []

[[modules]]
path = "my.module"
depends_on = ["other_module"]
```

Above is a simple example of re-defining `my.module` even though it would have matched the global double wildcard. This PR also supports overwriting in a consistent way through [domain config files](https://docs.gauge.sh/usage/configuration#tach-domain-toml) -- domains can overwrite the root, and deeper domains overwrite parent domains. Note that the 'root' module in a domain cannot be overwritten if explicitly defined.