### PR TITLE
disable ANSI color in test

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterator
 
 import pytest
 
@@ -13,11 +12,9 @@ def example_dir() -> Path:
 
 
 @pytest.fixture(autouse=True, scope="function")
-def no_color(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+def no_color(monkeypatch: pytest.MonkeyPatch) -> None:
     # According to https://bixense.com/clicolors/, NO_COLOR=1 should be enough.
     # "console", however, does not respect "NO_COLOR" as of this writing,
     # and requires CLICOLOR_FORCE being unset.
     monkeypatch.setenv("NO_COLOR", "1")
     monkeypatch.delenv("CLICOLOR_FORCE", raising=False)
-
-    yield


### PR DESCRIPTION
`console` package adds control codes to the output for coloring, etc, which can fail some tests when such tests expect no coloring.
This PR disables ANSI coloring by modifying environment variables `NO_COLOR` and `CLICOLOR_FORCE`.
