### PR TITLE
Simplify diagnostic filepath format

### DIFF
--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -566,9 +566,7 @@ def tach_check(
 
         if diagnostics:
             print(
-                extension.format_diagnostics(
-                    project_root=project_root, diagnostics=diagnostics
-                ),
+                extension.format_diagnostics(diagnostics=diagnostics),
                 file=sys.stderr,
             )
         exit_code = 1 if has_errors else 0
@@ -620,9 +618,7 @@ def tach_check_external(
         )
         if diagnostics:
             print(
-                extension.format_diagnostics(
-                    project_root=project_root, diagnostics=diagnostics
-                ),
+                extension.format_diagnostics(diagnostics=diagnostics),
                 file=sys.stderr,
             )
 

--- a/python/tach/extension.pyi
+++ b/python/tach/extension.pyi
@@ -57,10 +57,7 @@ def check_external_dependencies(
     project_root: Path,
     project_config: ProjectConfig,
 ) -> list[Diagnostic]: ...
-def format_diagnostics(
-    project_root: Path,
-    diagnostics: list[Diagnostic],
-) -> str: ...
+def format_diagnostics(diagnostics: list[Diagnostic]) -> str: ...
 def detect_unused_dependencies(
     project_root: Path,
     project_config: ProjectConfig,

--- a/python/tach/report.py
+++ b/python/tach/report.py
@@ -68,11 +68,11 @@ class ExternalDependency:
 
 
 def render_external_dependency(
-    dependency: ExternalDependency, display_path: Path
+    dependency: ExternalDependency,
+    project_root: Path,
 ) -> str:
     clickable_link = create_clickable_link(
-        file_path=dependency.absolute_file_path,
-        display_path=display_path,
+        file_path=dependency.absolute_file_path.relative_to(project_root),
         line=dependency.import_line_number,
     )
     import_info = f"Import '{dependency.import_module_path}' from package '{dependency.package_name}'"
@@ -83,7 +83,10 @@ def render_external_dependency(
 
 
 def render_external_dependency_report(
-    path: Path, dependencies: list[ExternalDependency], raw: bool = False
+    project_root: Path,
+    path: Path,
+    dependencies: list[ExternalDependency],
+    raw: bool = False,
 ) -> str:
     if not dependencies:
         if raw:
@@ -107,10 +110,7 @@ def render_external_dependency_report(
 
     for dependency in dependencies:
         lines.append(
-            render_external_dependency(
-                dependency=dependency,
-                display_path=dependency.absolute_file_path.relative_to(Path.cwd()),
-            )
+            render_external_dependency(dependency=dependency, project_root=project_root)
         )
 
     return "\n".join(lines)
@@ -180,7 +180,12 @@ def external_dependency_report(
             excluded_modules=set(project_config.external.exclude),
             project_config=project_config,
         )
-        return render_external_dependency_report(path, external_dependencies, raw=raw)
+        return render_external_dependency_report(
+            project_root=project_root,
+            path=path,
+            dependencies=external_dependencies,
+            raw=raw,
+        )
 
     all_external_dependencies: list[ExternalDependency] = []
     for pyfile in walk_pyfiles(
@@ -196,7 +201,12 @@ def external_dependency_report(
             )
         )
 
-    return render_external_dependency_report(path, all_external_dependencies, raw=raw)
+    return render_external_dependency_report(
+        project_root=project_root,
+        path=path,
+        dependencies=all_external_dependencies,
+        raw=raw,
+    )
 
 
 __all__ = ["report", "external_dependency_report"]

--- a/python/tach/utils/display.py
+++ b/python/tach/utils/display.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import os
 import sys
-from enum import Enum
-from functools import lru_cache
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -32,53 +29,7 @@ def colorize(text: str, color_start: str, color_end: str = BCOLORS.ENDC) -> str:
     return text
 
 
-class TerminalEnvironment(Enum):
-    UNKNOWN = 1
-    JETBRAINS = 2
-    VSCODE = 3
-
-
-@lru_cache(maxsize=None)
-def detect_environment() -> TerminalEnvironment:
-    if "jetbrains" in os.environ.get("TERMINAL_EMULATOR", "").lower():
-        return TerminalEnvironment.JETBRAINS
-    elif "vscode" in os.environ.get("TERM_PROGRAM", "").lower():
-        return TerminalEnvironment.VSCODE
-    return TerminalEnvironment.UNKNOWN
-
-
-def render_path_simple(file_path: Path, line: int | None = None) -> str:
+def create_clickable_link(file_path: Path, line: int | None = None) -> str:
     if line is not None:
-        return f"{file_path}[L{line}]"
+        return f"{file_path}:{line}"
     return str(file_path)
-
-
-def create_clickable_link(
-    file_path: Path, display_path: Path | None = None, line: int | None = None
-) -> str:
-    if not is_interactive():
-        return render_path_simple(file_path, line)
-
-    terminal_env = detect_environment()
-    abs_path = file_path.resolve()
-
-    if terminal_env == TerminalEnvironment.JETBRAINS:
-        link = f"file://{abs_path}:{line}" if line is not None else f"file://{abs_path}"
-    elif terminal_env == TerminalEnvironment.VSCODE:
-        link = (
-            f"vscode://file/{abs_path}:{line}"
-            if line is not None
-            else f"vscode://file/{abs_path}"
-        )
-    else:
-        # For generic terminals, use a standard file link
-        link = f"file://{abs_path}"
-
-    # ANSI escape codes for clickable link
-    if line:
-        # Show the line number if we have it
-        display_file_path = f"{display_path or file_path}[L{line}]"
-    else:
-        display_file_path = str(display_path) if display_path else str(file_path)
-    clickable_link = f"\033]8;;{link}\033\\{display_file_path}\033]8;;\033\\"
-    return clickable_link

--- a/python/tests/test_check.py
+++ b/python/tests/test_check.py
@@ -281,15 +281,13 @@ def test_many_features_example_dir(example_dir, capfd):
         ("[WARN]", "real_src/main.py", "ignore directive", "missing a reason"),
         (
             "[FAIL]",
-            "other_src_root/module4/service.py",
-            "L6",
+            "other_src_root/module4/service.py:6",
             "ignore directive",
             "unused",
         ),
         (
             "[FAIL]",
-            "other_src_root/module4/service.py",
-            "L12",
+            "other_src_root/module4/service.py:12",
             "ignore directive",
             "unused",
         ),
@@ -350,8 +348,7 @@ def test_many_features_example_dir(example_dir, capfd):
         ),
         (
             "[FAIL]",
-            "real_src/module1/controller.py",
-            "L5",
+            "real_src/module1/controller.py:5",
             "'hightest'",
             "lower than",
             "'low'",
@@ -359,8 +356,7 @@ def test_many_features_example_dir(example_dir, capfd):
         ),
         (
             "[FAIL]",
-            "real_src/module1/controller.py",
-            "L6",
+            "real_src/module1/controller.py:6",
             "'hightest'",
             "lower than",
             "'low'",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,50 +1,9 @@
-use std::env;
 use std::path::Path;
 
 use console::Term;
 
-#[derive(Debug, PartialEq, Eq)]
-enum TerminalEnvironment {
-    Unknown,
-    JetBrains,
-    VSCode,
-}
-
-fn detect_environment() -> TerminalEnvironment {
-    let terminal_emulator = env::var("TERMINAL_EMULATOR")
-        .unwrap_or_default()
-        .to_lowercase();
-    let term_program = env::var("TERM_PROGRAM").unwrap_or_default().to_lowercase();
-
-    if terminal_emulator.contains("jetbrains") {
-        TerminalEnvironment::JetBrains
-    } else if term_program.contains("vscode") {
-        TerminalEnvironment::VSCode
-    } else {
-        TerminalEnvironment::Unknown
-    }
-}
-
-pub fn create_clickable_link(file_path: &Path, abs_path: &Path, line: &usize) -> String {
-    if !is_interactive() {
-        return format!("{}[L{}]", abs_path.display(), line);
-    }
-    let terminal_env = detect_environment();
-    let file_path_str = file_path.to_string_lossy().to_string();
-    let abs_path_str = abs_path.to_string_lossy().to_string();
-    let link = match terminal_env {
-        TerminalEnvironment::JetBrains => {
-            format!("file://{}:{}", abs_path_str, line)
-        }
-        TerminalEnvironment::VSCode => {
-            format!("vscode://file/{}:{}", abs_path_str, line)
-        }
-        TerminalEnvironment::Unknown => {
-            format!("file://{}", abs_path_str)
-        }
-    };
-    let display_with_line = format!("{}[L{}]", file_path_str, line);
-    format!("\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\", link, display_with_line)
+pub fn create_clickable_link(file_path: &Path, line: &usize) -> String {
+    format!("{}:{}", file_path.display(), line)
 }
 
 pub fn supports_emoji() -> bool {

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -23,7 +23,6 @@ use super::helpers::import::get_located_project_imports;
 
 struct Dependency {
     file_path: PathBuf,
-    absolute_path: PathBuf,
     import: LocatedImport,
     source_module: String,
     target_module: String,
@@ -89,7 +88,6 @@ impl DependencyReport {
     fn render_dependency(&self, dependency: &Dependency) -> String {
         let clickable_link = create_clickable_link(
             &dependency.file_path,
-            &dependency.absolute_path,
             &dependency.import.alias_line_number(),
         );
         format!(
@@ -322,7 +320,6 @@ pub fn create_dependency_report(
                                     })
                                     .map(|(import, import_module)| Dependency {
                                         file_path: pyfile.clone(),
-                                        absolute_path: absolute_pyfile.clone(),
                                         import,
                                         source_module: target_module.full_path.clone(),
                                         target_module: import_module.full_path.clone(),
@@ -347,7 +344,6 @@ pub fn create_dependency_report(
                                     })
                                     .map(|import| Dependency {
                                         file_path: pyfile.clone(),
-                                        absolute_path: absolute_pyfile.clone(),
                                         import: import.clone(),
                                         source_module: file_module
                                             .as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,11 +287,8 @@ fn check_internal(
 }
 
 #[pyfunction]
-pub fn format_diagnostics(
-    project_root: PathBuf,
-    diagnostics: Vec<diagnostics::Diagnostic>,
-) -> String {
-    check::format::DiagnosticFormatter::new(project_root).format_diagnostics(&diagnostics)
+pub fn format_diagnostics(diagnostics: Vec<diagnostics::Diagnostic>) -> String {
+    check::format::format_diagnostics(&diagnostics)
 }
 
 #[pyfunction]


### PR DESCRIPTION
Fixes: #699 

This abandons the approach of using ASCII hyperlinks in favor of just printing a project-rooted filepath with standard formatting for line/character. This works nicely with modern terminals and IDEs that will detect and interpret the filepath.

This also automatically fixes link behavior for Cursor terminal users and other VSCode forks, which incorrectly used a VSCode URI.