### PR TITLE
run `mkdocs build --strict` in ci

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch:
 permissions:
   contents: write
+env:
+  PYTHON_VERSION: '3.12'  # Pin for consistency
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'  # Pin for consistency
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Install Dependencies
       run: ./pw uv sync --only-group docs
     - name: Build Documentation
@@ -36,7 +39,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Closes #852 

- Run `mkdocs build --strict` on PR's to main or pushes to main
- Docs `deploy` now depends on `build` succeeding.
- Bump actions/checkout to v5
- Pin Python version in Docs CI to 3.12 (for consistency)

EDIT: Tested the new doc build job on my fork first, and its [green](https://github.com/scott-huberty/tach/actions/runs/19546887877/job/55967920372?pr=1)!