### PR TITLE
Fix visibility in `tach.domain.toml`

### DIFF
--- a/python/tests/example/many_features/real_src/module1/tach.domain.toml
+++ b/python/tests/example/many_features/real_src/module1/tach.domain.toml
@@ -10,6 +10,7 @@ layer = "hightest"
 [[modules]]
 path = "api"
 depends_on = ["**"]
+visibility = ["<domain_root>"]
 layer = "mid"
 
 [[modules]]

--- a/python/tests/example/many_features/real_src/module3/submodule1/__init__.py
+++ b/python/tests/example/many_features/real_src/module3/submodule1/__init__.py
@@ -1,0 +1,1 @@
+from ..submodule2 import something

--- a/python/tests/example/many_features/real_src/module3/tach.domain.toml
+++ b/python/tests/example/many_features/real_src/module3/tach.domain.toml
@@ -4,7 +4,7 @@ layer = "low"
 
 [[modules]]
 path = "submodule1"
-depends_on = []
+depends_on = ["submodule2"]
 layer = "low"
 utility = true
 

--- a/python/tests/example/visibility_error/src/module1.py
+++ b/python/tests/example/visibility_error/src/module1.py
@@ -1,0 +1,1 @@
+from module3 import something

--- a/python/tests/example/visibility_error/src/module2.py
+++ b/python/tests/example/visibility_error/src/module2.py
@@ -1,0 +1,1 @@
+from module3 import something

--- a/python/tests/example/visibility_error/src/module3/tach.domain.toml
+++ b/python/tests/example/visibility_error/src/module3/tach.domain.toml
@@ -1,0 +1,2 @@
+[root]
+visibility = ["//module1"]

--- a/python/tests/example/visibility_error/tach.toml
+++ b/python/tests/example/visibility_error/tach.toml
@@ -1,0 +1,9 @@
+source_roots = ["src"]
+
+[[modules]]
+path = "module1"
+depends_on = ["module3"]
+
+[[modules]]
+path = "module2"
+depends_on = ["module3"]

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -464,3 +464,22 @@ def test_monorepo_workspace_example_dir_external(example_dir, capfd):
     ]
 
     _check_expected_messages_unordered(external_section, expected_external)
+
+
+def test_visibility_error_example_dir(example_dir, capfd):
+    project_root = example_dir / "visibility_error"
+    project_config = parse_project_config(root=project_root)
+    assert project_config is not None
+
+    with pytest.raises(SystemExit) as exc_info:
+        tach_check(
+            project_root=project_root,
+            project_config=project_config,
+        )
+    assert exc_info.value.code == 1
+
+    captured = capfd.readouterr()
+    assert "Module configuration error" in captured.err
+    assert "'module2' cannot depend on 'module3'" in captured.err
+    assert "module3" in captured.err
+    assert "['module1']" in captured.err

--- a/src/config/domain.rs
+++ b/src/config/domain.rs
@@ -8,10 +8,7 @@ use crate::filesystem::file_to_module_path;
 
 use super::edit::{ConfigEdit, ConfigEditor, EditError};
 use super::interfaces::InterfaceConfig;
-use super::modules::{
-    default_visibility, deserialize_modules, is_default_visibility, serialize_modules,
-    DependencyConfig, ModuleConfig,
-};
+use super::modules::{deserialize_modules, serialize_modules, DependencyConfig, ModuleConfig};
 use super::utils::*;
 use crate::parsing::error::ParsingError;
 
@@ -22,11 +19,8 @@ pub struct DomainRootConfig {
     pub depends_on: Option<Vec<DependencyConfig>>,
     #[serde(default)]
     pub layer: Option<String>,
-    #[serde(
-        default = "default_visibility",
-        skip_serializing_if = "is_default_visibility"
-    )]
-    pub visibility: Vec<String>,
+    #[serde(default)]
+    pub visibility: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub utility: bool,
     #[serde(default, skip_serializing_if = "is_false")]
@@ -147,7 +141,7 @@ impl Resolvable<ModuleConfig> for DomainRootConfig {
             &location.mod_path,
             self.depends_on.clone().map(|deps| deps.resolve(location)),
             self.layer.clone(),
-            self.visibility.resolve(location),
+            self.visibility.clone().map(|vis| vis.resolve(location)),
             self.utility,
             self.unchecked,
         )
@@ -160,7 +154,7 @@ impl Resolvable<ModuleConfig> for ModuleConfig {
             &format!("{}.{}", location.mod_path, self.path),
             self.depends_on.clone().map(|deps| deps.resolve(location)),
             self.layer.clone(),
-            self.visibility.resolve(location),
+            self.visibility.clone().map(|vis| vis.resolve(location)),
             self.utility,
             self.unchecked,
         )

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -146,14 +146,6 @@ impl<'de> Deserialize<'de> for DependencyConfig {
     }
 }
 
-pub fn default_visibility() -> Vec<String> {
-    global_visibility()
-}
-
-pub fn is_default_visibility(value: &Vec<String>) -> bool {
-    value == &default_visibility()
-}
-
 #[derive(Debug, Clone, PartialEq)]
 enum ModuleOrigin {
     Glob(String),
@@ -171,12 +163,9 @@ pub struct ModuleConfig {
     #[serde(default)]
     #[pyo3(get)]
     pub layer: Option<String>,
-    #[serde(
-        default = "default_visibility",
-        skip_serializing_if = "is_default_visibility"
-    )]
+    #[serde(default)]
     #[pyo3(get)]
-    pub visibility: Vec<String>,
+    pub visibility: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "is_false")]
     #[pyo3(get)]
     pub utility: bool,
@@ -200,10 +189,10 @@ pub struct ModuleConfig {
 impl Default for ModuleConfig {
     fn default() -> Self {
         Self {
-            path: Default::default(),
             depends_on: Some(vec![]),
+            path: Default::default(),
             layer: Default::default(),
-            visibility: default_visibility(),
+            visibility: Default::default(),
             utility: Default::default(),
             strict: Default::default(),
             unchecked: Default::default(),
@@ -218,7 +207,7 @@ impl ModuleConfig {
         path: &str,
         depends_on: Option<Vec<DependencyConfig>>,
         layer: Option<String>,
-        visibility: Vec<String>,
+        visibility: Option<Vec<String>>,
         utility: bool,
         unchecked: bool,
     ) -> Self {
@@ -284,7 +273,7 @@ impl ModuleConfig {
             path: path.to_string(),
             depends_on: Some(vec![]),
             layer: Some(layer.to_string()),
-            visibility: default_visibility(),
+            visibility: None,
             utility: false,
             strict: false,
             unchecked: false,
@@ -382,11 +371,8 @@ struct BulkModule {
     depends_on: Option<Vec<DependencyConfig>>,
     #[serde(default)]
     layer: Option<String>,
-    #[serde(
-        default = "default_visibility",
-        skip_serializing_if = "is_default_visibility"
-    )]
-    visibility: Vec<String>,
+    #[serde(default)]
+    visibility: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "is_false")]
     utility: bool,
     #[serde(default, skip_serializing_if = "is_false")]

--- a/src/modules/build.rs
+++ b/src/modules/build.rs
@@ -65,6 +65,7 @@ impl<'a> ModuleTreeBuilder<'a> {
     ) -> Result<ModuleTree, ModuleTreeError> {
         // Collect modules
         let modules: Vec<ModuleConfig> = modules.into_iter().collect();
+
         // Check for duplicate modules
         let duplicate_modules = find_duplicate_modules(&modules);
         if !duplicate_modules.is_empty() {
@@ -74,7 +75,7 @@ impl<'a> ModuleTreeBuilder<'a> {
         }
 
         // Check for visibility errors (dependency declared on invisible module)
-        let visibility_error_info = find_visibility_violations(&modules);
+        let visibility_error_info = find_visibility_violations(&modules)?;
         if !visibility_error_info.is_empty() {
             return Err(ModuleTreeError::VisibilityViolation(visibility_error_info));
         }


### PR DESCRIPTION
Fixes: #650 

This PR makes a couple changes to `visibility` to fix expected behavior when defined in `tach.domain.toml`.

First, the strings provided in `visibility` are resolved relative to the domain config location, using the same resolution rules as `depends_on`.

Second, the `visibility` matching logic is replaced with the module glob semantics used by `depends_on` and `path`.

This PR also adds relevant config to the example directories for testing.