### PR TITLE
require repo for git ignores

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -310,7 +310,9 @@ impl FSWalker {
         respect_gitignore: bool,
     ) -> Result<Self> {
         let mut walk_builder = ignore::WalkBuilder::new(project_root.as_ref());
-        walk_builder.require_git(false);
+        // Require git repository for git-related ignore rules
+        // This ensures .gitignore files outside repository boundaries are not considered
+        walk_builder.require_git(true);
         if !respect_gitignore {
             // Disable all ignore filters
             walk_builder.ignore(false);


### PR DESCRIPTION
I have a repo rooted at my home directory.  I have a `~/.gitignore` with `**/**` in it.  I have my git clones mostly located under `~/repos/tach` and similar.  tach was looking beyond the git clone repos and finding the `~/.gitignore` and ignoring all files instead of analyzing them.  This seems to still respect the 'local' `.gitignore` files while not processing the `~/.gitignore` that is beyond the root of the project work tree.
