### PR TITLE
Support 'visibility' in interfaces

### DIFF
--- a/public/tach-domain-toml-schema.json
+++ b/public/tach-domain-toml-schema.json
@@ -250,6 +250,14 @@
             "items": { "type": "string" },
             "description": "List of regex patterns that match modules which adopt this interface"
           },
+          "visibility": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": null,
+            "description": "List of visibility patterns"
+          },
           "data_types": {
             "type": "string",
             "default": "all",

--- a/public/tach-toml-schema.json
+++ b/public/tach-toml-schema.json
@@ -180,6 +180,14 @@
             "items": { "type": "string" },
             "description": "List of regex patterns that match modules which adopt this interface"
           },
+          "visibility": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": null,
+            "description": "List of visibility patterns"
+          },
           "data_types": {
             "type": "string",
             "default": "all",

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -127,6 +127,7 @@ class InterfaceConfig:
     expose: list[str]
     # 'from' in tach.toml
     from_modules: list[str]
+    visibility: list[str] | None
     data_types: InterfaceDataTypes
 
 CacheBackend = Literal["disk"]

--- a/python/tach/modularity.py
+++ b/python/tach/modularity.py
@@ -214,7 +214,8 @@ def build_modules(
         has_interface = False
         interface_members: set[str] = set()
         for interface in project_config.all_interfaces():
-            if any(
+            interface_is_visible = interface.visibility is None or module.path in interface.visibility
+            if interface_is_visible and any(
                 re.match(r"^" + pattern + r"$", module.path)
                 for pattern in interface.from_modules
             ):

--- a/python/tach/modularity.py
+++ b/python/tach/modularity.py
@@ -214,7 +214,9 @@ def build_modules(
         has_interface = False
         interface_members: set[str] = set()
         for interface in project_config.all_interfaces():
-            interface_is_visible = interface.visibility is None or module.path in interface.visibility
+            interface_is_visible = (
+                interface.visibility is None or module.path in interface.visibility
+            )
             if interface_is_visible and any(
                 re.match(r"^" + pattern + r"$", module.path)
                 for pattern in interface.from_modules

--- a/python/tach/modularity.py
+++ b/python/tach/modularity.py
@@ -214,10 +214,7 @@ def build_modules(
         has_interface = False
         interface_members: set[str] = set()
         for interface in project_config.all_interfaces():
-            interface_is_visible = (
-                interface.visibility is None or module.path in interface.visibility
-            )
-            if interface_is_visible and any(
+            if any(
                 re.match(r"^" + pattern + r"$", module.path)
                 for pattern in interface.from_modules
             ):

--- a/python/tests/example/many_features/other_src_root/module5/__init__.py
+++ b/python/tests/example/many_features/other_src_root/module5/__init__.py
@@ -1,0 +1,1 @@
+from module1.api import something

--- a/python/tests/example/many_features/other_src_root/module5/tach.domain.toml
+++ b/python/tests/example/many_features/other_src_root/module5/tach.domain.toml
@@ -1,5 +1,5 @@
 [root]
-depends_on = []
+depends_on = ["//module1.api"]
 layer = "mid"
 
 [[interfaces]]

--- a/python/tests/example/many_features/real_src/module1/tach.domain.toml
+++ b/python/tests/example/many_features/real_src/module1/tach.domain.toml
@@ -10,8 +10,18 @@ layer = "hightest"
 [[modules]]
 path = "api"
 depends_on = ["**"]
-visibility = ["<domain_root>"]
+visibility = ["<domain_root>", "//module5"]
 layer = "mid"
+
+[[interfaces]]
+expose = [".*"]
+from = ["api"]
+visibility = ["<domain_root>"]
+
+[[interfaces]]
+expose = ["MyAPI"]
+from = ["api"]
+visibility = ["//module5"]
 
 [[modules]]
 path = "submodule1"

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -315,6 +315,12 @@ def test_many_features_example_dir(example_dir, capfd):
             "module3.anything",
             "public interface",
         ),
+        (
+            "[FAIL]",
+            "other_src_root/module5/__init__.py",
+            "module1.api.something",
+            "public interface",
+        ),
     ]
 
     expected_dependencies = [

--- a/src/config/domain.rs
+++ b/src/config/domain.rs
@@ -182,6 +182,7 @@ impl Resolvable<InterfaceConfig> for InterfaceConfig {
                     _ => format!("{}.{}", location.mod_path, mod_path),
                 })
                 .collect(),
+            visibility: self.visibility.clone().map(|vis| vis.resolve(location)),
             data_types: self.data_types.clone(),
         }
     }

--- a/src/config/interfaces.rs
+++ b/src/config/interfaces.rs
@@ -43,6 +43,8 @@ pub struct InterfaceConfig {
         skip_serializing_if = "is_default_from_modules"
     )]
     pub from_modules: Vec<String>,
+    #[serde(default)]
+    pub visibility: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "InterfaceDataTypes::is_default")]
     pub data_types: InterfaceDataTypes,
 }

--- a/src/interfaces/compiled.rs
+++ b/src/interfaces/compiled.rs
@@ -11,11 +11,6 @@ pub struct CompiledInterface {
 
 impl CompiledInterface {
     pub fn matches_module(&self, module_path: &str) -> bool {
-        if let Some(visibility) = &self.visibility {
-            if !visibility.iter().any(|v| v == module_path) {
-                return false;
-            }
-        }
         self.from_modules
             .iter()
             .any(|regex| regex.is_match(module_path))
@@ -23,6 +18,16 @@ impl CompiledInterface {
 
     pub fn matches_member(&self, member_name: &str) -> bool {
         self.expose.iter().any(|regex| regex.is_match(member_name))
+    }
+
+    pub fn is_visible_to(&self, module_path: &str) -> bool {
+        self.visibility.as_ref().map_or(true, |visibility| {
+            visibility.iter().any(|v| v == module_path)
+        })
+    }
+
+    pub fn is_exposed_to(&self, member: &str, module_path: &str) -> bool {
+        self.matches_member(member) && self.is_visible_to(module_path)
     }
 
     pub fn should_type_check(&self, module_path: &str) -> bool {

--- a/src/interfaces/compiled.rs
+++ b/src/interfaces/compiled.rs
@@ -4,12 +4,18 @@ use regex::Regex;
 #[derive(Debug, Clone)]
 pub struct CompiledInterface {
     pub from_modules: Vec<Regex>,
+    pub visibility: Option<Vec<String>>,
     pub expose: Vec<Regex>,
     pub data_types: InterfaceDataTypes,
 }
 
 impl CompiledInterface {
     pub fn matches_module(&self, module_path: &str) -> bool {
+        if let Some(visibility) = &self.visibility {
+            if !visibility.iter().any(|v| v == module_path) {
+                return false;
+            }
+        }
         self.from_modules
             .iter()
             .any(|regex| regex.is_match(module_path))
@@ -45,6 +51,7 @@ impl<'a> CompiledInterfaces {
                     .iter()
                     .map(|pattern| Regex::new(&format!("^{}$", pattern)).unwrap())
                     .collect(),
+                visibility: interface.visibility.clone(),
             })
             .collect();
 

--- a/src/interfaces/data_types.rs
+++ b/src/interfaces/data_types.rs
@@ -333,6 +333,7 @@ mod tests {
         InterfaceConfig {
             expose: vec![".*".to_string()],
             from_modules: vec!["my_module".to_string()],
+            visibility: None,
             data_types: InterfaceDataTypes::Primitive,
         }
     }

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -71,6 +71,7 @@ fn migrate_strict_mode_to_interfaces(filepath: &Path, config: &mut ProjectConfig
             interfaces.push(InterfaceConfig {
                 expose: interface_members,
                 from_modules: vec![module.path.clone()],
+                visibility: None,
                 data_types: InterfaceDataTypes::All,
             });
         }


### PR DESCRIPTION
Fixes #651 

This PR allows an interface definition to include `visibility`, subject to the same behavior that exists for module dependencies.

An imported member passes interface checks if:
- its definition module has no interface
- there exists an interface for its definition module such that some element in `expose` matches the member path AND `visibility` matches the usage module