### PR TITLE
Performance fixes and polishing glob resolution

### DIFF
--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -257,7 +257,7 @@ def test_many_features_example_dir(example_dir, capfd):
     general_header = captured.err.index("General\n")
     interfaces_header = captured.err.index("Interfaces\n")
     dependencies_header = captured.err.index("Internal Dependencies\n")
-    unused_header = captured.err.index("Unused Dependencies\n")
+    unused_header = captured.err.index("Unused Dependencies")
 
     general_section = captured.err[general_header:interfaces_header]
     interfaces_section = captured.err[interfaces_header:dependencies_header]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ impl From<parsing::error::ParsingError> for PyErr {
             parsing::error::ParsingError::TomlParse(err) => PyValueError::new_err(err.to_string()),
             parsing::error::ParsingError::MissingField(err) => PyValueError::new_err(err),
             parsing::error::ParsingError::ModulePath(err) => PyValueError::new_err(err),
+            parsing::error::ParsingError::PathExclusion(err) => err.into(),
         }
     }
 }

--- a/src/modules/build.rs
+++ b/src/modules/build.rs
@@ -13,16 +13,16 @@ use super::{
     ModuleResolver, ModuleTree, ModuleTreeError,
 };
 
-pub struct ModuleTreeBuilder {
-    resolver: ModuleResolver,
+pub struct ModuleTreeBuilder<'a> {
+    resolver: ModuleResolver<'a>,
     forbid_circular_dependencies: bool,
     root_module_treatment: RootModuleTreatment,
 }
 
-impl ModuleTreeBuilder {
+impl<'a> ModuleTreeBuilder<'a> {
     pub fn new(
-        source_roots: &[PathBuf],
-        exclusions: &PathExclusions,
+        source_roots: &'a [PathBuf],
+        exclusions: &'a PathExclusions,
         forbid_circular_dependencies: bool,
         root_module_treatment: RootModuleTreatment,
     ) -> Self {
@@ -33,7 +33,7 @@ impl ModuleTreeBuilder {
         }
     }
 
-    pub fn resolve_modules<'a, T: IntoIterator<Item = &'a ModuleConfig>>(
+    pub fn resolve_modules<'b, T: IntoIterator<Item = &'b ModuleConfig>>(
         &self,
         modules: T,
     ) -> (Vec<ModuleConfig>, Vec<ModuleConfig>) {

--- a/src/modules/resolve.rs
+++ b/src/modules/resolve.rs
@@ -1,5 +1,6 @@
 use globset::{Error as GlobError, GlobBuilder, GlobMatcher};
-use std::path::{Path, PathBuf};
+use rayon::prelude::*;
+use std::path::PathBuf;
 
 use crate::{config::root_module::ROOT_MODULE_SENTINEL_TAG, exclusion::PathExclusions, filesystem};
 
@@ -53,17 +54,21 @@ impl ModuleGlob {
             })
             .collect::<Vec<_>>()
             .join("/");
+
         if pattern.ends_with("/**") {
             // We want this to match both the module itself and any submodules,
             //   which means we need to make the trailing slash optional.
             pattern = pattern[..pattern.len() - 3].to_string();
-            // NOTE: Using 'pattern{,/**}' does not work due to a bug in globset
-            //   so we instead use '{pattern,pattern/**}'
-            pattern = format!("{{{},{}/**}}", &pattern, &pattern);
+            pattern = format!("{}{{,/**}}", &pattern);
         }
+
+        // Add allowed file extensions to the pattern
+        pattern = format!("{}{{,.py,.pyi}}", pattern);
+
         let mut glob_builder = GlobBuilder::new(&pattern);
         let matcher = glob_builder
             .literal_separator(true)
+            .empty_alternates(true)
             .build()?
             .compile_matcher();
         Ok(matcher)
@@ -79,43 +84,25 @@ pub enum ModuleResolverError {
 }
 
 #[derive(Debug)]
-pub struct ModuleResolver {
-    modules: Vec<PathBuf>,
+pub struct ModuleResolver<'a> {
+    source_roots: &'a [PathBuf],
+    exclusions: &'a PathExclusions,
 }
 
-impl ModuleResolver {
-    fn collect_modules<P: AsRef<Path>>(
-        source_roots: &[P],
-        exclusions: &PathExclusions,
-    ) -> Vec<PathBuf> {
-        let mut modules = Vec::new();
-        for root in source_roots {
-            modules.extend(filesystem::walk_pymodules(
-                root.as_ref().to_str().unwrap(),
-                exclusions,
-            ));
-        }
-        modules
-    }
-
-    pub fn new<P: AsRef<Path>>(source_roots: &[P], exclusions: &PathExclusions) -> Self {
+impl<'a> ModuleResolver<'a> {
+    pub fn new(source_roots: &'a [PathBuf], exclusions: &'a PathExclusions) -> Self {
         Self {
-            modules: Self::collect_modules(source_roots, exclusions),
+            source_roots,
+            exclusions,
         }
-    }
-
-    pub fn validate_module_path_literal(&self, path: &str) -> bool {
-        self.modules.iter().any(|m| {
-            m.with_extension("")
-                .display()
-                .to_string()
-                .replace(std::path::MAIN_SEPARATOR, ".")
-                == path
-        })
     }
 
     pub fn is_module_path_glob(&self, path: &str) -> bool {
         ModuleGlob::parse(path).is_some()
+    }
+
+    fn validate_module_path_literal(&self, path: &str) -> bool {
+        filesystem::module_to_pyfile_or_dir_path(self.source_roots, path).is_some()
     }
 
     pub fn resolve_module_path(&self, path: &str) -> Result<Vec<String>, ModuleResolverError> {
@@ -139,14 +126,18 @@ impl ModuleResolver {
 
         let matcher = glob.into_matcher()?;
         Ok(self
-            .modules
-            .iter()
-            .map(|m| m.with_extension(""))
-            .filter(|m| matcher.is_match(m))
-            .map(|m| {
-                m.display()
-                    .to_string()
-                    .replace(std::path::MAIN_SEPARATOR, ".")
+            .source_roots
+            .par_iter()
+            .flat_map(|root| {
+                filesystem::walk_pymodules(root.as_os_str().to_str().unwrap(), self.exclusions)
+                    .par_bridge()
+                    .filter(|m| matcher.is_match(m))
+                    .map(|m| {
+                        m.with_extension("")
+                            .display()
+                            .to_string()
+                            .replace(std::path::MAIN_SEPARATOR, ".")
+                    })
             })
             .collect())
     }

--- a/src/parsing/error.rs
+++ b/src/parsing/error.rs
@@ -1,6 +1,7 @@
 use std::io;
 use thiserror::Error;
 
+use crate::exclusion::PathExclusionError;
 use crate::filesystem::FileSystemError;
 
 #[derive(Error, Debug)]
@@ -15,4 +16,6 @@ pub enum ParsingError {
     MissingField(String),
     #[error("Module path error: {0}")]
     ModulePath(String),
+    #[error("Path exclusion error: {0}")]
+    PathExclusion(#[from] PathExclusionError),
 }

--- a/tach.toml
+++ b/tach.toml
@@ -11,9 +11,7 @@ exclude = [
     "docs",
     "tach.egg-info",
 ]
-source_roots = [
-    "python",
-]
+source_roots = ["python"]
 exact = true
 forbid_circular_dependencies = true
 


### PR DESCRIPTION
Through profiling, I discovered that the `collect_modules` approach was disastrously slow on large codebases because it did a full linear scan to validate module path literals, instead of the previous direct check approach. Also, I used rayon to parallelize the full glob scan when it was actually needed.

Also, I discovered that the behavior I thought was a bug in globset was actually the `empty_alternates` option defaulting to `false` - so I've turned that on and used more intuitive patterns to let `.**` match the empty string at the end of a pattern and to avoid needing to use `with_extension("")` before checking matches (only after discovering matches do we need to slice off the extension).

This PR also removes the old hack of checking for `tach.toml` when looking for domain config files, opting instead to trust the exclude patterns in the project config. Profiling still shows this traversal is slow though, now due to the exclusion checks.