### PR TITLE
Stop `sync` from pruning globbed modules

### DIFF
--- a/python/tests/test_sync.py
+++ b/python/tests/test_sync.py
@@ -101,7 +101,8 @@ def test_many_features_example_dir(example_dir, capfd):
         assert project_config is not None
 
         modules = project_config.all_modules()
-        assert len(modules) == 12
+        # This should be the number of statically defined modules, before globbing
+        assert len(modules) == 14
 
         module2 = next(module for module in modules if module.path == "module2")
         assert set(map(lambda dep: dep.path, module2.depends_on)) == {"outer_module"}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -216,6 +216,8 @@ fn sync_dependency_constraints(
         project_config
             .module_paths()
             .iter()
+            // This is a hack to avoid pruning globbed modules
+            .filter(|path| !path.contains("*"))
             .for_each(|module_path| {
                 if !validate_module_path(
                     &project_config.absolute_source_roots().unwrap(),

--- a/tach.toml
+++ b/tach.toml
@@ -20,7 +20,7 @@ unused_ignore_directives = "error"
 require_ignore_directive_reasons = "error"
 
 [[modules]]
-path = "tach"
+path = "**"
 depends_on = []
 
 [[modules]]


### PR DESCRIPTION
In the current state, modules with globbed paths should be ignored by `tach sync`. They can be thought of as templates, which should be allowed even if they currently don't match anything, and should be allowed to 'over-provision' or 'under-declare' dependencies for the concrete modules they match.

However, `tach sync` is still expected to handle globbed dependencies in `depends_on`, and this PR does not touch that behavior.