### PR TITLE
Support 'exclusive' interfaces

### DIFF
--- a/python/tests/example/many_features/real_src/module1/__init__.py
+++ b/python/tests/example/many_features/real_src/module1/__init__.py
@@ -1,4 +1,4 @@
-from .api import MyApi
+from .api import something
 
 from module3 import content
 

--- a/python/tests/example/many_features/real_src/module1/tach.domain.toml
+++ b/python/tests/example/many_features/real_src/module1/tach.domain.toml
@@ -14,7 +14,7 @@ visibility = ["<domain_root>", "//module5"]
 layer = "mid"
 
 [[interfaces]]
-expose = [".*"]
+expose = ["something"]
 from = ["api"]
 
 [[interfaces]]

--- a/python/tests/example/many_features/real_src/module1/tach.domain.toml
+++ b/python/tests/example/many_features/real_src/module1/tach.domain.toml
@@ -16,12 +16,12 @@ layer = "mid"
 [[interfaces]]
 expose = [".*"]
 from = ["api"]
-visibility = ["<domain_root>"]
 
 [[interfaces]]
 expose = ["MyAPI"]
 from = ["api"]
 visibility = ["//module5"]
+exclusive = true
 
 [[modules]]
 path = "submodule1"

--- a/src/checks/interface.rs
+++ b/src/checks/interface.rs
@@ -66,7 +66,9 @@ impl<'a> InterfaceChecker<'a> {
             return InterfaceCheckResult::TopLevelModule;
         }
 
-        let matching_interfaces = self.interfaces.get_interfaces(definition_module);
+        let matching_interfaces = self
+            .interfaces
+            .get_visible_interfaces(definition_module, usage_module);
 
         if matching_interfaces.is_empty() {
             return InterfaceCheckResult::NoInterfaces;

--- a/src/config/cache.rs
+++ b/src/config/cache.rs
@@ -1,17 +1,13 @@
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use super::utils;
+
 #[derive(Debug, Serialize, Default, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum CacheBackend {
     #[default]
     Disk,
-}
-
-impl CacheBackend {
-    fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
 }
 
 impl IntoPy<PyObject> for CacheBackend {
@@ -25,16 +21,10 @@ impl IntoPy<PyObject> for CacheBackend {
 #[derive(Debug, Serialize, Default, Deserialize, Clone, PartialEq)]
 #[pyclass(get_all, module = "tach.extension")]
 pub struct CacheConfig {
-    #[serde(default, skip_serializing_if = "CacheBackend::is_default")]
+    #[serde(default, skip_serializing_if = "utils::is_default")]
     pub backend: CacheBackend,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub file_dependencies: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub env_dependencies: Vec<String>,
-}
-
-impl CacheConfig {
-    pub fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
 }

--- a/src/config/domain.rs
+++ b/src/config/domain.rs
@@ -1,4 +1,5 @@
 use std::iter;
+use std::ops::Not;
 use std::path::{Path, PathBuf};
 
 use pyo3::prelude::*;
@@ -9,7 +10,6 @@ use crate::filesystem::file_to_module_path;
 use super::edit::{ConfigEdit, ConfigEditor, EditError};
 use super::interfaces::InterfaceConfig;
 use super::modules::{deserialize_modules, serialize_modules, DependencyConfig, ModuleConfig};
-use super::utils::*;
 use crate::parsing::error::ParsingError;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
@@ -23,9 +23,9 @@ pub struct DomainRootConfig {
     pub layer: Option<String>,
     #[serde(default)]
     pub visibility: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     pub utility: bool,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     pub unchecked: bool,
 }
 
@@ -183,7 +183,8 @@ impl Resolvable<InterfaceConfig> for InterfaceConfig {
                 })
                 .collect(),
             visibility: self.visibility.clone().map(|vis| vis.resolve(location)),
-            data_types: self.data_types.clone(),
+            data_types: self.data_types,
+            exclusive: self.exclusive,
         }
     }
 }

--- a/src/config/external.rs
+++ b/src/config/external.rs
@@ -9,9 +9,3 @@ pub struct ExternalDependencyConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rename: Vec<String>,
 }
-
-impl ExternalDependencyConfig {
-    pub fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
-}

--- a/src/config/interfaces.rs
+++ b/src/config/interfaces.rs
@@ -1,9 +1,12 @@
 use std::fmt::Display;
+use std::ops::Not;
 
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Default, Deserialize, Clone, PartialEq)]
+use super::utils;
+
+#[derive(Debug, Serialize, Default, Deserialize, Clone, Copy, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum InterfaceDataTypes {
     #[default]
@@ -17,12 +20,6 @@ impl Display for InterfaceDataTypes {
             Self::All => write!(f, "all"),
             Self::Primitive => write!(f, "primitive"),
         }
-    }
-}
-
-impl InterfaceDataTypes {
-    fn is_default(&self) -> bool {
-        *self == Self::default()
     }
 }
 
@@ -45,8 +42,10 @@ pub struct InterfaceConfig {
     pub from_modules: Vec<String>,
     #[serde(default)]
     pub visibility: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "InterfaceDataTypes::is_default")]
+    #[serde(default, skip_serializing_if = "utils::is_default")]
     pub data_types: InterfaceDataTypes,
+    #[serde(default, skip_serializing_if = "Not::not")]
+    pub exclusive: bool,
 }
 
 fn default_from_modules() -> Vec<String> {

--- a/src/config/modules.rs
+++ b/src/config/modules.rs
@@ -1,18 +1,19 @@
-use crate::filesystem::module_path_is_included_in_paths;
-
-use super::root_module::ROOT_MODULE_SENTINEL_TAG;
-use super::utils::*;
-use crate::resolvers::ModuleGlob;
-use globset::GlobMatcher;
-use pyo3::prelude::*;
-use serde::ser::{Error, SerializeSeq, SerializeStruct};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::hash::{Hash, Hasher};
+use std::ops::Not;
 use std::path::PathBuf;
 use std::{
     collections::{HashMap, HashSet},
     fmt,
 };
+
+use globset::GlobMatcher;
+use pyo3::prelude::*;
+use serde::ser::{Error, SerializeSeq, SerializeStruct};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use super::root_module::ROOT_MODULE_SENTINEL_TAG;
+use crate::filesystem::module_path_is_included_in_paths;
+use crate::resolvers::ModuleGlob;
 
 #[derive(Clone, Debug, Default)]
 #[pyclass(module = "tach.extension")]
@@ -169,7 +170,7 @@ pub struct ModuleConfig {
     #[serde(default)]
     #[pyo3(get)]
     pub visibility: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     #[pyo3(get)]
     pub utility: bool,
     // TODO: Remove this in a future version
@@ -179,7 +180,7 @@ pub struct ModuleConfig {
     #[serde(default, skip_serializing)]
     #[pyo3(get)]
     pub strict: bool,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     #[pyo3(get)]
     pub unchecked: bool,
     // Hidden field to track grouping
@@ -390,9 +391,9 @@ struct BulkModule {
     layer: Option<String>,
     #[serde(default)]
     visibility: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     utility: bool,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     unchecked: bool,
 }
 

--- a/src/config/plugins/all.rs
+++ b/src/config/plugins/all.rs
@@ -9,9 +9,3 @@ pub struct PluginsConfig {
     #[serde(default)]
     pub django: Option<DjangoConfig>,
 }
-
-impl PluginsConfig {
-    pub fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
-}

--- a/src/config/plugins/django.rs
+++ b/src/config/plugins/django.rs
@@ -7,9 +7,3 @@ pub struct DjangoConfig {
     #[serde(default)]
     pub settings_module: String,
 }
-
-impl DjangoConfig {
-    pub fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
-}

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::iter;
+use std::ops::Not;
 use std::path::PathBuf;
 
 use crate::exclusion::PathExclusions;
@@ -17,7 +18,7 @@ use super::modules::{deserialize_modules, serialize_modules, DependencyConfig, M
 use super::plugins::PluginsConfig;
 use super::root_module::RootModuleTreatment;
 use super::rules::RulesConfig;
-use super::utils::*;
+use super::utils;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct PyProjectWrapper {
@@ -49,13 +50,13 @@ pub struct ProjectConfig {
     #[serde(default)]
     #[pyo3(get)]
     pub interfaces: Vec<InterfaceConfig>,
-    #[serde(default, skip_serializing_if = "is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[pyo3(get)]
     pub layers: Vec<String>,
-    #[serde(default, skip_serializing_if = "CacheConfig::is_default")]
+    #[serde(default, skip_serializing_if = "utils::is_default")]
     #[pyo3(get)]
     pub cache: CacheConfig,
-    #[serde(default, skip_serializing_if = "ExternalDependencyConfig::is_default")]
+    #[serde(default, skip_serializing_if = "utils::is_default")]
     #[pyo3(get)]
     pub external: ExternalDependencyConfig,
     #[serde(default)]
@@ -64,31 +65,34 @@ pub struct ProjectConfig {
     #[serde(default = "default_source_roots")]
     #[pyo3(get, set)]
     pub source_roots: Vec<PathBuf>,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     #[pyo3(get)]
     pub exact: bool,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     #[pyo3(get)]
     pub disable_logging: bool,
-    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    #[serde(
+        default = "utils::default_true",
+        skip_serializing_if = "utils::is_true"
+    )]
     #[pyo3(get, set)]
     pub ignore_type_checking_imports: bool,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     #[pyo3(get, set)]
     pub include_string_imports: bool,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     #[pyo3(get)]
     pub forbid_circular_dependencies: bool,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "Not::not")]
     #[pyo3(get, set)]
     pub use_regex_matching: bool,
-    #[serde(default, skip_serializing_if = "RootModuleTreatment::is_default")]
+    #[serde(default, skip_serializing_if = "utils::is_default")]
     #[pyo3(get)]
     pub root_module: RootModuleTreatment,
-    #[serde(default, skip_serializing_if = "RulesConfig::is_default")]
+    #[serde(default, skip_serializing_if = "utils::is_default")]
     #[pyo3(get)]
     pub rules: RulesConfig,
-    #[serde(default, skip_serializing_if = "PluginsConfig::is_default")]
+    #[serde(default, skip_serializing_if = "utils::is_default")]
     #[pyo3(get)]
     pub plugins: PluginsConfig,
     #[serde(skip)]

--- a/src/config/root_module.rs
+++ b/src/config/root_module.rs
@@ -13,12 +13,6 @@ pub enum RootModuleTreatment {
     DependenciesOnly,
 }
 
-impl RootModuleTreatment {
-    pub fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
-}
-
 impl IntoPy<PyObject> for RootModuleTreatment {
     fn into_py(self, py: Python) -> PyObject {
         match self {

--- a/src/config/rules.rs
+++ b/src/config/rules.rs
@@ -75,9 +75,3 @@ impl Default for RulesConfig {
         }
     }
 }
-
-impl RulesConfig {
-    pub fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
-}

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -3,18 +3,10 @@ pub fn default_true() -> bool {
     true
 }
 
-pub fn global_visibility() -> Vec<String> {
-    vec!["*".to_string()]
-}
-
 pub fn is_true(value: &bool) -> bool {
     *value
 }
 
-pub fn is_false(value: &bool) -> bool {
-    !*value
-}
-
-pub fn is_empty<T>(value: &[T]) -> bool {
-    value.is_empty()
+pub fn is_default<T: Default + PartialEq>(value: &T) -> bool {
+    value == &T::default()
 }

--- a/src/interfaces/compiled.rs
+++ b/src/interfaces/compiled.rs
@@ -81,9 +81,16 @@ impl<'a> CompiledInterfaces {
             .any(|interface| interface.should_type_check())
     }
 
-    pub fn get_interfaces(&'a self, module_path: &'a str) -> Vec<&'a CompiledInterface> {
+    pub fn get_visible_interfaces(
+        &'a self,
+        definition_module: &'a str,
+        usage_module: &'a str,
+    ) -> Vec<&'a CompiledInterface> {
         let mut interfaces = Vec::new();
-        for compiled_interface in self.interfaces_for_module(module_path) {
+        for compiled_interface in self
+            .interfaces_for_module(definition_module)
+            .filter(|interface| interface.is_visible_to(usage_module))
+        {
             if compiled_interface.exclusive {
                 // If we encounter an exclusive interface, we return it immediately
                 return vec![compiled_interface];

--- a/src/interfaces/compiled.rs
+++ b/src/interfaces/compiled.rs
@@ -7,6 +7,7 @@ pub struct CompiledInterface {
     pub visibility: Option<Vec<String>>,
     pub expose: Vec<Regex>,
     pub data_types: InterfaceDataTypes,
+    pub exclusive: bool,
 }
 
 impl CompiledInterface {
@@ -30,8 +31,8 @@ impl CompiledInterface {
         self.matches_member(member) && self.is_visible_to(module_path)
     }
 
-    pub fn should_type_check(&self, module_path: &str) -> bool {
-        self.data_types != InterfaceDataTypes::All && self.matches_module(module_path)
+    pub fn should_type_check(&self) -> bool {
+        self.data_types != InterfaceDataTypes::All
     }
 }
 
@@ -45,7 +46,7 @@ impl<'a> CompiledInterfaces {
         let compiled = interfaces
             .into_iter()
             .map(|interface| CompiledInterface {
-                data_types: interface.data_types.clone(),
+                data_types: interface.data_types,
                 from_modules: interface
                     .from_modules
                     .iter()
@@ -57,6 +58,7 @@ impl<'a> CompiledInterfaces {
                     .map(|pattern| Regex::new(&format!("^{}$", pattern)).unwrap())
                     .collect(),
                 visibility: interface.visibility.clone(),
+                exclusive: interface.exclusive,
             })
             .collect();
 
@@ -65,33 +67,47 @@ impl<'a> CompiledInterfaces {
         }
     }
 
-    pub fn should_type_check(&self, module_path: &str) -> bool {
-        self.interfaces
-            .iter()
-            .any(|interface| interface.should_type_check(module_path))
-    }
-
-    pub fn get_interfaces(&self, module_path: &str) -> Vec<&CompiledInterface> {
+    pub fn interfaces_for_module(
+        &'a self,
+        module_path: &'a str,
+    ) -> impl Iterator<Item = &'a CompiledInterface> {
         self.interfaces
             .iter()
             .filter(|interface| interface.matches_module(module_path))
+    }
+
+    pub fn should_type_check(&'a self, module_path: &'a str) -> bool {
+        self.interfaces_for_module(module_path)
+            .any(|interface| interface.should_type_check())
+    }
+
+    pub fn get_interfaces(&'a self, module_path: &'a str) -> Vec<&'a CompiledInterface> {
+        let mut interfaces = Vec::new();
+        for compiled_interface in self.interfaces_for_module(module_path) {
+            if compiled_interface.exclusive {
+                // If we encounter an exclusive interface, we return it immediately
+                return vec![compiled_interface];
+            }
+            interfaces.push(compiled_interface);
+        }
+        interfaces
+    }
+
+    pub fn get_interfaces_to_type_check(
+        &'a self,
+        module_path: &'a str,
+    ) -> Vec<&'a CompiledInterface> {
+        self.interfaces_for_module(module_path)
+            .filter(|interface| interface.should_type_check())
             .collect()
     }
 
-    pub fn get_interfaces_to_type_check(&self, module_path: &str) -> Vec<&CompiledInterface> {
-        self.interfaces
-            .iter()
-            .filter(|interface| interface.should_type_check(module_path))
-            .collect()
-    }
-
-    pub fn get_data_types(&self, module_path: &str, member_name: &str) -> &InterfaceDataTypes {
+    pub fn get_data_types(&self, module_path: &str, member_name: &str) -> InterfaceDataTypes {
         // NOTE: this takes the first matching interface,
         //   however, if multiple interfaces match, we need to establish a precedence order
-        self.get_interfaces(module_path)
-            .iter()
+        self.interfaces_for_module(module_path)
             .find(|interface| interface.matches_member(member_name))
-            .map(|interface| &interface.data_types)
-            .unwrap_or(&InterfaceDataTypes::All)
+            .map(|interface| interface.data_types)
+            .unwrap_or(InterfaceDataTypes::All)
     }
 }

--- a/src/interfaces/data_types.rs
+++ b/src/interfaces/data_types.rs
@@ -222,22 +222,16 @@ impl DataTypeChecker for InterfaceDataTypes {
         return_type: &Option<String>,
     ) -> TypeCheckResult {
         match self {
-            InterfaceDataTypes::All => TypeCheckResult::MatchedInterface {
-                expected: self.clone(),
-            },
+            InterfaceDataTypes::All => TypeCheckResult::MatchedInterface { expected: *self },
             InterfaceDataTypes::Primitive => {
                 if parameters
                     .iter()
                     .all(|p| is_primitive_type(p.annotation.as_deref().unwrap_or("")))
                     && return_type.as_ref().is_some_and(|t| is_primitive_type(t))
                 {
-                    TypeCheckResult::MatchedInterface {
-                        expected: self.clone(),
-                    }
+                    TypeCheckResult::MatchedInterface { expected: *self }
                 } else {
-                    TypeCheckResult::DidNotMatchInterface {
-                        expected: self.clone(),
-                    }
+                    TypeCheckResult::DidNotMatchInterface { expected: *self }
                 }
             }
         }
@@ -245,18 +239,12 @@ impl DataTypeChecker for InterfaceDataTypes {
 
     fn type_check_variable(&self, annotation: &Option<String>) -> TypeCheckResult {
         match self {
-            InterfaceDataTypes::All => TypeCheckResult::MatchedInterface {
-                expected: self.clone(),
-            },
+            InterfaceDataTypes::All => TypeCheckResult::MatchedInterface { expected: *self },
             InterfaceDataTypes::Primitive => {
                 if is_primitive_type(annotation.as_deref().unwrap_or("")) {
-                    TypeCheckResult::MatchedInterface {
-                        expected: self.clone(),
-                    }
+                    TypeCheckResult::MatchedInterface { expected: *self }
                 } else {
-                    TypeCheckResult::DidNotMatchInterface {
-                        expected: self.clone(),
-                    }
+                    TypeCheckResult::DidNotMatchInterface { expected: *self }
                 }
             }
         }
@@ -269,7 +257,7 @@ impl DataTypeChecker for InterfaceDataTypes {
 
 pub fn type_check_interface_member(
     interface_member: &InterfaceMember,
-    data_types: &InterfaceDataTypes,
+    data_types: InterfaceDataTypes,
 ) -> TypeCheckResult {
     // NOTE: will need more parameters/state to do this for most cases
     match &interface_member.node {
@@ -335,6 +323,7 @@ mod tests {
             from_modules: vec!["my_module".to_string()],
             visibility: None,
             data_types: InterfaceDataTypes::Primitive,
+            exclusive: false,
         }
     }
 

--- a/src/parsing/config.rs
+++ b/src/parsing/config.rs
@@ -73,6 +73,7 @@ fn migrate_strict_mode_to_interfaces(filepath: &Path, config: &mut ProjectConfig
                 from_modules: vec![module.path.clone()],
                 visibility: None,
                 data_types: InterfaceDataTypes::All,
+                exclusive: false,
             });
         }
     }


### PR DESCRIPTION
Now that interfaces can be 'split' using `visibility`, it is useful to be able to say that a given interface is the 'exclusive' way that a module is allowed to be used by another module.

For example, consider the following config within a `tach.domain.toml`:

```toml
[[modules]]
path = "api"
depends_on = ["**"]
visibility = ["<domain_root>", "//module5"]
layer = "mid"

[[interfaces]]
expose = ["something"]
from = ["api"]

[[interfaces]]
expose = ["MyAPI"]
from = ["api"]
visibility = ["//module5"]
exclusive = true
```

Given the configuration above, the 'default' interface exposed by `api` is `api.something`.
However, `module5` may only use `api.MyAPI`.

Before this PR, and without the `exclusive` flag, this would not have been possible. In that case, `module5` would have been allowed to use both `api.something` and `api.MyAPI`.