### PR TITLE
fix: report syntax errors as errors, not warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,8 @@ exempt-modules = ["typing", "typing_extensions"]
 [tool.pyright]
 include = ["python", "vscode"]
 # https://github.com/DetachHead/basedpyright/issues/31
-ignore = ["pw", "vscode/bundled", "vscode/.nox", "vscode/node_modules"]
-exclude = ["pw", "vscode/bundled", "vscode/.nox", "vscode/node_modules"]
+ignore = ["pw", "vscode/bundled", "vscode/.nox", "vscode/node_modules", "python/tests/example/syntax_error_fixture/**"]
+exclude = ["pw", "vscode/bundled", "vscode/.nox", "vscode/node_modules", "python/tests/example/syntax_error_fixture/**"]
 executionEnvironments = [{ root = "python" }, { root = "vscode" }]
 pythonVersion = "3.10"
 reportImplicitStringConcatenation = false # conflicts with ruff formatter

--- a/python/tests/example/multi_package/src/pack-a/src/myorg/pack_a/syntax_error.py
+++ b/python/tests/example/multi_package/src/pack-a/src/myorg/pack_a/syntax_error.py
@@ -1,3 +1,0 @@
-# File with syntax error for testing
-def broken(:
-    pass

--- a/python/tests/example/multi_package/src/pack-a/src/myorg/pack_a/syntax_error.py
+++ b/python/tests/example/multi_package/src/pack-a/src/myorg/pack_a/syntax_error.py
@@ -1,0 +1,3 @@
+# File with syntax error for testing
+def broken(:
+    pass

--- a/python/tests/example/syntax_error_fixture/mymodule/__init__.py
+++ b/python/tests/example/syntax_error_fixture/mymodule/__init__.py
@@ -1,0 +1,3 @@
+# Module with syntax error for testing
+def broken(:
+    pass

--- a/python/tests/example/syntax_error_fixture/tach.toml
+++ b/python/tests/example/syntax_error_fixture/tach.toml
@@ -1,0 +1,3 @@
+[[modules]]
+path = "mymodule"
+depends_on = []

--- a/src/commands/check/check_external.rs
+++ b/src/commands/check/check_external.rs
@@ -265,8 +265,8 @@ fn check_with_modules(
                             ),
                         )]
                     }
-                    Err(DiagnosticError::ImportParse(_)) => {
-                        vec![Diagnostic::new_global_warning(
+                    Err(DiagnosticError::ImportParse(_)) | Err(DiagnosticError::PythonParse(_)) => {
+                        vec![Diagnostic::new_global_error(
                             DiagnosticDetails::Configuration(
                                 ConfigurationDiagnostic::SkippedFileSyntaxError {
                                     file_path: file_path.display().to_string(),

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -255,3 +255,66 @@ pub fn check(
 
     Ok(diagnostics)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ProjectConfig;
+    use crate::diagnostics::Severity;
+    use crate::tests::fixtures::example_dir;
+    use rstest::*;
+
+    #[fixture]
+    fn multi_package_config() -> ProjectConfig {
+        use crate::config::ModuleConfig;
+
+        ProjectConfig {
+            modules: vec![
+                ModuleConfig::from_path("myorg.pack_a"),
+            ],
+            source_roots: [
+                "src/pack-a/src",
+                "src/pack-b/src",
+                "src/pack-c/src",
+                "src/pack-d/src",
+                "src/pack-e/src",
+                "src/pack-f/src",
+                "src/pack-g/src",
+            ]
+            .iter()
+            .map(PathBuf::from)
+            .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[rstest]
+    fn check_internal_syntax_error_reports_as_error(
+        example_dir: PathBuf,
+        multi_package_config: ProjectConfig,
+    ) {
+        let project_root = example_dir.join("multi_package");
+        let result = check(&project_root, &multi_package_config, true, false).unwrap();
+
+        // Find the syntax error diagnostic
+        let syntax_error = result
+            .iter()
+            .find(|d| matches!(
+                d.details(),
+                DiagnosticDetails::Configuration(ConfigurationDiagnostic::SkippedFileSyntaxError { .. })
+            ))
+            .expect("Expected a syntax error diagnostic");
+
+        // The diagnostic should be an error, not a warning
+        assert!(matches!(
+            syntax_error,
+            Diagnostic::Global {
+                severity: Severity::Error,
+                details: DiagnosticDetails::Configuration(
+                    ConfigurationDiagnostic::SkippedFileSyntaxError { .. }
+                )
+            }
+        ));
+    }
+}
+

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -265,25 +265,11 @@ mod tests {
     use rstest::*;
 
     #[fixture]
-    fn multi_package_config() -> ProjectConfig {
+    fn syntax_error_config() -> ProjectConfig {
         use crate::config::ModuleConfig;
 
         ProjectConfig {
-            modules: vec![
-                ModuleConfig::from_path("myorg.pack_a"),
-            ],
-            source_roots: [
-                "src/pack-a/src",
-                "src/pack-b/src",
-                "src/pack-c/src",
-                "src/pack-d/src",
-                "src/pack-e/src",
-                "src/pack-f/src",
-                "src/pack-g/src",
-            ]
-            .iter()
-            .map(PathBuf::from)
-            .collect(),
+            modules: vec![ModuleConfig::from_path("mymodule")],
             ..Default::default()
         }
     }
@@ -291,10 +277,10 @@ mod tests {
     #[rstest]
     fn check_internal_syntax_error_reports_as_error(
         example_dir: PathBuf,
-        multi_package_config: ProjectConfig,
+        syntax_error_config: ProjectConfig,
     ) {
-        let project_root = example_dir.join("multi_package");
-        let result = check(&project_root, &multi_package_config, true, false).unwrap();
+        let project_root = example_dir.join("syntax_error_fixture");
+        let result = check(&project_root, &syntax_error_config, true, false).unwrap();
 
         // Find the syntax error diagnostic
         let syntax_error = result

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -285,10 +285,14 @@ mod tests {
         // Find the syntax error diagnostic
         let syntax_error = result
             .iter()
-            .find(|d| matches!(
-                d.details(),
-                DiagnosticDetails::Configuration(ConfigurationDiagnostic::SkippedFileSyntaxError { .. })
-            ))
+            .find(|d| {
+                matches!(
+                    d.details(),
+                    DiagnosticDetails::Configuration(
+                        ConfigurationDiagnostic::SkippedFileSyntaxError { .. }
+                    )
+                )
+            })
             .expect("Expected a syntax error diagnostic");
 
         // The diagnostic should be an error, not a warning
@@ -303,4 +307,3 @@ mod tests {
         ));
     }
 }
-

--- a/src/commands/check/check_internal.rs
+++ b/src/commands/check/check_internal.rs
@@ -223,8 +223,8 @@ pub fn check(
                             ),
                         )]
                     }
-                    Err(DiagnosticError::ImportParse(_)) => {
-                        vec![Diagnostic::new_global_warning(
+                    Err(DiagnosticError::ImportParse(_)) | Err(DiagnosticError::PythonParse(_)) => {
+                        vec![Diagnostic::new_global_error(
                             DiagnosticDetails::Configuration(
                                 ConfigurationDiagnostic::SkippedFileSyntaxError {
                                     file_path: file_path.display().to_string(),


### PR DESCRIPTION
Fixes #845, fixes #846.

Syntax errors during `tach check` were reported as warnings and didn't affect the exit code. The `DiagnosticError::PythonParse` variant was missing from the error match arm, and `ImportParse` errors were routed to `new_global_warning` instead of `new_global_error`.

Both variants now produce `new_global_error`, so syntax errors surface as errors and fail the check.