### PR TITLE
Add layers_explicit_depends_on to tach.toml JSON schema

### DIFF
--- a/public/tach-toml-schema.json
+++ b/public/tach-toml-schema.json
@@ -269,6 +269,11 @@
       },
       "additionalProperties": false
     },
+    "layers_explicit_depends_on": {
+      "type": "boolean",
+      "default": false,
+      "description": "When enabled, modules must explicitly declare dependencies on other layers using depends_on, even when those dependencies would be allowed by the layer hierarchy. Utility modules remain accessible without explicit declaration."
+    },
     "layers": {
       "type": "array",
       "items": {


### PR DESCRIPTION
#### Problem

Been getting issues in my local where EvenBetterToml was yelling at me about layers_explicit_depends_on not fitting the schema

-- 

#### The change:


The `layers_explicit_depends_on` option (added in #898) is missing from the JSON schema in `public/tach-toml-schema.json`. This causes editors using schema-aware TOML validators (e.g. EvenBetterToml / Taplo) to flag it as an unknown property.

This PR adds `layers_explicit_depends_on` as a boolean property (default `false`) to the schema, with a description consistent with the existing documentation in `docs/usage/configuration.md` and `docs/usage/layers.md`.