### PR TITLE
Add `cannot_depend_on` field to modules

### DIFF
--- a/public/tach-domain-toml-schema.json
+++ b/public/tach-domain-toml-schema.json
@@ -35,6 +35,15 @@
             "default": null,
             "description": "List of dependencies for the module"
           },
+          "cannot_depend_on": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Path to the dependency"
+            },
+            "default": null,
+            "description": "List of forbidden dependencies for the module"
+          },
           "layer": {
             "type": "string",
             "description": "The architectural layer this module belongs to"
@@ -58,7 +67,7 @@
             "items": {
               "type": "string"
             },
-            "default": ["*"],
+            "default": null,
             "description": "List of visibility patterns"
           }
         },
@@ -106,6 +115,15 @@
                 "default": null,
                 "description": "List of dependencies for the module"
               },
+              "cannot_depend_on": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Path to the dependency"
+                },
+                "default": null,
+                "description": "List of forbidden dependencies for the module"
+              },
               "layer": {
                 "type": "string",
                 "description": "The architectural layer this module belongs to"
@@ -129,7 +147,7 @@
                 "items": {
                   "type": "string"
                 },
-                "default": ["*"],
+                "default": null,
                 "description": "List of visibility patterns"
               }
             },
@@ -174,6 +192,15 @@
                 "default": null,
                 "description": "List of dependencies for the module"
               },
+              "cannot_depend_on": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Path to the dependency"
+                },
+                "default": null,
+                "description": "List of forbidden dependencies for the module"
+              },
               "layer": {
                 "type": "string",
                 "description": "The architectural layer this module belongs to"
@@ -197,7 +224,7 @@
                 "items": {
                   "type": "string"
                 },
-                "default": ["*"],
+                "default": null,
                 "description": "List of visibility patterns"
               }
             },

--- a/public/tach-toml-schema.json
+++ b/public/tach-toml-schema.json
@@ -45,6 +45,15 @@
                 "default": null,
                 "description": "List of dependencies for the module"
               },
+              "cannot_depend_on": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Path to the dependency"
+                },
+                "default": null,
+                "description": "List of forbidden dependencies for the module"
+              },
               "layer": {
                 "type": "string",
                 "description": "The architectural layer this module belongs to"
@@ -68,7 +77,7 @@
                 "items": {
                   "type": "string"
                 },
-                "default": ["*"],
+                "default": null,
                 "description": "List of visibility patterns"
               }
             },
@@ -113,6 +122,15 @@
                 "default": null,
                 "description": "List of dependencies for the module"
               },
+              "cannot_depend_on": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Path to the dependency"
+                },
+                "default": null,
+                "description": "List of forbidden dependencies for the module"
+              },
               "layer": {
                 "type": "string",
                 "description": "The architectural layer this module belongs to"
@@ -136,7 +154,7 @@
                 "items": {
                   "type": "string"
                 },
-                "default": ["*"],
+                "default": null,
                 "description": "List of visibility patterns"
               }
             },

--- a/python/tests/example/many_features/real_src/module3/submodule1/__init__.py
+++ b/python/tests/example/many_features/real_src/module3/submodule1/__init__.py
@@ -1,1 +1,3 @@
 from ..submodule2 import something
+
+from ..submodule3 import something_else

--- a/python/tests/example/many_features/real_src/module3/tach.domain.toml
+++ b/python/tests/example/many_features/real_src/module3/tach.domain.toml
@@ -4,12 +4,17 @@ layer = "low"
 
 [[modules]]
 path = "submodule1"
-depends_on = ["submodule2"]
+cannot_depend_on = ["submodule2"]
 layer = "low"
 utility = true
 
 [[modules]]
 path = "submodule2"
+depends_on = []
+layer = "low"
+
+[[modules]]
+path = "submodule3"
 depends_on = []
 layer = "low"
 

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -359,6 +359,13 @@ def test_many_features_example_dir(example_dir, capfd):
             "'low'",
             "module3",
         ),
+        (
+            "[FAIL]",
+            "real_src/module3/submodule1/__init__.py",
+            "'module3.submodule1'",
+            "cannot depend on",
+            "'module3.submodule2'",
+        ),
     ]
 
     expected_unused = [

--- a/python/tests/test_sync.py
+++ b/python/tests/test_sync.py
@@ -102,7 +102,7 @@ def test_many_features_example_dir(example_dir, capfd):
 
         modules = project_config.all_modules()
         # This should be the number of statically defined modules, before globbing
-        assert len(modules) == 14
+        assert len(modules) == 15
 
         module2 = next(module for module in modules if module.path == "module2")
         assert set(map(lambda dep: dep.path, module2.depends_on)) == {"outer_module"}

--- a/src/checks/internal_dependency.rs
+++ b/src/checks/internal_dependency.rs
@@ -127,25 +127,22 @@ impl<'a> InternalDependencyChecker<'a> {
         let file_nearest_module_path = &file_module_config.path;
         let dependency_nearest_module_path = &dependency_module_config.path;
 
-        match file_module_config
+        if let Some(DependencyConfig { .. }) = file_module_config
             .forbidden_dependencies_iter()
             .find(|dep| dep.matches(dependency_nearest_module_path))
         {
-            Some(DependencyConfig { .. }) => {
-                return Ok(vec![Diagnostic::new_located_error(
-                    relative_file_path.to_path_buf(),
-                    file_module.line_number(dependency.offset()),
-                    dependency
-                        .original_line_offset()
-                        .map(|offset| file_module.line_number(offset)),
-                    DiagnosticDetails::Code(CodeDiagnostic::ForbiddenDependency {
-                        dependency: dependency.module_path().to_string(),
-                        usage_module: file_nearest_module_path.to_string(),
-                        definition_module: dependency_nearest_module_path.to_string(),
-                    }),
-                )])
-            }
-            None => (), // Further checks will be done below, this dependency is not explicitly forbidden
+            return Ok(vec![Diagnostic::new_located_error(
+                relative_file_path.to_path_buf(),
+                file_module.line_number(dependency.offset()),
+                dependency
+                    .original_line_offset()
+                    .map(|offset| file_module.line_number(offset)),
+                DiagnosticDetails::Code(CodeDiagnostic::ForbiddenDependency {
+                    dependency: dependency.module_path().to_string(),
+                    usage_module: file_nearest_module_path.to_string(),
+                    definition_module: dependency_nearest_module_path.to_string(),
+                }),
+            )]);
         }
 
         if file_module_config.depends_on.is_none() {

--- a/src/checks/internal_dependency.rs
+++ b/src/checks/internal_dependency.rs
@@ -124,6 +124,30 @@ impl<'a> InternalDependencyChecker<'a> {
             LayerCheckResult::SameLayer | LayerCheckResult::LayerNotSpecified => (), // We need to do further processing to determine if the dependency is allowed
         };
 
+        let file_nearest_module_path = &file_module_config.path;
+        let dependency_nearest_module_path = &dependency_module_config.path;
+
+        match file_module_config
+            .forbidden_dependencies_iter()
+            .find(|dep| dep.matches(dependency_nearest_module_path))
+        {
+            Some(DependencyConfig { .. }) => {
+                return Ok(vec![Diagnostic::new_located_error(
+                    relative_file_path.to_path_buf(),
+                    file_module.line_number(dependency.offset()),
+                    dependency
+                        .original_line_offset()
+                        .map(|offset| file_module.line_number(offset)),
+                    DiagnosticDetails::Code(CodeDiagnostic::ForbiddenDependency {
+                        dependency: dependency.module_path().to_string(),
+                        usage_module: file_nearest_module_path.to_string(),
+                        definition_module: dependency_nearest_module_path.to_string(),
+                    }),
+                )])
+            }
+            None => (), // Further checks will be done below, this dependency is not explicitly forbidden
+        }
+
         if file_module_config.depends_on.is_none() {
             return Ok(vec![]);
         }
@@ -132,13 +156,8 @@ impl<'a> InternalDependencyChecker<'a> {
             return Ok(vec![]);
         }
 
-        let file_nearest_module_path = &file_module_config.path;
-        let dependency_nearest_module_path = &dependency_module_config.path;
-
         match file_module_config
             .dependencies_iter()
-            // this is where we match depends_on to the module boundary path
-            // DependencyConfig should build a matcher up-front for any glob patterns
             .find(|dep| dep.matches(dependency_nearest_module_path))
         {
             Some(DependencyConfig {

--- a/src/commands/check/format.rs
+++ b/src/commands/check/format.rs
@@ -23,6 +23,7 @@ impl From<&DiagnosticDetails> for DiagnosticGroupKind {
             DiagnosticDetails::Code(code_diagnostic_details) => match code_diagnostic_details {
                 CodeDiagnostic::UndeclaredDependency { .. } => Self::InternalDependency,
                 CodeDiagnostic::DeprecatedDependency { .. } => Self::InternalDependency,
+                CodeDiagnostic::ForbiddenDependency { .. } => Self::InternalDependency,
                 CodeDiagnostic::LayerViolation { .. } => Self::InternalDependency,
                 CodeDiagnostic::PrivateDependency { .. } => Self::Interface,
                 CodeDiagnostic::InvalidDataTypeExport { .. } => Self::Interface,

--- a/src/config/domain.rs
+++ b/src/config/domain.rs
@@ -18,6 +18,8 @@ pub struct DomainRootConfig {
     #[serde(default)]
     pub depends_on: Option<Vec<DependencyConfig>>,
     #[serde(default)]
+    pub cannot_depend_on: Option<Vec<DependencyConfig>>,
+    #[serde(default)]
     pub layer: Option<String>,
     #[serde(default)]
     pub visibility: Option<Vec<String>>,
@@ -140,6 +142,9 @@ impl Resolvable<ModuleConfig> for DomainRootConfig {
             // Root modules represent the domain itself
             &location.mod_path,
             self.depends_on.clone().map(|deps| deps.resolve(location)),
+            self.cannot_depend_on
+                .clone()
+                .map(|deps| deps.resolve(location)),
             self.layer.clone(),
             self.visibility.clone().map(|vis| vis.resolve(location)),
             self.utility,
@@ -153,6 +158,9 @@ impl Resolvable<ModuleConfig> for ModuleConfig {
         ModuleConfig::new(
             &format!("{}.{}", location.mod_path, self.path),
             self.depends_on.clone().map(|deps| deps.resolve(location)),
+            self.cannot_depend_on
+                .clone()
+                .map(|deps| deps.resolve(location)),
             self.layer.clone(),
             self.visibility.clone().map(|vis| vis.resolve(location)),
             self.utility,

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -297,6 +297,13 @@ impl ModuleConfig {
             .flat_map(|deps| deps.iter())
     }
 
+    pub fn forbidden_dependencies_iter(&self) -> impl Iterator<Item = &DependencyConfig> {
+        self.cannot_depend_on
+            .as_ref()
+            .into_iter()
+            .flat_map(|deps| deps.iter())
+    }
+
     pub fn with_dependencies_removed(&self) -> Self {
         Self {
             depends_on: Some(vec![]),

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -161,6 +161,9 @@ pub struct ModuleConfig {
     #[pyo3(get, set)]
     pub depends_on: Option<Vec<DependencyConfig>>,
     #[serde(default)]
+    #[pyo3(get, set)]
+    pub cannot_depend_on: Option<Vec<DependencyConfig>>,
+    #[serde(default)]
     #[pyo3(get)]
     pub layer: Option<String>,
     #[serde(default)]
@@ -189,7 +192,9 @@ pub struct ModuleConfig {
 impl Default for ModuleConfig {
     fn default() -> Self {
         Self {
+            // By default, a module can depend on nothing
             depends_on: Some(vec![]),
+            cannot_depend_on: Default::default(),
             path: Default::default(),
             layer: Default::default(),
             visibility: Default::default(),
@@ -206,6 +211,7 @@ impl ModuleConfig {
     pub fn new(
         path: &str,
         depends_on: Option<Vec<DependencyConfig>>,
+        cannot_depend_on: Option<Vec<DependencyConfig>>,
         layer: Option<String>,
         visibility: Option<Vec<String>>,
         utility: bool,
@@ -214,6 +220,7 @@ impl ModuleConfig {
         Self {
             path: path.to_string(),
             depends_on,
+            cannot_depend_on,
             layer,
             visibility,
             utility,
@@ -272,6 +279,7 @@ impl ModuleConfig {
         Self {
             path: path.to_string(),
             depends_on: Some(vec![]),
+            cannot_depend_on: None,
             layer: Some(layer.to_string()),
             visibility: None,
             utility: false,
@@ -370,6 +378,8 @@ struct BulkModule {
     #[serde(default)]
     depends_on: Option<Vec<DependencyConfig>>,
     #[serde(default)]
+    cannot_depend_on: Option<Vec<DependencyConfig>>,
+    #[serde(default)]
     layer: Option<String>,
     #[serde(default)]
     visibility: Option<Vec<String>>,
@@ -391,6 +401,7 @@ impl TryFrom<&[&ModuleConfig]> for BulkModule {
         let mut bulk = BulkModule {
             paths: modules.iter().map(|m| m.path.clone()).collect(),
             depends_on: None,
+            cannot_depend_on: None,
             layer: first.layer.clone(),
             visibility: first.visibility.clone(),
             utility: first.utility,
@@ -399,11 +410,18 @@ impl TryFrom<&[&ModuleConfig]> for BulkModule {
 
         let mut unique_deps: HashSet<DependencyConfig> = HashSet::new();
         for module in modules {
-            if let Some(depends_on) = module.depends_on.clone() {
-                unique_deps.extend(depends_on);
+            if let Some(depends_on) = &module.depends_on {
+                // We merge dependencies from all modules, since they may have been mutated in commands like 'sync'
+                unique_deps.extend(depends_on.clone());
             }
 
             // Validate that other fields match the first module
+            if module.cannot_depend_on != first.cannot_depend_on {
+                return Err(format!(
+                    "Inconsistent 'cannot_depend_on' list in bulk module group for path {}",
+                    module.path
+                ));
+            }
             if module.layer != first.layer {
                 return Err(format!(
                     "Inconsistent layer in bulk module group for path {}",
@@ -501,6 +519,7 @@ where
                 .map(|path| ModuleConfig {
                     path,
                     depends_on: bulk.depends_on.clone(),
+                    cannot_depend_on: bulk.cannot_depend_on.clone(),
                     layer: bulk.layer.clone(),
                     visibility: bulk.visibility.clone(),
                     utility: bulk.utility,

--- a/src/diagnostics/diagnostics.rs
+++ b/src/diagnostics/diagnostics.rs
@@ -99,6 +99,13 @@ pub enum CodeDiagnostic {
         definition_module: String,
     },
 
+    #[error("Cannot use '{dependency}'. Module '{usage_module}' cannot depend on '{definition_module}'.")]
+    ForbiddenDependency {
+        dependency: String,
+        usage_module: String,
+        definition_module: String,
+    },
+
     #[error("Cannot use '{dependency}'. Layer '{usage_layer}' ('{usage_module}') is lower than layer '{definition_layer}' ('{definition_module}').")]
     LayerViolation {
         dependency: String,
@@ -137,6 +144,7 @@ impl CodeDiagnostic {
             | CodeDiagnostic::InvalidDataTypeExport { dependency, .. }
             | CodeDiagnostic::UndeclaredDependency { dependency, .. }
             | CodeDiagnostic::DeprecatedDependency { dependency, .. }
+            | CodeDiagnostic::ForbiddenDependency { dependency, .. }
             | CodeDiagnostic::LayerViolation { dependency, .. }
             | CodeDiagnostic::UnnecessarilyIgnoredDependency { dependency, .. } => Some(dependency),
             CodeDiagnostic::UnusedIgnoreDirective() => None,
@@ -155,6 +163,7 @@ impl CodeDiagnostic {
             | CodeDiagnostic::InvalidDataTypeExport { usage_module, .. }
             | CodeDiagnostic::UndeclaredDependency { usage_module, .. }
             | CodeDiagnostic::DeprecatedDependency { usage_module, .. }
+            | CodeDiagnostic::ForbiddenDependency { usage_module, .. }
             | CodeDiagnostic::LayerViolation { usage_module, .. } => Some(usage_module),
             _ => None,
         }
@@ -172,6 +181,9 @@ impl CodeDiagnostic {
                 definition_module, ..
             }
             | CodeDiagnostic::DeprecatedDependency {
+                definition_module, ..
+            }
+            | CodeDiagnostic::ForbiddenDependency {
                 definition_module, ..
             }
             | CodeDiagnostic::LayerViolation {
@@ -387,6 +399,7 @@ impl Diagnostic {
             self.details(),
             DiagnosticDetails::Code(CodeDiagnostic::UndeclaredDependency { .. })
                 | DiagnosticDetails::Code(CodeDiagnostic::DeprecatedDependency { .. })
+                | DiagnosticDetails::Code(CodeDiagnostic::ForbiddenDependency { .. })
                 | DiagnosticDetails::Code(CodeDiagnostic::LayerViolation { .. })
         )
     }

--- a/tach.toml
+++ b/tach.toml
@@ -25,9 +25,7 @@ depends_on = []
 
 [[modules]]
 path = "tach.__main__"
-depends_on = [
-    "tach.start",
-]
+depends_on = ["tach.start"]
 layer = "ui"
 
 


### PR DESCRIPTION
Fixes: #584 

This PR adds a field called `cannot_depend_on` to each item in `modules`.

The field functions as the inverse of `depends_on`, and takes precedence.

That is, if an import comes from an internal module which matches a pattern in `cannot_depend_on`, it will be forbidden immediately. Otherwise, normal checks are performed. By default, `cannot_depend_on` is null and not considered.