### PR TITLE
Add rule for `'local_imports'`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ profile.json
 
 # Rust
 .cargo/
+
+# Cursor
+.cursorrules

--- a/public/tach-toml-schema.json
+++ b/public/tach-toml-schema.json
@@ -324,6 +324,12 @@
           "enum": ["error", "warn", "off"],
           "default": "error",
           "description": "How to handle unused external dependencies"
+        },
+        "local_imports": {
+          "type": "string",
+          "enum": ["error", "warn", "off"],
+          "default": "error",
+          "description": "How to handle imports that are not at the global scope (e.g. within a function, class, or control structure)"
         }
       },
       "additionalProperties": false

--- a/python/tests/example/many_features/real_src/module1/local_imports.py
+++ b/python/tests/example/many_features/real_src/module1/local_imports.py
@@ -1,0 +1,7 @@
+def do_something():
+    from . import api
+    from .submodule import helper
+    from ..module2 import service
+    api.call()
+    helper.help()
+    service.serve() 

--- a/python/tests/example/many_features/tach.toml
+++ b/python/tests/example/many_features/tach.toml
@@ -37,6 +37,7 @@ layer = "hightest"
 [rules]
 unused_ignore_directives = "error"
 require_ignore_directive_reasons = "warn"
+local_imports = "off"
 
 [plugins.django]
 settings_module = "django_settings"

--- a/src/checks/external_dependency.rs
+++ b/src/checks/external_dependency.rs
@@ -60,6 +60,7 @@ impl<'a> ExternalDependencyChecker<'a> {
                         diagnostic,
                         processed_file.relative_file_path().to_path_buf(),
                         processed_file.line_number(import.alias_offset()),
+                        Some(processed_file.line_number(import.import_offset())),
                     ));
                 }
                 return None;
@@ -93,6 +94,7 @@ impl<'a> ExternalDependencyChecker<'a> {
                         diagnostic,
                         processed_file.relative_file_path().to_path_buf(),
                         processed_file.line_number(import.alias_offset()),
+                        Some(processed_file.line_number(import.import_offset())),
                     ));
                 }
                 return None;
@@ -150,6 +152,7 @@ impl<'a> ExternalDependencyChecker<'a> {
                         diagnostic,
                         processed_file.relative_file_path().to_path_buf(),
                         processed_file.line_number(import.alias_offset()),
+                        Some(processed_file.line_number(import.import_offset())),
                     ));
                 }
                 return None;

--- a/src/checks/ignore_directive.rs
+++ b/src/checks/ignore_directive.rs
@@ -25,6 +25,7 @@ impl<'a> IgnoreDirectivePostProcessor<'a> {
             DiagnosticDetails::Code(CodeDiagnostic::UnusedIgnoreDirective()),
             relative_file_path.to_path_buf(),
             ignore_directive.line_no,
+            None,
         )
     }
 
@@ -79,6 +80,7 @@ impl<'a> IgnoreDirectivePostProcessor<'a> {
                 DiagnosticDetails::Code(CodeDiagnostic::MissingIgnoreDirectiveReason()),
                 relative_file_path.to_path_buf(),
                 ignore_directive.line_no,
+                None,
             ))
         } else {
             None

--- a/src/checks/internal_dependency.rs
+++ b/src/checks/internal_dependency.rs
@@ -128,6 +128,9 @@ impl<'a> InternalDependencyChecker<'a> {
                                 e.details().clone(),
                                 relative_file_path.to_path_buf(),
                                 file_module.line_number(dependency.offset()),
+                                dependency
+                                    .original_line_offset()
+                                    .map(|offset| file_module.line_number(offset)),
                             )]);
                         }
                         return Ok(vec![]);
@@ -159,6 +162,9 @@ impl<'a> InternalDependencyChecker<'a> {
                             diagnostic,
                             relative_file_path.to_path_buf(),
                             file_module.line_number(dependency.offset()),
+                            dependency
+                                .original_line_offset()
+                                .map(|offset| file_module.line_number(offset)),
                         )]);
                     }
                     return Ok(vec![]);
@@ -205,6 +211,9 @@ impl<'a> InternalDependencyChecker<'a> {
                                 diagnostic,
                                 relative_file_path.to_path_buf(),
                                 file_module.line_number(dependency.offset()),
+                                dependency
+                                    .original_line_offset()
+                                    .map(|offset| file_module.line_number(offset)),
                             )]);
                         }
                         return Ok(vec![]);
@@ -237,6 +246,9 @@ impl<'a> InternalDependencyChecker<'a> {
                                 diagnostic,
                                 relative_file_path.to_path_buf(),
                                 file_module.line_number(dependency.offset()),
+                                dependency
+                                    .original_line_offset()
+                                    .map(|offset| file_module.line_number(offset)),
                             )]);
                         }
                         return Ok(vec![]);

--- a/src/checks/internal_dependency.rs
+++ b/src/checks/internal_dependency.rs
@@ -8,15 +8,21 @@ use crate::{
     modules::ModuleTree,
     processors::FileModule,
 };
-use std::path::Path;
 
 #[derive(Debug)]
 enum LayerCheckResult {
     Ok,
     SameLayer,
     LayerNotSpecified,
-    LayerViolation(Diagnostic),
-    UnknownLayer(Diagnostic),
+    LayerViolation {
+        source_layer: String,
+        source_module: String,
+        target_layer: String,
+        target_module: String,
+    },
+    UnknownLayer {
+        unknown_layer: String,
+    },
 }
 
 pub struct InternalDependencyChecker<'a> {
@@ -34,12 +40,9 @@ impl<'a> InternalDependencyChecker<'a> {
 
     fn check_layers(
         &self,
-        file_module: &FileModule,
-        dependency: &Dependency,
         layers: &[String],
         source_module_config: &ModuleConfig,
         target_module_config: &ModuleConfig,
-        relative_file_path: &Path,
     ) -> LayerCheckResult {
         match (&source_module_config.layer, &target_module_config.layer) {
             (Some(source_layer), Some(target_layer)) => {
@@ -53,42 +56,21 @@ impl<'a> InternalDependencyChecker<'a> {
                         } else if source_index < target_index {
                             LayerCheckResult::Ok
                         } else {
-                            LayerCheckResult::LayerViolation(Diagnostic::new_located_error(
-                                relative_file_path.to_path_buf(),
-                                file_module.line_number(dependency.offset()),
-                                dependency
-                                    .original_line_offset()
-                                    .map(|offset| file_module.line_number(offset)),
-                                DiagnosticDetails::Code(CodeDiagnostic::LayerViolation {
-                                    dependency: dependency.module_path().to_string(),
-                                    usage_module: source_module_config.path.clone(),
-                                    usage_layer: source_layer.clone(),
-                                    definition_module: target_module_config.path.clone(),
-                                    definition_layer: target_layer.clone(),
-                                }),
-                            ))
+                            LayerCheckResult::LayerViolation {
+                                source_layer: source_layer.clone(),
+                                source_module: source_module_config.path.clone(),
+                                target_layer: target_layer.clone(),
+                                target_module: target_module_config.path.clone(),
+                            }
                         }
                     }
                     // If either index is not found, the layer is unknown
-                    (Some(_), None) => LayerCheckResult::UnknownLayer(
-                        Diagnostic::new_global_error(DiagnosticDetails::Configuration(
-                            ConfigurationDiagnostic::UnknownLayer {
-                                layer: target_layer.clone(),
-                            },
-                        )),
-                    ),
-                    (None, Some(_)) => LayerCheckResult::UnknownLayer(
-                        Diagnostic::new_global_error(DiagnosticDetails::Configuration(
-                            ConfigurationDiagnostic::UnknownLayer {
-                                layer: source_layer.clone(),
-                            },
-                        )),
-                    ),
-                    _ => LayerCheckResult::UnknownLayer(Diagnostic::new_global_error(
-                        DiagnosticDetails::Configuration(ConfigurationDiagnostic::UnknownLayer {
-                            layer: source_layer.clone(),
-                        }),
-                    )),
+                    (Some(_), None) => LayerCheckResult::UnknownLayer {
+                        unknown_layer: target_layer.clone(),
+                    },
+                    (None, Some(_)) | (None, None) => LayerCheckResult::UnknownLayer {
+                        unknown_layer: source_layer.clone(),
+                    },
                 }
             }
             _ => LayerCheckResult::LayerNotSpecified, // At least one module does not have a layer
@@ -109,23 +91,29 @@ impl<'a> InternalDependencyChecker<'a> {
 
         let relative_file_path = file_module.relative_file_path();
         // Layer check should take precedence over other depends_on checks
-        match self.check_layers(
-            file_module,
-            dependency,
-            layers,
-            file_module_config,
-            dependency_module_config,
-            relative_file_path,
-        ) {
+        match self.check_layers(layers, file_module_config, dependency_module_config) {
             LayerCheckResult::Ok => return Ok(vec![]), // Higher layers can unconditionally import lower layers
-            LayerCheckResult::LayerViolation(e) | LayerCheckResult::UnknownLayer(e) => {
+            LayerCheckResult::LayerViolation {
+                source_layer,
+                source_module,
+                target_layer,
+                target_module,
+            } => {
+                let details = DiagnosticDetails::Code(CodeDiagnostic::LayerViolation {
+                    dependency: dependency.module_path().to_string(),
+                    usage_module: source_module,
+                    usage_layer: source_layer,
+                    definition_module: target_module,
+                    definition_layer: target_layer,
+                });
+
                 if let Dependency::Import(import) = dependency {
                     if !import.is_global_scope {
                         if let Ok(severity) = (&self.project_config.rules.local_imports).try_into()
                         {
                             return Ok(vec![Diagnostic::new_located(
                                 severity,
-                                e.details().clone(),
+                                details,
                                 relative_file_path.to_path_buf(),
                                 file_module.line_number(dependency.offset()),
                                 dependency
@@ -136,7 +124,33 @@ impl<'a> InternalDependencyChecker<'a> {
                         return Ok(vec![]);
                     }
                 }
-                return Ok(vec![e]);
+
+                return Ok(vec![Diagnostic::new_located_error(
+                    relative_file_path.to_path_buf(),
+                    file_module.line_number(dependency.offset()),
+                    dependency
+                        .original_line_offset()
+                        .map(|offset| file_module.line_number(offset)),
+                    details,
+                )]);
+            }
+            LayerCheckResult::UnknownLayer { unknown_layer } => {
+                let details =
+                    DiagnosticDetails::Configuration(ConfigurationDiagnostic::UnknownLayer {
+                        layer: unknown_layer,
+                    });
+
+                if let Dependency::Import(import) = dependency {
+                    if !import.is_global_scope {
+                        if let Ok(severity) = (&self.project_config.rules.local_imports).try_into()
+                        {
+                            return Ok(vec![Diagnostic::new_global(severity, details)]);
+                        }
+                        return Ok(vec![]);
+                    }
+                }
+
+                return Ok(vec![Diagnostic::new_global_error(details)]);
             }
             LayerCheckResult::SameLayer | LayerCheckResult::LayerNotSpecified => (), // We need to do further processing to determine if the dependency is allowed
         };

--- a/src/commands/check/check_external.rs
+++ b/src/commands/check/check_external.rs
@@ -55,10 +55,11 @@ impl<'a> CheckExternalPipeline<'a> {
                 package_resolver,
             ),
             dependency_checker: ExternalDependencyChecker::new(
-                package_resolver,
+                project_config,
                 module_mappings,
                 stdlib_modules,
                 excluded_external_modules,
+                package_resolver,
             ),
             ignore_directive_post_processor: IgnoreDirectivePostProcessor::new(project_config),
         }

--- a/src/config/rules.rs
+++ b/src/config/rules.rs
@@ -64,6 +64,11 @@ pub struct RulesConfig {
         skip_serializing_if = "RuleSetting::is_error"
     )]
     pub unused_external_dependencies: RuleSetting,
+    #[serde(
+        default = "RuleSetting::error",
+        skip_serializing_if = "RuleSetting::is_error"
+    )]
+    pub local_imports: RuleSetting,
 }
 
 impl Default for RulesConfig {
@@ -72,6 +77,7 @@ impl Default for RulesConfig {
             unused_ignore_directives: RuleSetting::warn(),
             require_ignore_directive_reasons: RuleSetting::off(),
             unused_external_dependencies: RuleSetting::error(),
+            local_imports: RuleSetting::error(),
         }
     }
 }

--- a/src/dependencies/import.rs
+++ b/src/dependencies/import.rs
@@ -87,6 +87,10 @@ impl ExternalImportWithDistributionNames<'_> {
         self.import.import_offset
     }
 
+    pub fn is_global_scope(&self) -> bool {
+        self.import.is_global_scope
+    }
+
     pub fn distribution_names(&self) -> &Vec<String> {
         &self.distribution_names
     }

--- a/src/dependencies/import.rs
+++ b/src/dependencies/import.rs
@@ -15,6 +15,7 @@ pub struct NormalizedImport {
     pub import_offset: TextSize,    // Source location of the import statement
     pub alias_offset: TextSize,     // Source location of the alias
     pub is_absolute: bool,          // Whether the import is absolute
+    pub is_global_scope: bool,      // Whether the import is at the global scope
 }
 
 impl NormalizedImport {
@@ -66,10 +67,6 @@ impl LocatedImport {
         self.import.is_absolute
     }
 }
-
-pub struct AllImports;
-pub struct ProjectImports;
-pub struct ExternalImports;
 
 #[derive(Debug)]
 pub struct ExternalImportWithDistributionNames<'a> {

--- a/src/diagnostics/diagnostics.rs
+++ b/src/diagnostics/diagnostics.rs
@@ -282,13 +282,14 @@ impl Diagnostic {
         details: DiagnosticDetails,
         file_path: PathBuf,
         line_number: usize,
+        original_line_number: Option<usize>,
     ) -> Self {
         Self::Located {
             severity,
             details,
             file_path,
             line_number,
-            original_line_number: None,
+            original_line_number,
         }
     }
 

--- a/src/processors/import.rs
+++ b/src/processors/import.rs
@@ -32,6 +32,7 @@ pub struct ImportVisitor {
     is_package: bool,
     ignore_type_checking_imports: bool,
     pub normalized_imports: Vec<NormalizedImport>,
+    depth: usize,
 }
 
 impl ImportVisitor {
@@ -45,6 +46,7 @@ impl ImportVisitor {
             is_package,
             ignore_type_checking_imports,
             normalized_imports: Default::default(),
+            depth: 0,
         }
     }
 
@@ -61,6 +63,7 @@ impl ImportVisitor {
                 alias_offset: alias.range.start(),
                 import_offset: import_statement.range.start(),
                 is_absolute: true,
+                is_global_scope: self.depth == 0,
             };
             normalized_imports.push(import);
         }
@@ -131,6 +134,7 @@ impl ImportVisitor {
                 alias_offset: name.range.start(),
                 import_offset: import_statement.range.start(),
                 is_absolute: false,
+                is_global_scope: self.depth == 0,
             };
 
             normalized_imports.push(import);
@@ -167,9 +171,21 @@ impl StatementVisitor<'_> for ImportVisitor {
             Stmt::Import(statement) => self.visit_stmt_import(statement),
             Stmt::ImportFrom(statement) => self.visit_stmt_import_from(statement),
             Stmt::If(statement) => {
+                self.depth += 1;
                 if !self.should_ignore_if_statement(statement) {
                     walk_stmt(self, stmt)
                 }
+                self.depth -= 1;
+            }
+            Stmt::FunctionDef(_)
+            | Stmt::ClassDef(_)
+            | Stmt::With(_)
+            | Stmt::For(_)
+            | Stmt::While(_)
+            | Stmt::Try(_) => {
+                self.depth += 1;
+                walk_stmt(self, stmt);
+                self.depth -= 1;
             }
             _ => walk_stmt(self, stmt),
         }
@@ -206,6 +222,7 @@ impl Visitor<'_> for StringImportVisitor<'_> {
                 alias_offset: string_literal.range.start(),
                 import_offset: string_literal.range.start(),
                 is_absolute: true,
+                is_global_scope: true, // Treating string imports as global scope unconditionally
             });
         }
     }
@@ -270,4 +287,338 @@ pub fn get_normalized_imports<P: AsRef<Path>>(
         ignore_type_checking_imports,
         include_string_imports,
     )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::fs;
+
+    use rstest::{fixture, rstest};
+    use tempfile::TempDir;
+
+    use crate::processors::import::get_normalized_imports;
+
+    #[fixture]
+    fn temp_project() -> TempDir {
+        TempDir::new().unwrap()
+    }
+
+    fn create_file(root: &Path, path: &str, content: &str) {
+        if let Some(parent) = Path::new(path).parent() {
+            fs::create_dir_all(root.join(parent)).unwrap();
+        }
+        fs::write(root.join(path), content).unwrap();
+    }
+
+    #[rstest]
+    fn test_basic_imports(temp_project: TempDir) {
+        let root = temp_project.path();
+        let content = r#"
+import os
+from local.module import function
+from another.module import Class as AliasedClass
+"#;
+        create_file(root, "test_file.py", content);
+
+        let source_roots = vec![root.to_path_buf()];
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("test_file.py"),
+            content,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 3);
+        assert!(result.iter().any(|import| import.module_path == "os"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "local.module.function"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "another.module.Class"));
+    }
+
+    #[rstest]
+    fn test_type_checking_imports(temp_project: TempDir) {
+        let root = temp_project.path();
+        let content = r#"
+from typing import List
+if TYPE_CHECKING:
+    from local.module import TypeClass
+    from another.module import Interface
+
+from actual.module import RealClass
+"#;
+        create_file(root, "test_file.py", content);
+
+        // Test with type checking imports ignored
+        let source_roots = vec![root.to_path_buf()];
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("test_file.py"),
+            content,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "typing.List"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "actual.module.RealClass"));
+
+        // Test with type checking imports included
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("test_file.py"),
+            content,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 4);
+
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "typing.List"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "local.module.TypeClass"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "another.module.Interface"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "actual.module.RealClass"));
+    }
+
+    #[rstest]
+    fn test_relative_imports(temp_project: TempDir) {
+        let root = temp_project.path();
+
+        // Create package structure
+        create_file(root, "package/__init__.py", "");
+        create_file(root, "package/submodule/__init__.py", "");
+
+        let content = r#"
+from . import sibling
+from .. import parent
+from .other import child
+"#;
+        create_file(root, "package/submodule/module.py", content);
+
+        let source_roots = vec![root.to_path_buf()];
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("package/submodule/module.py"),
+            content,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 3);
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "package.submodule.sibling"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "package.parent"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "package.submodule.other.child"));
+    }
+
+    #[rstest]
+    fn test_string_imports(temp_project: TempDir) {
+        let root = temp_project.path();
+        let content = r#"
+MODULES = [
+    "package.module.submodule",
+    "another.module.function",
+]
+"#;
+        create_file(root, "package/module/submodule.py", "");
+        create_file(root, "another/module/function.py", "");
+        create_file(root, "test_file.py", content);
+
+        // Test without string imports
+        let source_roots = vec![root.to_path_buf()];
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("test_file.py"),
+            content,
+            true,
+            false,
+        )
+        .unwrap();
+        assert_eq!(result.len(), 0);
+
+        // Test with string imports
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("test_file.py"),
+            content,
+            true,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "package.module.submodule"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "another.module.function"));
+    }
+
+    #[rstest]
+    fn test_multiple_source_roots(temp_project: TempDir) {
+        let root = temp_project.path();
+
+        // Create two source roots with their own packages
+        create_file(root, "src1/package1/__init__.py", "");
+        create_file(root, "src2/package2/__init__.py", "");
+
+        let content = r#"
+from package1 import module1
+from package2 import module2
+"#;
+        create_file(root, "src1/main.py", content);
+
+        let source_roots = vec![root.join("src1"), root.join("src2")];
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("src1/main.py"),
+            content,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "package1.module1"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "package2.module2"));
+    }
+
+    #[rstest]
+    fn test_init_file_imports(temp_project: TempDir) {
+        let root = temp_project.path();
+
+        create_file(
+            root,
+            "package/__init__.py",
+            r#"
+from .module1 import func1
+from .module2 import func2
+"#,
+        );
+        create_file(root, "package/module1.py", "");
+        create_file(root, "package/module2.py", "");
+
+        let content = fs::read_to_string(root.join("package/__init__.py")).unwrap();
+        let source_roots = vec![root.to_path_buf()];
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("package/__init__.py"),
+            &content,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "package.module1.func1"));
+        assert!(result
+            .iter()
+            .any(|import| import.module_path == "package.module2.func2"));
+    }
+
+    #[rstest]
+    fn test_import_scopes(temp_project: TempDir) {
+        let root = temp_project.path();
+        let content = r#"
+import os
+from sys import path
+
+def function():
+    import datetime
+    if False:
+        from json import loads
+
+class MyClass:
+    import re
+    from math import sqrt
+
+    def another_function():
+        import random
+        from itertools import chain
+
+if True:
+    import random
+    from itertools import chain
+"#;
+        create_file(root, "test_file.py", content);
+
+        let source_roots = vec![root.to_path_buf()];
+        let result = get_normalized_imports(
+            &source_roots,
+            root.join("test_file.py"),
+            content,
+            true,
+            false,
+        )
+        .unwrap();
+
+        // Check global scope imports
+        let global_imports: Vec<_> = result
+            .iter()
+            .filter(|import| import.is_global_scope)
+            .collect();
+        assert_eq!(global_imports.len(), 2);
+        assert!(global_imports
+            .iter()
+            .any(|import| import.module_path == "os"));
+        assert!(global_imports
+            .iter()
+            .any(|import| import.module_path == "sys.path"));
+
+        // Check non-global scope imports
+        let non_global_imports: Vec<_> = result
+            .iter()
+            .filter(|import| !import.is_global_scope)
+            .collect();
+        assert_eq!(non_global_imports.len(), 8);
+        assert!(non_global_imports
+            .iter()
+            .any(|import| import.module_path == "datetime"));
+        assert!(non_global_imports
+            .iter()
+            .any(|import| import.module_path == "json.loads"));
+        assert!(non_global_imports
+            .iter()
+            .any(|import| import.module_path == "re"));
+        assert!(non_global_imports
+            .iter()
+            .any(|import| import.module_path == "math.sqrt"));
+        assert!(non_global_imports
+            .iter()
+            .any(|import| import.module_path == "random"));
+        assert!(non_global_imports
+            .iter()
+            .any(|import| import.module_path == "itertools.chain"));
+    }
 }


### PR DESCRIPTION
Fixes: #599 

This PR adds a 'rule' configuration option called `rules.local_imports`. It can be set as usual:

```toml
[rules]
local_imports = "error"  # | "warn" | "off"
```

This rule applies to any Diagnostic that would have been emitted due to an import which is not at the global scope. This includes imports within 'if' statements, functions, classes, or other control structures.

```python
def fun():
    # this is a local import
    from mymodule import api
    api()
```

The default setting is `"error"`, since today local imports are treated identically to global imports and will produce dependency/interface errors.

Setting `local_imports = "off"` means that you will no longer see Diagnostics for local imports, even when they violate dependency rules or public interfaces.