### PR TITLE
Add package name to check-external diagnostics

### DIFF
--- a/src/checks/external_dependency.rs
+++ b/src/checks/external_dependency.rs
@@ -56,6 +56,13 @@ impl<'a> ExternalDependencyChecker<'a> {
                 Some(processed_file.line_number(import.import.import_offset)),
                 DiagnosticDetails::Code(CodeDiagnostic::UndeclaredExternalDependency {
                     dependency: import.import.top_level_module_name().to_string(),
+                    package_name: processed_file
+                        .package
+                        .name
+                        .as_ref()
+                        .map_or(processed_file.package.root.display().to_string(), |name| {
+                            name.to_string()
+                        }),
                 }),
             ))
         } else {

--- a/src/diagnostics/diagnostics.rs
+++ b/src/diagnostics/diagnostics.rs
@@ -117,13 +117,16 @@ pub enum CodeDiagnostic {
     #[error("Ignore directive is missing a reason.")]
     MissingIgnoreDirectiveReason(),
 
-    #[error("Dependency '{dependency}' is not declared in the project.")]
-    UndeclaredExternalDependency { dependency: String },
+    #[error("Dependency '{dependency}' is not declared in package '{package_name}'.")]
+    UndeclaredExternalDependency {
+        dependency: String,
+        package_name: String,
+    },
 
-    #[error("External package '{package_module_name}' is not used in package '{package_root}'.")]
+    #[error("External package '{package_module_name}' is not used in package '{package_name}'.")]
     UnusedExternalDependency {
         package_module_name: String,
-        package_root: String,
+        package_name: String,
     },
 }
 

--- a/src/resolvers/package.rs
+++ b/src/resolvers/package.rs
@@ -195,14 +195,10 @@ impl<'a> PackageResolver<'a> {
         self.package_for_source_root.get(source_root.as_ref())
     }
 
-    pub fn get_dependencies_for_package_root(
-        &self,
-        package_root: &PathBuf,
-    ) -> Option<&HashSet<String>> {
+    pub fn get_package_by_package_root(&self, package_root: &PathBuf) -> Option<&Package> {
         self.package_for_source_root
             .values()
             .find(|package| &package.root == package_root)
-            .map(|package| &package.dependencies)
     }
 
     pub fn resolve_file_path<P: AsRef<Path>>(&self, file_path: P) -> PackageResolution {


### PR DESCRIPTION
This is a quality-of-life change for diagnostics from `check-external`. Undeclared dependencies will now indicate the package name, and unused dependencies will use the package name instead of the path. If the package name is not found in either case, the fallback is to use the package path.