### PR TITLE
Fix pytest deprecation warnings

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1474,48 +1474,6 @@
                 }
             }
         ],
-        "./python/tach/pytest_plugin.py": [
-            {
-                "code": "reportUnusedParameter",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnusedParameter",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportExplicitAny",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnusedParameter",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./python/tach/show.py": [
             {
                 "code": "reportAny",

--- a/python/tach/pytest_plugin.py
+++ b/python/tach/pytest_plugin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, cast
+from typing import TYPE_CHECKING, Generator, cast
 
 import pytest
 from pytest import Cache, Collector, Config, Item, StashKey
@@ -341,9 +341,6 @@ def _pluralize(word: str, count: int) -> str:
 
 def pytest_report_collectionfinish(
     config: Config,
-    start_path: Path,
-    startdir: Any,
-    items: list[pytest.Item],
 ) -> str | list[str]:
     """Report skipped/would-skip test files after collection.
 


### PR DESCRIPTION
see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path