### PR TITLE
Fix ignore directives not emitting diagnostics in some cases

### DIFF
--- a/python/tests/example/many_features/other_src_root/module1/api.py
+++ b/python/tests/example/many_features/other_src_root/module1/api.py
@@ -1,5 +1,4 @@
-# tach-ignore
-from module1.submodule1.api import Api
+from module1.submodule1.api import Api  # tach-ignore
 
 from module1.submodule1.api import OtherApi
 

--- a/src/diagnostics/diagnostics.rs
+++ b/src/diagnostics/diagnostics.rs
@@ -152,6 +152,14 @@ pub enum CodeDiagnostic {
 }
 
 impl CodeDiagnostic {
+    pub fn is_ignore_directive_related(&self) -> bool {
+        matches!(
+            self,
+            CodeDiagnostic::UnusedIgnoreDirective()
+                | CodeDiagnostic::MissingIgnoreDirectiveReason()
+        )
+    }
+
     pub fn dependency(&self) -> Option<&str> {
         match self {
             CodeDiagnostic::PrivateDependency { dependency, .. }
@@ -367,6 +375,13 @@ impl Diagnostic {
                 original_line_number,
                 ..
             } => *original_line_number,
+        }
+    }
+
+    pub fn is_ignore_directive_related(&self) -> bool {
+        match self.details() {
+            DiagnosticDetails::Code(details) => details.is_ignore_directive_related(),
+            _ => false,
         }
     }
 

--- a/src/processors/ignore_directive.rs
+++ b/src/processors/ignore_directive.rs
@@ -41,6 +41,11 @@ impl IgnoreDirective {
             return false;
         }
 
+        // If the diagnostic is related to an ignore directive, it should never be matched
+        if diagnostic.is_ignore_directive_related() {
+            return false;
+        }
+
         // If the directive is a blanket ignore, it matches any diagnostic
         if self.modules.is_empty() {
             return true;


### PR DESCRIPTION
Due to the interaction of a few different features, a same-line `tach-ignore` comment _without_ a reason may have incorrectly skipped diagnostics, even when it was unused.

Essentially the issue was:
- `tach-ignore` comment is added without a reason, causing a diagnostic if the `require_ignore_directive_reasons` rule is on
- we check if the ignore comment is additionally unused (due to `unused_ignore_directives`) -- by scanning through diagnostics to see if any 'match' the ignore comment
- the ignore comment 'matches' its own diagnostic, thereby both removing the 'reason' diagnostic and avoiding an 'unused' diagnostic

This PR simply updates the match logic to never match diagnostics related to ignore comments.