### PR TITLE
Allow arbitrary glob patterns in module path segments

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -8,6 +8,7 @@ use crate::config::root_module::{RootModuleTreatment, ROOT_MODULE_SENTINEL_TAG};
 use crate::config::{DependencyConfig, ProjectConfig};
 use crate::diagnostics::Diagnostic;
 use crate::filesystem::validate_module_path;
+use crate::modules::resolve::has_glob_syntax;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -94,8 +95,7 @@ pub fn detect_unused_dependencies(
     for module_path in project_config
         .module_paths()
         .into_iter()
-        // This is a hack to avoid checking globbed modules for unused dependencies
-        .filter(|path| !path.contains("*"))
+        .filter(|path| !has_glob_syntax(path))
     {
         let module_detected_dependencies =
             detected_dependencies
@@ -164,8 +164,7 @@ fn sync_dependency_constraints(
     for module_path in project_config
         .module_paths()
         .into_iter()
-        // This is a hack to avoid attempting to sync globbed modules
-        .filter(|path| !path.contains("*"))
+        .filter(|path| !has_glob_syntax(path))
     {
         let module_detected_dependencies =
             detected_dependencies
@@ -216,8 +215,7 @@ fn sync_dependency_constraints(
         project_config
             .module_paths()
             .iter()
-            // This is a hack to avoid pruning globbed modules
-            .filter(|path| !path.contains("*"))
+            .filter(|path| !has_glob_syntax(path))
             .for_each(|module_path| {
                 if !validate_module_path(
                     &project_config.absolute_source_roots().unwrap(),

--- a/src/modules/build.rs
+++ b/src/modules/build.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::{
+    resolve::has_glob_syntax,
     validation::{
         find_duplicate_modules, find_modules_with_cycles, find_visibility_violations,
         validate_root_module_treatment,
@@ -44,7 +45,7 @@ impl<'a> ModuleTreeBuilder<'a> {
             let mod_path = module.mod_path();
             if let Ok(resolved_paths) = self.resolver.resolve_module_path(&mod_path) {
                 resolved_modules.extend(resolved_paths.into_iter().map(|path| {
-                    if self.resolver.is_module_path_glob(&mod_path) {
+                    if has_glob_syntax(&mod_path) {
                         module.clone_with_path(&path).with_glob_origin(&mod_path)
                     } else {
                         module.clone_with_path(&path)

--- a/src/modules/resolve.rs
+++ b/src/modules/resolve.rs
@@ -6,7 +6,7 @@ use crate::{config::root_module::ROOT_MODULE_SENTINEL_TAG, exclusion::PathExclus
 
 #[derive(Debug)]
 enum ModuleGlobSegment {
-    Literal(String),
+    Pattern(String),
     Wildcard,
     DoubleWildcard,
 }
@@ -28,17 +28,9 @@ impl ModuleGlob {
             .map(|s| match s {
                 "*" => ModuleGlobSegment::Wildcard,
                 "**" => ModuleGlobSegment::DoubleWildcard,
-                _ => ModuleGlobSegment::Literal(s.to_string()),
+                _ => ModuleGlobSegment::Pattern(s.to_string()),
             })
             .collect();
-
-        if segments
-            .iter()
-            .all(|s| matches!(s, ModuleGlobSegment::Literal(_)))
-        {
-            // No wildcard segments, not a glob
-            return None;
-        }
 
         Some(Self { segments })
     }
@@ -48,7 +40,7 @@ impl ModuleGlob {
             .segments
             .iter()
             .map(|s| match s {
-                ModuleGlobSegment::Literal(s) => globset::escape(s),
+                ModuleGlobSegment::Pattern(s) => s.to_owned(),
                 ModuleGlobSegment::Wildcard => "*".to_string(),
                 ModuleGlobSegment::DoubleWildcard => "**".to_string(),
             })

--- a/src/modules/resolve.rs
+++ b/src/modules/resolve.rs
@@ -1,51 +1,40 @@
 use globset::{Error as GlobError, GlobBuilder, GlobMatcher};
+use itertools::Itertools;
 use rayon::prelude::*;
 use std::path::PathBuf;
 
 use crate::{config::root_module::ROOT_MODULE_SENTINEL_TAG, exclusion::PathExclusions, filesystem};
 
-#[derive(Debug)]
-enum ModuleGlobSegment {
-    Pattern(String),
-    Wildcard,
-    DoubleWildcard,
+pub fn has_glob_syntax(pattern: &str) -> bool {
+    pattern.chars().enumerate().any(|(i, c)| {
+        match c {
+            '*' | '?' | '[' | ']' | '{' | '}' => {
+                // Check if the character is escaped
+                i == 0 || pattern.as_bytes()[i - 1] != b'\\'
+            }
+            _ => false,
+        }
+    })
 }
 
 #[derive(Debug)]
 pub struct ModuleGlob {
-    segments: Vec<ModuleGlobSegment>,
+    segments: Vec<String>,
 }
 
 impl ModuleGlob {
     pub fn parse(pattern: &str) -> Option<Self> {
-        if !pattern.contains('*') {
-            // No wildcards, not a glob
+        if !has_glob_syntax(pattern) {
             return None;
         }
 
-        let segments: Vec<ModuleGlobSegment> = pattern
-            .split('.')
-            .map(|s| match s {
-                "*" => ModuleGlobSegment::Wildcard,
-                "**" => ModuleGlobSegment::DoubleWildcard,
-                _ => ModuleGlobSegment::Pattern(s.to_string()),
-            })
-            .collect();
-
-        Some(Self { segments })
+        Some(Self {
+            segments: pattern.split('.').map(|s| s.to_string()).collect(),
+        })
     }
 
     pub fn into_matcher(self) -> Result<GlobMatcher, GlobError> {
-        let mut pattern = self
-            .segments
-            .iter()
-            .map(|s| match s {
-                ModuleGlobSegment::Pattern(s) => s.to_owned(),
-                ModuleGlobSegment::Wildcard => "*".to_string(),
-                ModuleGlobSegment::DoubleWildcard => "**".to_string(),
-            })
-            .collect::<Vec<_>>()
-            .join("/");
+        let mut pattern = self.segments.iter().join("/");
 
         if pattern.ends_with("/**") {
             // We want this to match both the module itself and any submodules,
@@ -87,10 +76,6 @@ impl<'a> ModuleResolver<'a> {
             source_roots,
             exclusions,
         }
-    }
-
-    pub fn is_module_path_glob(&self, path: &str) -> bool {
-        ModuleGlob::parse(path).is_some()
     }
 
     fn validate_module_path_literal(&self, path: &str) -> bool {


### PR DESCRIPTION
Before this PR, module path globs were not able to use glob functionality like wildcards, alternations, or optionals within a path segment. This was an artificial restriction that is not relevant to the final implementation. This PR removes the restriction by substituting each segment as-is into the glob pattern.

Additionally, it is now insufficient to check for a `'*'` character to identify globbed module paths, since other syntax may be used without a wildcard. This PR replaces that check with `has_glob_syntax`, which does not verify the pattern compiles, but at least that it uses unescaped special glob characters.