### PR TITLE
Support globs in `source_roots`

### DIFF
--- a/python/tests/example/monorepo_workspace/pyproject.toml
+++ b/python/tests/example/monorepo_workspace/pyproject.toml
@@ -13,4 +13,4 @@ members = ["packages/*"]
 
 
 [tool.tach]
-source_roots = ["src", "packages/package1/src", "packages/package2/src"]
+source_roots = ["**/src"]

--- a/src/commands/check/check_external.rs
+++ b/src/commands/check/check_external.rs
@@ -11,7 +11,7 @@ use crate::filesystem::{walk_pyfiles, ProjectFile};
 use crate::interrupt::check_interrupt;
 use crate::processors::file_module::FileModule;
 use crate::processors::ExternalDependencyExtractor;
-use crate::resolvers::PackageResolver;
+use crate::resolvers::{PackageResolver, SourceRootResolver};
 use pyo3::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -187,12 +187,13 @@ fn check_with_modules(
     let stdlib_modules: HashSet<String> = stdlib_modules.iter().cloned().collect();
     let excluded_external_modules: HashSet<String> =
         project_config.external.exclude.iter().cloned().collect();
-    let source_roots: Vec<PathBuf> = project_config.resolve_source_roots(project_root);
     let exclusions = PathExclusions::new(
         project_root,
         &project_config.exclude,
         project_config.use_regex_matching,
     )?;
+    let source_root_resolver = SourceRootResolver::new(project_root, &exclusions);
+    let source_roots: Vec<PathBuf> = source_root_resolver.resolve(&project_config.source_roots)?;
     let package_resolver = PackageResolver::try_new(project_root, &source_roots, &exclusions)?;
 
     let pipeline = CheckExternalPipeline::new(

--- a/src/commands/check/check_external.rs
+++ b/src/commands/check/check_external.rs
@@ -187,7 +187,7 @@ fn check_with_modules(
     let stdlib_modules: HashSet<String> = stdlib_modules.iter().cloned().collect();
     let excluded_external_modules: HashSet<String> =
         project_config.external.exclude.iter().cloned().collect();
-    let source_roots: Vec<PathBuf> = project_config.prepend_roots(project_root);
+    let source_roots: Vec<PathBuf> = project_config.resolve_source_roots(project_root);
     let exclusions = PathExclusions::new(
         project_root,
         &project_config.exclude,

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -135,13 +135,13 @@ pub fn check(
     let mut diagnostics = Vec::new();
     let found_imports = AtomicBool::new(false);
     let exclusions = PathExclusions::new(
-        &project_root,
+        project_root,
         &project_config.exclude,
         project_config.use_regex_matching,
     )?;
-    let source_root_resolver = SourceRootResolver::new(&project_root, &exclusions);
+    let source_root_resolver = SourceRootResolver::new(project_root, &exclusions);
     let source_roots = source_root_resolver.resolve(&project_config.source_roots)?;
-    let package_resolver = PackageResolver::try_new(&project_root, &source_roots, &exclusions)?;
+    let package_resolver = PackageResolver::try_new(project_root, &source_roots, &exclusions)?;
     let module_tree_builder = ModuleTreeBuilder::new(
         &source_roots,
         &exclusions,
@@ -198,19 +198,19 @@ pub fn check(
                     return vec![];
                 }
 
-                let project_file =
-                    match ProjectFile::try_new(&project_root, source_root, &file_path) {
-                        Ok(project_file) => project_file,
-                        Err(_) => {
-                            return vec![Diagnostic::new_global_warning(
-                                DiagnosticDetails::Configuration(
-                                    ConfigurationDiagnostic::SkippedFileIoError {
-                                        file_path: file_path.display().to_string(),
-                                    },
-                                ),
-                            )]
-                        }
-                    };
+                let project_file = match ProjectFile::try_new(project_root, source_root, &file_path)
+                {
+                    Ok(project_file) => project_file,
+                    Err(_) => {
+                        return vec![Diagnostic::new_global_warning(
+                            DiagnosticDetails::Configuration(
+                                ConfigurationDiagnostic::SkippedFileIoError {
+                                    file_path: file_path.display().to_string(),
+                                },
+                            ),
+                        )]
+                    }
+                };
 
                 match pipeline.diagnostics(project_file) {
                     Ok(diagnostics) => diagnostics,

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -134,7 +134,7 @@ pub fn check(
 
     let mut diagnostics = Vec::new();
     let found_imports = AtomicBool::new(false);
-    let source_roots: Vec<PathBuf> = project_config.prepend_roots(&project_root);
+    let source_roots: Vec<PathBuf> = project_config.resolve_source_roots(&project_root);
     let exclusions = PathExclusions::new(
         &project_root,
         &project_config.exclude,

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -117,7 +117,7 @@ impl<'a> FileChecker<'a> for CheckInternalPipeline<'a> {
 }
 
 pub fn check(
-    project_root: PathBuf,
+    project_root: &PathBuf,
     project_config: &ProjectConfig,
     dependencies: bool,
     interfaces: bool,

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -18,7 +18,7 @@ use crate::{
     interrupt::check_interrupt,
     modules::{ModuleTree, ModuleTreeBuilder},
     processors::{FileModule, InternalDependencyExtractor},
-    resolvers::PackageResolver,
+    resolvers::{PackageResolver, SourceRootResolver},
 };
 
 pub type Result<T> = std::result::Result<T, CheckError>;
@@ -134,12 +134,13 @@ pub fn check(
 
     let mut diagnostics = Vec::new();
     let found_imports = AtomicBool::new(false);
-    let source_roots: Vec<PathBuf> = project_config.resolve_source_roots(&project_root);
     let exclusions = PathExclusions::new(
         &project_root,
         &project_config.exclude,
         project_config.use_regex_matching,
     )?;
+    let source_root_resolver = SourceRootResolver::new(&project_root, &exclusions);
+    let source_roots = source_root_resolver.resolve(&project_config.source_roots)?;
     let package_resolver = PackageResolver::try_new(&project_root, &source_roots, &exclusions)?;
     let module_tree_builder = ModuleTreeBuilder::new(
         &source_roots,

--- a/src/commands/check/error.rs
+++ b/src/commands/check/error.rs
@@ -29,4 +29,6 @@ pub enum CheckError {
     Configuration(String),
     #[error("Package resolution error: {0}")]
     PackageResolution(#[from] resolvers::PackageResolutionError),
+    #[error("Source root resolution error: {0}")]
+    SourceRootResolution(#[from] resolvers::SourceRootResolverError),
 }

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -224,7 +224,7 @@ pub fn create_dependency_report(
         return Err(ReportCreationError::NothingToReport);
     }
 
-    let source_roots = project_config.prepend_roots(project_root);
+    let source_roots = project_config.resolve_source_roots(project_root);
     let exclusions = PathExclusions::new(
         project_root,
         &project_config.exclude,

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -18,6 +18,7 @@ use crate::filesystem::{file_to_module_path, walk_pyfiles, FileSystemError};
 use crate::interrupt::check_interrupt;
 use crate::modules::{ModuleTreeBuilder, ModuleTreeError};
 use crate::processors::import::ImportParseError;
+use crate::resolvers::{SourceRootResolver, SourceRootResolverError};
 
 use super::helpers::import::get_located_project_imports;
 
@@ -45,6 +46,8 @@ pub enum ReportCreationError {
     Interrupted,
     #[error("Failed to build exclusion patterns: {0}")]
     PathExclusion(#[from] PathExclusionError),
+    #[error("Failed to resolve source roots: {0}")]
+    SourceRootResolver(#[from] SourceRootResolverError),
 }
 
 pub type Result<T> = std::result::Result<T, ReportCreationError>;
@@ -224,12 +227,13 @@ pub fn create_dependency_report(
         return Err(ReportCreationError::NothingToReport);
     }
 
-    let source_roots = project_config.resolve_source_roots(project_root);
     let exclusions = PathExclusions::new(
         project_root,
         &project_config.exclude,
         project_config.use_regex_matching,
     )?;
+    let source_root_resolver = SourceRootResolver::new(project_root, &exclusions);
+    let source_roots = source_root_resolver.resolve(&project_config.source_roots)?;
     let module_tree_builder = ModuleTreeBuilder::new(
         &source_roots,
         &exclusions,

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -7,8 +7,9 @@ use crate::config::edit::{ConfigEditor, EditError};
 use crate::config::root_module::{RootModuleTreatment, ROOT_MODULE_SENTINEL_TAG};
 use crate::config::{DependencyConfig, ProjectConfig};
 use crate::diagnostics::Diagnostic;
+use crate::exclusion::{PathExclusionError, PathExclusions};
 use crate::filesystem::validate_module_path;
-use crate::resolvers::glob;
+use crate::resolvers::{glob, SourceRootResolver, SourceRootResolverError};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -24,6 +25,10 @@ pub enum SyncError {
     RootModuleViolation(String),
     #[error("Failed to apply edits to project configuration.\n{0}")]
     EditError(#[from] EditError),
+    #[error("Failed to handle excluded paths.\n{0}")]
+    PathExclusion(#[from] PathExclusionError),
+    #[error("Failed to resolve source roots.\n{0}")]
+    SourceRootResolution(#[from] SourceRootResolverError),
 }
 
 fn handle_added_dependency(
@@ -88,7 +93,7 @@ pub fn detect_unused_dependencies(
     // This is a shortcut to finding all cross-module dependencies
     // TODO: dedicated function
     let cleared_project_config = project_config.with_dependencies_removed();
-    let check_result = check_internal(project_root, &cleared_project_config, true, false)?;
+    let check_result = check_internal(&project_root, &cleared_project_config, true, false)?;
     let detected_dependencies = detect_dependencies(&check_result);
 
     let mut unused_dependencies: Vec<UnusedDependencies> = vec![];
@@ -141,7 +146,7 @@ fn sync_dependency_constraints(
     // This is a shortcut to finding all cross-module dependencies
     // TODO: dedicated function
     let cleared_project_config = project_config.with_dependencies_removed();
-    let check_result = check_internal(project_root, &cleared_project_config, true, false)?;
+    let check_result = check_internal(&project_root, &cleared_project_config, true, false)?;
     let detected_dependencies = detect_dependencies(&check_result);
 
     // Root module is a special case -- it may not be in module paths and still implicitly detect dependencies
@@ -212,15 +217,19 @@ fn sync_dependency_constraints(
     }
 
     if prune {
+        let exclusions = PathExclusions::new(
+            &project_root,
+            &project_config.exclude,
+            project_config.use_regex_matching,
+        )?;
+        let source_root_resolver = SourceRootResolver::new(&project_root, &exclusions);
+        let source_roots = source_root_resolver.resolve(&project_config.source_roots)?;
         project_config
             .module_paths()
             .iter()
             .filter(|path| !glob::has_glob_syntax(path))
             .for_each(|module_path| {
-                if !validate_module_path(
-                    &project_config.absolute_source_roots().unwrap(),
-                    module_path,
-                ) {
+                if !validate_module_path(&source_roots, module_path) {
                     // Not clear what to do if enqueueing deletion fails
                     let _ = project_config.delete_module(module_path.to_string());
                 }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -8,7 +8,7 @@ use crate::config::root_module::{RootModuleTreatment, ROOT_MODULE_SENTINEL_TAG};
 use crate::config::{DependencyConfig, ProjectConfig};
 use crate::diagnostics::Diagnostic;
 use crate::filesystem::validate_module_path;
-use crate::modules::resolve::has_glob_syntax;
+use crate::resolvers::glob;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
@@ -95,7 +95,7 @@ pub fn detect_unused_dependencies(
     for module_path in project_config
         .module_paths()
         .into_iter()
-        .filter(|path| !has_glob_syntax(path))
+        .filter(|path| !glob::has_glob_syntax(path))
     {
         let module_detected_dependencies =
             detected_dependencies
@@ -164,7 +164,7 @@ fn sync_dependency_constraints(
     for module_path in project_config
         .module_paths()
         .into_iter()
-        .filter(|path| !has_glob_syntax(path))
+        .filter(|path| !glob::has_glob_syntax(path))
     {
         let module_detected_dependencies =
             detected_dependencies
@@ -215,7 +215,7 @@ fn sync_dependency_constraints(
         project_config
             .module_paths()
             .iter()
-            .filter(|path| !has_glob_syntax(path))
+            .filter(|path| !glob::has_glob_syntax(path))
             .for_each(|module_path| {
                 if !validate_module_path(
                     &project_config.absolute_source_roots().unwrap(),

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -1,14 +1,14 @@
 use std::collections::HashSet;
-use std::path::Path;
 use std::{collections::HashMap, path::PathBuf};
 
 use pyo3::{pyclass, pymethods};
 use thiserror::Error;
 
 use crate::config::{ModuleConfig, ProjectConfig};
-use crate::exclusion::PathExclusions;
+use crate::exclusion::{PathExclusionError, PathExclusions};
 use crate::filesystem::{self as fs};
 use crate::modules::{ModuleTree, ModuleTreeBuilder};
+use crate::resolvers::{SourceRootResolver, SourceRootResolverError};
 
 use super::helpers::import::get_located_project_imports;
 
@@ -18,6 +18,10 @@ pub enum TestError {
     Filesystem(#[from] fs::FileSystemError),
     #[error("Could not find module containing path: {0}")]
     ModuleNotFound(String),
+    #[error("Path exclusion error: {0}")]
+    PathExclusion(#[from] PathExclusionError),
+    #[error("Source root resolution error: {0}")]
+    SourceRootResolution(#[from] SourceRootResolverError),
 }
 
 pub type Result<T> = std::result::Result<T, TestError>;
@@ -48,7 +52,6 @@ impl TachPytestPluginHandler {
         changed_files: Vec<PathBuf>,
         all_affected_modules: HashSet<PathBuf>,
     ) -> Self {
-        let source_roots = project_config.resolve_source_roots(&project_root);
         // TODO: Remove unwraps
         let exclusions = PathExclusions::new(
             &project_root,
@@ -56,6 +59,10 @@ impl TachPytestPluginHandler {
             project_config.use_regex_matching,
         )
         .unwrap();
+        let source_root_resolver = SourceRootResolver::new(&project_root, &exclusions);
+        let source_roots = source_root_resolver
+            .resolve(&project_config.source_roots)
+            .unwrap();
         let module_tree_builder = ModuleTreeBuilder::new(
             &source_roots,
             &exclusions,
@@ -134,11 +141,17 @@ fn build_module_consumer_map(modules: &Vec<ModuleConfig>) -> HashMap<&String, Ve
 }
 
 fn get_changed_module_paths(
-    project_root: &Path,
+    project_root: &PathBuf,
     project_config: &ProjectConfig,
     changed_files: Vec<PathBuf>,
 ) -> Result<Vec<String>> {
-    let source_roots: Vec<PathBuf> = project_config.resolve_source_roots(project_root);
+    let exclusions = PathExclusions::new(
+        project_root,
+        &project_config.exclude,
+        project_config.use_regex_matching,
+    )?;
+    let source_root_resolver = SourceRootResolver::new(project_root, &exclusions);
+    let source_roots: Vec<PathBuf> = source_root_resolver.resolve(&project_config.source_roots)?;
 
     let changed_module_paths = changed_files
         .into_iter()
@@ -173,7 +186,7 @@ fn find_affected_modules(
 }
 
 pub fn get_affected_modules(
-    project_root: &Path,
+    project_root: &PathBuf,
     project_config: &ProjectConfig,
     changed_files: Vec<PathBuf>,
     module_tree: &ModuleTree,

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -48,7 +48,7 @@ impl TachPytestPluginHandler {
         changed_files: Vec<PathBuf>,
         all_affected_modules: HashSet<PathBuf>,
     ) -> Self {
-        let source_roots = project_config.prepend_roots(&project_root);
+        let source_roots = project_config.resolve_source_roots(&project_root);
         // TODO: Remove unwraps
         let exclusions = PathExclusions::new(
             &project_root,
@@ -138,7 +138,7 @@ fn get_changed_module_paths(
     project_config: &ProjectConfig,
     changed_files: Vec<PathBuf>,
 ) -> Result<Vec<String>> {
-    let source_roots: Vec<PathBuf> = project_config.prepend_roots(project_root);
+    let source_roots: Vec<PathBuf> = project_config.resolve_source_roots(project_root);
 
     let changed_module_paths = changed_files
         .into_iter()

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -1,7 +1,14 @@
 use thiserror::Error;
 
+use crate::exclusion::PathExclusionError;
+use crate::resolvers::SourceRootResolverError;
+
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("Config file does not exist")]
     ConfigDoesNotExist,
+    #[error("Failed to handle excluded paths.\n{0}")]
+    PathExclusion(#[from] PathExclusionError),
+    #[error("Failed to resolve source roots.\n{0}")]
+    SourceRootResolution(#[from] SourceRootResolverError),
 }

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -2,7 +2,7 @@ use crate::filesystem::module_path_is_included_in_paths;
 
 use super::root_module::ROOT_MODULE_SENTINEL_TAG;
 use super::utils::*;
-use crate::modules::ModuleGlob;
+use crate::resolvers::ModuleGlob;
 use globset::GlobMatcher;
 use pyo3::prelude::*;
 use serde::ser::{Error, SerializeSeq, SerializeStruct};

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -171,20 +171,6 @@ impl ProjectConfig {
             .collect())
     }
 
-    pub fn resolve_source_roots(&self, project_root: &Path) -> Vec<PathBuf> {
-        // don't prepend if root is "."
-        self.source_roots
-            .iter()
-            .map(|root| {
-                if root.display().to_string() == "." {
-                    project_root.to_path_buf()
-                } else {
-                    project_root.join(root)
-                }
-            })
-            .collect()
-    }
-
     pub fn with_dependencies_removed(&self) -> Self {
         Self {
             modules: self

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -171,8 +171,7 @@ impl ProjectConfig {
             .collect())
     }
 
-    // TODO: use absolute_source_roots
-    pub fn prepend_roots(&self, project_root: &Path) -> Vec<PathBuf> {
+    pub fn resolve_source_roots(&self, project_root: &Path) -> Vec<PathBuf> {
         // don't prepend if root is "."
         self.source_roots
             .iter()

--- a/src/exclusion.rs
+++ b/src/exclusion.rs
@@ -31,6 +31,13 @@ pub struct PathExclusions {
 }
 
 impl PathExclusions {
+    pub fn empty<P: AsRef<Path>>(project_root: P) -> Self {
+        Self {
+            project_root: project_root.as_ref().to_path_buf(),
+            patterns: vec![],
+        }
+    }
+
     pub fn new<P: AsRef<Path>>(
         project_root: P,
         exclude_paths: &[String],

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -241,7 +241,7 @@ pub fn read_file_content<P: AsRef<Path>>(path: P) -> Result<String> {
     Ok(content)
 }
 
-fn is_hidden(entry: &DirEntry) -> bool {
+pub fn is_hidden(entry: &DirEntry) -> bool {
     entry
         .file_name()
         .to_str()
@@ -249,7 +249,7 @@ fn is_hidden(entry: &DirEntry) -> bool {
         .unwrap_or(false)
 }
 
-fn direntry_is_excluded(entry: &DirEntry, exclusions: &PathExclusions) -> bool {
+pub fn direntry_is_excluded(entry: &DirEntry, exclusions: &PathExclusions) -> bool {
     exclusions.is_path_excluded(entry.path())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,9 @@ impl From<parsing::error::ParsingError> for PyErr {
             parsing::error::ParsingError::TomlParse(err) => PyValueError::new_err(err.to_string()),
             parsing::error::ParsingError::MissingField(err) => PyValueError::new_err(err),
             parsing::error::ParsingError::ModulePath(err) => PyValueError::new_err(err),
+            parsing::error::ParsingError::SourceRootResolution(err) => {
+                PyValueError::new_err(err.to_string())
+            }
             parsing::error::ParsingError::PathExclusion(err) => err.into(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,8 @@ impl From<sync::SyncError> for PyErr {
             sync::SyncError::CheckError(err) => err.into(),
             sync::SyncError::RootModuleViolation(err) => PyValueError::new_err(err.to_string()),
             sync::SyncError::EditError(err) => PyValueError::new_err(err.to_string()),
+            sync::SyncError::SourceRootResolution(err) => PyValueError::new_err(err.to_string()),
+            sync::SyncError::PathExclusion(err) => err.into(),
         }
     }
 }
@@ -292,7 +294,7 @@ fn check_internal(
     dependencies: bool,
     interfaces: bool,
 ) -> check::check_internal::Result<Vec<diagnostics::Diagnostic>> {
-    check::check_internal(project_root, project_config, dependencies, interfaces)
+    check::check_internal(&project_root, project_config, dependencies, interfaces)
 }
 
 #[pyfunction]

--- a/src/lsp/server.rs
+++ b/src/lsp/server.rs
@@ -178,8 +178,7 @@ impl LSPServer {
         eprintln!("Linting for diagnostics: {uri_pathbuf:?}");
         eprintln!("Project root: {}", self.project_root.display());
 
-        let check_result =
-            check_internal(self.project_root.clone(), &self.project_config, true, true)?;
+        let check_result = check_internal(&self.project_root, &self.project_config, true, true)?;
         let check_external_result = check_external(&self.project_root, &self.project_config)?;
 
         let diagnostics = self

--- a/src/modules/build.rs
+++ b/src/modules/build.rs
@@ -3,15 +3,15 @@ use std::path::PathBuf;
 use crate::{
     config::{ModuleConfig, RootModuleTreatment},
     exclusion::PathExclusions,
+    resolvers::{glob, ModuleResolver},
 };
 
 use super::{
-    resolve::has_glob_syntax,
     validation::{
         find_duplicate_modules, find_modules_with_cycles, find_visibility_violations,
         validate_root_module_treatment,
     },
-    ModuleResolver, ModuleTree, ModuleTreeError,
+    ModuleTree, ModuleTreeError,
 };
 
 pub struct ModuleTreeBuilder<'a> {
@@ -45,7 +45,7 @@ impl<'a> ModuleTreeBuilder<'a> {
             let mod_path = module.mod_path();
             if let Ok(resolved_paths) = self.resolver.resolve_module_path(&mod_path) {
                 resolved_modules.extend(resolved_paths.into_iter().map(|path| {
-                    if has_glob_syntax(&mod_path) {
+                    if glob::has_glob_syntax(&mod_path) {
                         module.clone_with_path(&path).with_glob_origin(&mod_path)
                     } else {
                         module.clone_with_path(&path)

--- a/src/modules/error.rs
+++ b/src/modules/error.rs
@@ -1,8 +1,7 @@
 use thiserror::Error;
 
 use crate::python::error::ParsingError;
-
-use super::resolve::ModuleResolverError;
+use crate::resolvers;
 
 #[derive(Debug, Clone)]
 pub struct VisibilityErrorInfo {
@@ -30,5 +29,5 @@ pub enum ModuleTreeError {
     #[error("Module not found: {0}")]
     ModuleNotFound(String),
     #[error("Module resolution error: {0}")]
-    ModuleResolutionError(#[from] ModuleResolverError),
+    ModuleResolutionError(#[from] resolvers::ModuleResolverError),
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,10 +1,8 @@
 pub mod build;
 pub mod error;
-pub mod resolve;
 pub mod tree;
 pub mod validation;
 
 pub use build::ModuleTreeBuilder;
 pub use error::ModuleTreeError;
-pub use resolve::{ModuleGlob, ModuleResolver, ModuleResolverError};
 pub use tree::{ModuleNode, ModuleTree};

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -14,6 +14,7 @@ use crate::{
     exclusion::PathExclusions,
     filesystem::{read_file_content, walk_domain_config_files},
     python::parsing::parse_interface_members,
+    resolvers::SourceRootResolver,
 };
 
 use super::error;
@@ -152,12 +153,14 @@ pub fn parse_domain_config<P: AsRef<Path>>(
 }
 
 pub fn add_domain_configs<P: AsRef<Path>>(config: &mut ProjectConfig, root_dir: P) -> Result<()> {
-    let root_dir = root_dir.as_ref();
-    let exclusions = PathExclusions::new(root_dir, &config.exclude, config.use_regex_matching)?;
+    let root_dir = root_dir.as_ref().to_path_buf();
+    let exclusions = PathExclusions::new(&root_dir, &config.exclude, config.use_regex_matching)?;
+    let source_root_resolver = SourceRootResolver::new(&root_dir, &exclusions);
+    let source_roots = source_root_resolver.resolve(&config.source_roots)?;
     let mut domain_configs =
         walk_domain_config_files(root_dir.as_os_str().to_str().unwrap(), &exclusions)
             .par_bridge()
-            .map(|filepath| parse_domain_config(&config.resolve_source_roots(root_dir), filepath))
+            .map(|filepath| parse_domain_config(&source_roots, filepath))
             .collect::<Result<Vec<_>>>()?;
     domain_configs.drain(..).for_each(|domain| {
         config.add_domain(domain);

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -157,7 +157,7 @@ pub fn add_domain_configs<P: AsRef<Path>>(config: &mut ProjectConfig, root_dir: 
     let mut domain_configs =
         walk_domain_config_files(root_dir.as_os_str().to_str().unwrap(), &exclusions)
             .par_bridge()
-            .map(|filepath| parse_domain_config(&config.prepend_roots(root_dir), filepath))
+            .map(|filepath| parse_domain_config(&config.resolve_source_roots(root_dir), filepath))
             .collect::<Result<Vec<_>>>()?;
     domain_configs.drain(..).for_each(|domain| {
         config.add_domain(domain);

--- a/src/parsing/error.rs
+++ b/src/parsing/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::exclusion::PathExclusionError;
 use crate::filesystem::FileSystemError;
-
+use crate::resolvers::SourceRootResolverError;
 #[derive(Error, Debug)]
 pub enum ParsingError {
     #[error("IO error: {0}")]
@@ -18,4 +18,6 @@ pub enum ParsingError {
     ModulePath(String),
     #[error("Path exclusion error: {0}")]
     PathExclusion(#[from] PathExclusionError),
+    #[error("Source root resolution error: {0}")]
+    SourceRootResolution(#[from] SourceRootResolverError),
 }

--- a/src/resolvers/glob.rs
+++ b/src/resolvers/glob.rs
@@ -2,6 +2,9 @@ use globset::{Error, GlobBuilder, GlobMatcher};
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use walkdir::WalkDir;
 
+use crate::exclusion::PathExclusions;
+use crate::filesystem::{direntry_is_excluded, is_hidden};
+
 pub fn has_glob_syntax(pattern: &str) -> bool {
     pattern.chars().enumerate().any(|(i, c)| {
         match c {
@@ -27,6 +30,7 @@ pub fn build_matcher(pattern: &str) -> Result<GlobMatcher, Error> {
 pub fn find_matching_directories<P: AsRef<Path>>(
     root_path: P,
     pattern: &str,
+    path_exclusions: &PathExclusions,
 ) -> Result<Vec<PathBuf>, Error> {
     let matcher = build_matcher(&format!(
         "{}{}{}",
@@ -37,6 +41,7 @@ pub fn find_matching_directories<P: AsRef<Path>>(
 
     let matching_dirs = WalkDir::new(root_path)
         .into_iter()
+        .filter_entry(|e| !is_hidden(e) && !direntry_is_excluded(e, path_exclusions))
         .filter_map(|entry| entry.ok())
         .filter(|entry| entry.file_type().is_dir())
         .filter(|entry| {

--- a/src/resolvers/glob.rs
+++ b/src/resolvers/glob.rs
@@ -1,0 +1,53 @@
+use globset::{Error, GlobBuilder, GlobMatcher};
+use std::path::{Path, PathBuf, MAIN_SEPARATOR};
+use walkdir::WalkDir;
+
+pub fn has_glob_syntax(pattern: &str) -> bool {
+    pattern.chars().enumerate().any(|(i, c)| {
+        match c {
+            '*' | '?' | '[' | ']' | '{' | '}' => {
+                // Check if the character is escaped
+                i == 0 || pattern.as_bytes()[i - 1] != b'\\'
+            }
+            _ => false,
+        }
+    })
+}
+
+pub fn build_matcher(pattern: &str) -> Result<GlobMatcher, Error> {
+    let mut glob_builder = GlobBuilder::new(pattern);
+    let matcher = glob_builder
+        .literal_separator(true)
+        .empty_alternates(true)
+        .build()?
+        .compile_matcher();
+    Ok(matcher)
+}
+
+pub fn find_matching_directories<P: AsRef<Path>>(
+    root_path: P,
+    pattern: &str,
+) -> Result<Vec<PathBuf>, Error> {
+    let matcher = build_matcher(&format!(
+        "{}{}{}",
+        root_path.as_ref().display(),
+        MAIN_SEPARATOR,
+        pattern
+    ))?;
+
+    let matching_dirs = WalkDir::new(root_path)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_dir())
+        .filter(|entry| {
+            entry
+                .path()
+                .as_os_str()
+                .to_str()
+                .is_some_and(|path| matcher.is_match(path))
+        })
+        .map(|entry| entry.path().to_path_buf())
+        .collect();
+
+    Ok(matching_dirs)
+}

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -1,3 +1,8 @@
+pub mod glob;
+pub mod module;
 pub mod package;
+pub mod source_root;
 
+pub use module::{ModuleGlob, ModuleResolver, ModuleResolverError};
 pub use package::{Package, PackageResolution, PackageResolutionError, PackageResolver};
+pub use source_root::SourceRootResolver;

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -5,4 +5,4 @@ pub mod source_root;
 
 pub use module::{ModuleGlob, ModuleResolver, ModuleResolverError};
 pub use package::{Package, PackageResolution, PackageResolutionError, PackageResolver};
-pub use source_root::SourceRootResolver;
+pub use source_root::{SourceRootResolver, SourceRootResolverError};

--- a/src/resolvers/source_root.rs
+++ b/src/resolvers/source_root.rs
@@ -1,0 +1,149 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use globset;
+use thiserror::Error;
+
+use super::glob;
+
+#[derive(Error, Debug)]
+pub enum SourceRootResolverError {
+    #[error("Invalid source root: {0}")]
+    InvalidSourceRoot(String),
+    #[error("Failed to handle glob: {0}")]
+    GlobError(#[from] globset::Error),
+}
+
+pub struct SourceRootResolver<'a> {
+    project_root: &'a PathBuf,
+}
+
+impl<'a> SourceRootResolver<'a> {
+    pub fn new(project_root: &'a PathBuf) -> Self {
+        Self { project_root }
+    }
+
+    pub fn resolve(
+        &self,
+        source_roots: &[PathBuf],
+    ) -> Result<Vec<PathBuf>, SourceRootResolverError> {
+        Ok(source_roots
+            .iter()
+            .map(|root| {
+                if root.as_os_str().to_str() == Some(".") {
+                    // Don't want to construct a path like: "<project_root>/."
+                    Ok(vec![self.project_root.to_path_buf()])
+                } else {
+                    match root.as_os_str().to_str() {
+                        Some(s) => {
+                            if glob::has_glob_syntax(s) {
+                                glob::find_matching_directories(self.project_root, s)
+                                    .map_err(SourceRootResolverError::GlobError)
+                            } else {
+                                Ok(vec![self.project_root.join(root)])
+                            }
+                        }
+                        None => Err(SourceRootResolverError::InvalidSourceRoot(
+                            root.display().to_string(),
+                        )),
+                    }
+                }
+            })
+            .collect::<Result<HashSet<_>, _>>()? // This propagates errors and deduplicates
+            .into_iter()
+            .flatten()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn setup_test_directory() -> TempDir {
+        let temp_dir = TempDir::new().unwrap();
+        let root_path = temp_dir.path();
+
+        // Create a directory structure for testing
+        fs::create_dir_all(root_path.join("src/main")).unwrap();
+        fs::create_dir_all(root_path.join("src/lib")).unwrap();
+        fs::create_dir_all(root_path.join("tests")).unwrap();
+        fs::create_dir_all(root_path.join("examples/one")).unwrap();
+        fs::create_dir_all(root_path.join("examples/two")).unwrap();
+        fs::create_dir_all(root_path.join("docs")).unwrap();
+
+        temp_dir
+    }
+
+    #[test]
+    fn test_resolve_single_directory() {
+        let temp_dir = setup_test_directory();
+        let project_root = PathBuf::from(temp_dir.path());
+        let resolver = SourceRootResolver::new(&project_root);
+
+        let source_roots = vec![PathBuf::from("src")];
+        let resolved = resolver.resolve(&source_roots).unwrap();
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0], project_root.join("src"));
+    }
+
+    #[test]
+    fn test_resolve_current_directory() {
+        let temp_dir = setup_test_directory();
+        let project_root = PathBuf::from(temp_dir.path());
+        let resolver = SourceRootResolver::new(&project_root);
+
+        let source_roots = vec![PathBuf::from(".")];
+        let resolved = resolver.resolve(&source_roots).unwrap();
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0], project_root);
+    }
+
+    #[test]
+    fn test_resolve_glob_pattern() {
+        let temp_dir = setup_test_directory();
+        let project_root = PathBuf::from(temp_dir.path());
+        let resolver = SourceRootResolver::new(&project_root);
+
+        let source_roots = vec![PathBuf::from("examples/*")];
+        let resolved = resolver.resolve(&source_roots).unwrap();
+
+        assert_eq!(resolved.len(), 2);
+        assert!(resolved.contains(&project_root.join("examples/one")));
+        assert!(resolved.contains(&project_root.join("examples/two")));
+    }
+
+    #[test]
+    fn test_resolve_multiple_patterns() {
+        let temp_dir = setup_test_directory();
+        let project_root = PathBuf::from(temp_dir.path());
+        let resolver = SourceRootResolver::new(&project_root);
+
+        let source_roots = vec![PathBuf::from("src/*"), PathBuf::from("tests")];
+        let resolved = resolver.resolve(&source_roots).unwrap();
+
+        assert_eq!(resolved.len(), 3);
+        assert!(resolved.contains(&project_root.join("src/main")));
+        assert!(resolved.contains(&project_root.join("src/lib")));
+        assert!(resolved.contains(&project_root.join("tests")));
+    }
+
+    #[test]
+    fn test_resolve_deduplicates_paths() {
+        let temp_dir = setup_test_directory();
+        let project_root = PathBuf::from(temp_dir.path());
+        let resolver = SourceRootResolver::new(&project_root);
+
+        let source_roots = vec![
+            PathBuf::from("src"),
+            PathBuf::from("src"), // Duplicate
+        ];
+        let resolved = resolver.resolve(&source_roots).unwrap();
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0], project_root.join("src"));
+    }
+}


### PR DESCRIPTION
This PR improves the ergonomics of Tach for monorepos by allowing glob patterns in `source_roots`.

This means that instead of needing to specify a literal path to each source root (typically just `src` in each package), you can use configuration like this:

```toml
source_roots = ["**/src"]
```

This will be resolved up-front into all matching directories.

Note that `exclude` will be taken into account when resolving globs.