### PR TITLE
fix: pytest plugin now skips all tests in unaffected files

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1543,6 +1543,14 @@
                 "code": "reportUnusedParameter",
                 "range": {
                     "startColumn": 4,
+                    "endColumn": 11,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 4,
                     "endColumn": 14,
                     "lineCount": 1
                 }
@@ -10239,48 +10247,6 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 62,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./python/tests/test_pytest_plugin.py": [
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 35,
                     "lineCount": 1
                 }
             }


### PR DESCRIPTION
## Summary

Fixes a bug where only the first test from each unaffected file was skipped, instead of all tests in that file.

## The Bug

When running `tach test --base HEAD` (no changes), only 1 test per file was being skipped:

```
collected 8 items
[Tach] Skipped 1 test file (1 tests) since they were unaffected by current changes.
============================== 7 passed ===============================
```

## Root Cause

In `pytest_collection_modifyitems`, after processing the first test from a file:
1. The path was added to `seen`
2. Subsequent tests from the same file hit `if item.path in seen: continue`
3. This skipped the removal logic, leaving those tests in the collection

## The Fix

Use a two-pass approach:
1. **First pass**: Identify all paths that should be removed (without modifying the list)
2. **Second pass**: Filter out all items from those paths at once using list comprehension

## After Fix

```
collected 8 items
[Tach] Skipped 1 test file (8 tests) since they were unaffected by current changes.
============================ no tests ran =============================
```

## Testing

Tested with a minimal example project:
- No changes: All 8 tests correctly skipped ✓
- With changes to module: All 8 tests correctly run ✓