### PR TITLE
Fix error when pyproject.toml found but has not Tach config

### DIFF
--- a/python/tach/parsing/config.py
+++ b/python/tach/parsing/config.py
@@ -94,7 +94,12 @@ def parse_project_config(
             )
         return project_config
     elif (root / "pyproject.toml").exists():
-        return extension.parse_project_config_from_pyproject(root / "pyproject.toml")
+        try:
+            return extension.parse_project_config_from_pyproject(
+                root / "pyproject.toml"
+            )
+        except Exception:
+            return None
     else:
         # No TOML found, check for deprecated (YAML) config as a fallback
         file_path = fs.get_deprecated_project_config_path(root)


### PR DESCRIPTION
Follow-on fix for #638 

On a fresh project, a `pyproject.toml` is very likely to be detected, but we incorrectly assume that this means we can parse it for Tach config. This causes a failure if the `tool.tach` table is not found.

This simply returns None when parsing fails in this case.