### PR TITLE
Fix panic in relative imports past source root

### DIFF
--- a/src/processors/import.rs
+++ b/src/processors/import.rs
@@ -94,6 +94,11 @@ impl ImportVisitor {
         };
 
         let base_path_parts: Vec<&str> = mod_path.split('.').collect();
+        if num_paths_to_strip > base_path_parts.len() {
+            // This relative import appears to reach beyond the current source root
+            // so we ignore it
+            return normalized_imports;
+        }
         let base_path_parts = if num_paths_to_strip > 0 {
             base_path_parts[..base_path_parts.len().saturating_sub(num_paths_to_strip)].to_vec()
         } else {

--- a/src/processors/import.rs
+++ b/src/processors/import.rs
@@ -95,7 +95,7 @@ impl ImportVisitor {
 
         let base_path_parts: Vec<&str> = mod_path.split('.').collect();
         let base_path_parts = if num_paths_to_strip > 0 {
-            base_path_parts[..base_path_parts.len() - num_paths_to_strip].to_vec()
+            base_path_parts[..base_path_parts.len().saturating_sub(num_paths_to_strip)].to_vec()
         } else {
             base_path_parts
         };


### PR DESCRIPTION
There was a bare subtraction in a slice when resolving a relative import, which caused integer underflow and a panic.

This PR uses saturating_sub to avoid underflow in any case, and specifically checks for excessive relative imports and returns early.